### PR TITLE
ci: Add signoff to update deps workflow

### DIFF
--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -36,5 +36,6 @@ jobs:
           # More info: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs
           # TODO: Use FINCH_BOT_TOKEN instead of GITHUB_TOKEN.
           token: ${{ secrets.GITHUB_TOKEN }}
+          signoff: true
           # TODO: Add updated lima version in the title.
           title: 'build(deps): Bump lima version'


### PR DESCRIPTION
Signed-off-by: Vishwas Siravara <siravara@amazon.com>

Issue #, if available:
N/A
*Description of changes:*
Commit by `update-deps.yaml` workflow are not signed which leads to CI failing. [error](https://github.com/runfinch/finch-core/pull/14/checks?check_run_id=9806064207)
*Testing done:*
Can be done only on main branch since the action is triggered by `workflow_dispatch`. 


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
