### PR TITLE
docs: clarify installation instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ The binary in _output can be directly used. E.g. initializing the vm and display
 ./_output/bin/finch version
 ```
 
-You can run `make install` to make finch binary globally accessible.
+You can also run `make install` to build and make finch binary globally accessible. However, note that this may conflict with the one installed via an official installer.
 
 
 ### Unit Testing

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ CORE_OUTDIR := $(CURDIR)/$(CORE_FILENAME)/_output
 CORE_VDE_PREFIX ?= $(OUTDIR)/dependencies/vde/opt/finch
 LICENSEDIR := $(OUTDIR)/license-files
 VERSION := $(shell git describe --match 'v[0-9]*' --dirty='.modified' --always --tags)
-LDFLAGS := "-X $(PACKAGE)/pkg/version.Version=$(VERSION)"
+LDFLAGS := "-s -w -X $(PACKAGE)/pkg/version.Version=$(VERSION)"
 
 .DEFAULT_GOAL := all
 
@@ -114,7 +114,7 @@ copy:
 	(cd _output && tar c * | tar Cvx  $(DEST) )
 
 .PHONY: install
-install: copy
+install: finch copy
 	sudo ln -sf $(DEST)/bin/finch "$(BINDIR)/finch"
 
 uninstall.finch:

--- a/README.md
+++ b/README.md
@@ -24,14 +24,36 @@ To get started with Finch on macOS, the prerequisites are:
 * Intel or Apple Silicon M1 system for macOS
 * Recommended minimum configuration is 2 CPU, 4 GB memory
 
+##### From Go
+
+The easiest way to install the Finch is to use Go way by issuing the following command:
+
+```sh
+$ go install github.com/runfinch/finch/cmd@v0.1.0
+```
+
+##### From Releases
+
 Download a release package for your architecture from the [project's GitHub releases](https://github.com/runfinch/finch/releases) page, and once downloaded double click and follow the directions.
+
+##### From Source
+
+If you want to build and compile the source code, follow the instructions below:
+
+```sh
+$ git clone git@github.com:runfinch/finch.git
+$ cd finch
+$ make install
+```
+
+#### Running the VM
 
 Once the installation is complete, `finch vm init` is required once to set up the underlying system. This initial setup usually takes about a minute.
 
 ```sh
-finch vm init
+$ finch vm init
 INFO[0000] Initializing and starting Finch virtual machine...
-..
+...
 INFO[0067] Finch virtual machine started successfully
 ```
 
@@ -40,7 +62,7 @@ INFO[0067] Finch virtual machine started successfully
 You can now run a test container. If you're familiar with container development, you can use the `run` command as you'd expect.
 
 ```sh
-finch run --rm public.ecr.aws/finch/hello-finch
+$ finch run --rm public.ecr.aws/finch/hello-finch
 ```
 
 If you're new to containers, that is so exciting! Give the command above a try after you've installed and initialized Finch. The `run` command pulls an image locally if it's not already present, and then creates and runs a container for you. Note the handy `--rm` option will delete the container instance once it's done executing.
@@ -48,10 +70,9 @@ If you're new to containers, that is so exciting! Give the command above a try a
 To build an image, try a quick example from the finch client repository.
 
 ```sh
-git clone git@github.com:runfinch/finch.git
-cd finch/contrib/hello-finch
-finch build . -t hello-finch
-..
+$ git clone git@github.com:runfinch/finch.git
+$ cd finch/contrib/hello-finch
+$ finch build . -t hello-finch
 ```
 
 Again if you're new to containers, you just built a container image. Nice!
@@ -61,10 +82,10 @@ The `build` command will work with the build system (the Moby Project's BuildKit
 Finch makes it easy to build and run containers across architectures with the `--platform` option. When used with the `run` command, it will create a container using the specified architecture. For example, on an Apple Silicon M1 system, `--platform=amd64` will create a container and run processes within it using an x86-64 architecture.
 
 ```sh
-uname -ms
+$ uname -ms
 Darwin arm64
 
-finch run --rm --platform=amd64 public.ecr.aws/amazonlinux/amazonlinux uname -ms
+$ finch run --rm --platform=amd64 public.ecr.aws/amazonlinux/amazonlinux uname -ms
 Linux x86_64
 ```
 


### PR DESCRIPTION
This commit clarifies some installation strategies for newcomers.

Signed-off-by: Furkan <furkan.turkal@trendyol.com>

Issue #, if available: `-`

*Description of changes:*
* Fix an issue where `make install` was just trying to symlink a file without building the actual binary itself. (Was a bit confusing for fresh users - and better UX to cover POLA law)
* Add `$` prefix to actual commands
* Add 2 new sections to installation section in the README
* Decreased build size  %15-%20 by stripping DWARF and debug symbols

*Testing done:*

* Issue the new commands that recently added to README and expect all works.

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
