### PR TITLE
fix: add generic workflow for docs

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -1,0 +1,38 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**.md'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**.md'
+
+jobs:
+  gen-code-no-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipping CI for docs"
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipping CI for docs"
+  go-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipping CI for docs"
+  go-mod-tidy-check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipping CI for docs"
+  check-licenses:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipping CI for docs"
+  e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipping CI for docs"


### PR DESCRIPTION
Issue #, if available:

- https://github.com/runfinch/finch/issues/18

*Description of changes:*

- Added a dummy ci workflow for docs. See [github docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks).

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
