### PR TITLE
ci: added the contrib folder to be ignored by CI

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -14,37 +14,39 @@ on:
       - main
     paths:
       - '**.md'
+      - 'contrib/**'
   pull_request:
     branches:
       - main
     paths:
       - '**.md'
+      - 'contrib/**'
 
 jobs:
   gen-code-no-diff:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Skipping CI for docs"
+      - run: echo "Skipping CI for docs & contrib files"
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Skipping CI for docs"
+      - run: echo "Skipping CI for docs & contrib files"
   go-linter:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Skipping CI for docs"
+      - run: echo "Skipping CI for docs & contrib files"
   go-mod-tidy-check:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Skipping CI for docs"
+      - run: echo "Skipping CI for docs & contrib files"
   check-licenses:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Skipping CI for docs"
+      - run: echo "Skipping CI for docs & contrib files"
   e2e-tests:
     strategy:
       matrix:
         os: [[self-hosted, macos, amd64, 11.7], [self-hosted, macos, amd64, 12.6], [self-hosted, macos, arm64, 11.7], [self-hosted, macos, arm64, 12.6]]
     runs-on: ${{ matrix.os }} 
     steps:
-      - run: echo "Skipping CI for docs"
+      - run: echo "Skipping CI for docs & contrib files"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,11 +7,13 @@ on:
       - main
     paths-ignore:
       - '**.md'
+      - 'contrib/**'
   pull_request:
     branches:
       - main
     paths-ignore:
       - '**.md'
+      - 'contrib/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Signed-off-by: Weike Qu <weikequ@amazon.com>

*Description of changes:*
- Current CI still runs when files in contrib folder is edited. The CI should ignore the contrib folder.

- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
