### PR TITLE
refactor: Inject version in buildtime

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-go@v3
         with:
           # Since this repository is not meant to be used as a library,
@@ -86,6 +89,9 @@ jobs:
     runs-on: ${{ matrix.os }} 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - name: Clean up previous files
         run: |
           sudo rm -rf /opt/finch

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,9 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          persist-credentials: false
       - uses: actions/setup-go@v3
         with:
           # Since this repository is not meant to be used as a library,
@@ -90,6 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          # We need to get all the git tags to make version injection work. See VERSION in Makefile for more detail.
           fetch-depth: 0
           persist-credentials: false
       - name: Clean up previous files

--- a/.github/workflows/upload-build-to-s3.yaml
+++ b/.github/workflows/upload-build-to-s3.yaml
@@ -21,7 +21,7 @@ jobs:
           go-version: 1.19.x
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Make macos arm64 build
@@ -47,7 +47,7 @@ jobs:
           go-version: 1.19.x
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Make macos amd64 build
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           persist-credentials: false
 
       - name: configure aws credentials

--- a/cmd/finch/main.go
+++ b/cmd/finch/main.go
@@ -54,7 +54,7 @@ var newApp = func(logger flog.Logger, fp path.Finch, fs afero.Fs, fc *config.Fin
 		Short:         "Finch: open-source container development tool",
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		Version:       finchVersion(),
+		Version:       finchVersion,
 	}
 	// TODO: Decide when to forward --debug to the dependencies
 	// (e.g. nerdctl for container commands and limactl for VM commands).

--- a/cmd/finch/main_test.go
+++ b/cmd/finch/main_test.go
@@ -131,7 +131,7 @@ func TestNewApp(t *testing.T) {
 	cmd := newApp(l, fp, fs, &config.Finch{})
 
 	assert.Equal(t, cmd.Name(), finchRootCmd)
-	assert.Equal(t, cmd.Version, finchVersion())
+	assert.Equal(t, cmd.Version, finchVersion)
 	assert.Equal(t, cmd.SilenceUsage, true)
 	assert.Equal(t, cmd.SilenceErrors, true)
 	// confirm the number of command, comprised of nerdctl commands + finch commands (version, vm)

--- a/cmd/finch/version.go
+++ b/cmd/finch/version.go
@@ -7,18 +7,17 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
+	"github.com/runfinch/finch/pkg/version"
 )
 
-func finchVersion() string {
-	// TODO: Remove hardcoded version after the git can be access through buildtime
-	return "v0.1.1"
-}
+var finchVersion = version.Version
 
 func newVersionCommand() *cobra.Command {
 	versionCommand := &cobra.Command{
 		Use:   "version",
 		Args:  cobra.NoArgs,
-		Short: "Show Finch version information",
+		Short: "Shows Finch version information",
 		RunE:  versionAction,
 	}
 
@@ -26,6 +25,6 @@ func newVersionCommand() *cobra.Command {
 }
 
 func versionAction(cmd *cobra.Command, args []string) error {
-	fmt.Println("Finch version:", finchVersion())
+	fmt.Println("Finch version:", finchVersion)
 	return nil
 }

--- a/cmd/finch/version_test.go
+++ b/cmd/finch/version_test.go
@@ -44,5 +44,5 @@ func TestVersionAction(t *testing.T) {
 	}
 
 	output := captureStdout(t, versionActionFunc)
-	assert.Contains(t, output, finchVersion())
+	assert.Contains(t, output, finchVersion)
 }

--- a/e2e/version_test.go
+++ b/e2e/version_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/runfinch/common-tests/command"
 	"github.com/runfinch/common-tests/option"
+
 	"github.com/runfinch/finch/pkg/version"
 )
 

--- a/e2e/version_test.go
+++ b/e2e/version_test.go
@@ -10,12 +10,13 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/runfinch/common-tests/command"
 	"github.com/runfinch/common-tests/option"
+	"github.com/runfinch/finch/pkg/version"
 )
 
 var testVersion = func(o *option.Option) {
 	ginkgo.Context("Version", func() {
 		ginkgo.Specify("Test version", func() {
-			gomega.Expect(command.StdoutStr(o, "version")).To(gomega.Equal(fmt.Sprintf("Finch version: %s", "v0.1.1")))
+			gomega.Expect(command.StdoutStr(o, "version")).To(gomega.Equal(fmt.Sprintf("Finch version: %s", version.Version)))
 		})
 	})
 }


### PR DESCRIPTION
Issue #, if available:
#95 

*Description of changes:*
Change `fetch-depth` in actions to get the version from GO buildtime

*Testing done:*
https://github.com/runfinch/finch/actions/runs/3637545601/jobs/6138677221 (e.g., [`v0.1.0-37-g1afbe3a`](https://github.com/runfinch/finch/actions/runs/3637545601/jobs/6138677221#step:4:84))


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
