### PR TITLE
ci: clean up everything before each run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,8 +109,12 @@ jobs:
           sudo rm -rf /opt/finch
           sudo rm -rf ~/.finch
           sudo rm -rf ./_output
-          sudo pkill '^qemu-system'
-          sudo pkill '^socket_vmnet'
+          if pgrep '^qemu-system'; then
+            sudo pkill '^qemu-system'
+          fi
+          if pgrep '^socket_vmnet'; then
+            sudo pkill '^socket_vmnet'
+          fi
       - run: brew install go lz4 automake autoconf libtool 
       - name: Build project
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,6 +108,9 @@ jobs:
         run: |
           sudo rm -rf /opt/finch
           sudo rm -rf ~/.finch
+          sudo rm -rf ./_output
+          sudo pkill '^qemu-system'
+          sudo pkill '^socket_vmnet'
       - run: brew install go lz4 automake autoconf libtool 
       - name: Build project
         run: |


### PR DESCRIPTION
## Summary

Currently if a run is canceled midway, the environment is left untidied, which may cause subsequent runs to fail. Take this [run](https://github.com/runfinch/finch/actions/runs/3527869248/jobs/5917387104) for example, `_output` was not cleaned up, so the run failed.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
