### PR TITLE
refactor: Remove unnecessary property when creating command

### DIFF
--- a/cmd/nerdctl.go
+++ b/cmd/nerdctl.go
@@ -31,8 +31,6 @@ func (ncc *nerdctlCommandCreator) create(cmdName string, cmdDesc string) *cobra.
 	command := &cobra.Command{
 		Use:   cmdName,
 		Short: cmdDesc,
-		// TODO(Ang): Remove it (https://github.com/runfinch/finch/pull/40#issuecomment-1263878146).
-		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 		// If we don't specify it, and the user issues `finch run -d alpine`,
 		// the args passed to nerdctlCommand.run will be empty because
 		// cobra will try to parse `-d alpine` as if alpine is the value of the `-d` flag.

--- a/cmd/nerdctl_test.go
+++ b/cmd/nerdctl_test.go
@@ -28,7 +28,6 @@ func TestNerdctlCommandCreator_create(t *testing.T) {
 	cmd := newNerdctlCommandCreator(nil, nil).create("build", "build description")
 	assert.Equal(t, cmd.Name(), "build")
 	assert.Equal(t, cmd.DisableFlagParsing, true)
-	assert.Equal(t, cmd.FParseErrWhitelist, cobra.FParseErrWhitelist{UnknownFlags: true})
 }
 
 func TestNerdctlCommand_runAdaptor(t *testing.T) {


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
It turns out we don't need `FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true}` when creating command.

*Testing done:*
E2E test and manual test.


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
