### PR TITLE
refactor: log format

### DIFF
--- a/cmd/virtual_machine_init.go
+++ b/cmd/virtual_machine_init.go
@@ -68,7 +68,7 @@ func (iva *initVMAction) run() error {
 
 	err = dependency.InstallOptionalDeps(iva.optionalDepGroups, iva.logger)
 	if err != nil {
-		iva.logger.Error(fmt.Sprintf("Dependency error: %s", err))
+		iva.logger.Errorf("Dependency error: %v", err)
 	}
 
 	err = iva.limaConfigApplier.Apply()

--- a/cmd/virtual_machine_start.go
+++ b/cmd/virtual_machine_start.go
@@ -60,7 +60,7 @@ func (sva *startVMAction) run() error {
 	}
 	err = dependency.InstallOptionalDeps(sva.optionalDepGroups, sva.logger)
 	if err != nil {
-		sva.logger.Error(fmt.Sprintf("Dependency error: %s", err))
+		sva.logger.Errorf("Dependency error: %v", err.Error)
 	}
 
 	err = sva.limaConfigApplier.Apply()

--- a/pkg/dependency/vmnet/binaries.go
+++ b/pkg/dependency/vmnet/binaries.go
@@ -70,7 +70,7 @@ func (bin *binaries) Installed() bool {
 		return false
 	}
 	if !dirExists {
-		bin.l.Infof("binaries directory doesn't exist")
+		bin.l.Info("binaries directory doesn't exist")
 		return false
 	}
 	buildArtifactFileBytes, err := afero.ReadFile(bin.fs, bin.buildArtifactSocketVmnetExe())

--- a/pkg/dependency/vmnet/update_override_lima_config.go
+++ b/pkg/dependency/vmnet/update_override_lima_config.go
@@ -92,7 +92,7 @@ func (overConf *overrideLimaConfig) appendNetworkConfiguration(filePath string) 
 	}
 	defer func() {
 		if err := f.Close(); err != nil {
-			overConf.l.Errorf("error closing file at path %s, error: %v", filePath, err)
+			overConf.l.Errorf("error closing file at path %s, error: %s", filePath, err.Error())
 		}
 	}()
 	if _, err := f.WriteString(networkConfigString); err != nil {

--- a/pkg/dependency/vmnet/update_override_lima_config.go
+++ b/pkg/dependency/vmnet/update_override_lima_config.go
@@ -92,7 +92,7 @@ func (overConf *overrideLimaConfig) appendNetworkConfiguration(filePath string) 
 	}
 	defer func() {
 		if err := f.Close(); err != nil {
-			overConf.l.Errorf("error closing file at path %s, error: %s", filePath, err.Error())
+			overConf.l.Errorf("error closing file at path %s, error: %v", filePath, err)
 		}
 	}()
 	if _, err := f.WriteString(networkConfigString); err != nil {


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*

I fixed log format.
It's failed on purpose to confirm the logs.

```
DEBU[0000] Creating limactl command: ARGUMENTS: [ls -f {{.Status}} finch], LIMA_HOME: /user/workspace/finch/lima/data 
DEBU[0000] Status of virtual machine:                   
INFO[0000] dependency socket_vmnet file not found: open /user/workspace/finch/dependencies/lima-socket_vmnet/opt/finch/bin/socket_vmnet: no such file or directory 
INFO[0000] Requesting root access to finish network dependency configuration 
Password:
DEBU[0004] Creating limactl command: ARGUMENTS: [sudoers], LIMA_HOME: /user/workspace/finch/lima/data 
DEBU[0004] config file not found: %!w(*fs.PathError=&{open /user/workspace/finch/lima/data/_config/override.yaml 2}) 
INFO[0004] dependency socket_vmnet file not found: open /user/workspace/finch/dependencies/lima-socket_vmnet/opt/finch/bin/socket_vmnet: no such file or directory 
ERRO[0004] Dependency error: failed to install dependencies: [Failed to finish installing rootful dependencies which are needed for external network access within the guest OS. Boot will continue, but container exposed ports will not be accessible from macOS.: [error copying files to directory /opt/finch, err: exit status 1, stderr: cp: /user/workspace/finch/dependencies/lima-socket_vmnet/opt/finch: No such file or directory
 skipping installation of network configuration because pre-requisites are missing]] 
FATA[0004] failed to load the lima config file: open /user/workspace/finch/lima/data/_config/override.yaml: no such file or directory
```
logrus finally call [(*Entry).Logf](https://github.com/sirupsen/logrus/blob/master/entry.go#L347). The function uses fmt.Sprintf to format. So, %w cannot use to format.

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
