### PR TITLE
chores: fix TODOs blocked by repos being private

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,18 +41,12 @@ jobs:
   # It's recommended to run golangci-lint in a job separate from other jobs (go test, etc) because different jobs run in parallel.
   go-linter:
     runs-on: ubuntu-latest
-    # TODO: Remove this when we make the repos public.
-    env:
-      GOPRIVATE: github.com/runfinch/common-tests
-      ACCESS_TOKEN: ${{ secrets.FINCH_BOT_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
           cache: true
-      # TODO: Remove this when we make the repos public.
-      - run: git config --global url.https://$ACCESS_TOKEN@github.com/.insteadOf https://github.com/
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -63,35 +57,23 @@ jobs:
           args: --fix=false
   go-mod-tidy-check:
     runs-on: ubuntu-latest
-    # TODO: Remove this when we make the repos public.
-    env:
-      GOPRIVATE: github.com/runfinch/common-tests
-      ACCESS_TOKEN: ${{ secrets.FINCH_BOT_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
           cache: true
-      # TODO: Remove this when we make the repos public.
-      - run: git config --global url.https://$ACCESS_TOKEN@github.com/.insteadOf https://github.com/
       # TODO: Use `go mod tidy --check` after https://github.com/golang/go/issues/27005 is fixed.
       - run: go mod tidy
       - run: git diff --exit-code
   check-licenses:
     runs-on: ubuntu-latest
-    # TODO: Remove this when we make the repos public.
-    env:
-      GOPRIVATE: github.com/runfinch/common-tests
-      ACCESS_TOKEN: ${{ secrets.FINCH_BOT_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
           cache: true
-      # TODO: Remove this when we make the repos public.
-      - run: git config --global url.https://$ACCESS_TOKEN@github.com/.insteadOf https://github.com/
       - run: make check-licenses
   e2e-tests:
     strategy:
@@ -99,9 +81,6 @@ jobs:
       matrix:
         os: [[self-hosted, macos, amd64, 11.7], [self-hosted, macos, amd64, 12.6], [self-hosted, macos, arm64, 11.7], [self-hosted, macos, arm64, 12.6]]
     runs-on: ${{ matrix.os }} 
-    # TODO: Remove this when we make the repos public
-    env:
-      ACCESS_TOKEN: ${{ secrets.FINCH_BOT_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - name: Clean up previous files
@@ -114,7 +93,4 @@ jobs:
           export PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH"
           which libtool
           make
-      # TODO: Remove this when we make the repos public
-      - name: Configure repo access
-        run: git config --global url.https://$ACCESS_TOKEN@github.com/.insteadOf https://github.com/
       - run: make test-e2e

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -2,7 +2,6 @@
 name: "Lint PR Title"
 
 on:
-  # TODO: Change to pull_request_target after the repo is public.
   pull_request:
     types:
       - opened


### PR DESCRIPTION
## Summary

PR fixes the TODOs blocked by the fact that https://github.com/runfinch/common-tests was private.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
