### PR TITLE
fix: fix the misleading log when applying invalid config

### DIFF
--- a/cmd/finch/main_test.go
+++ b/cmd/finch/main_test.go
@@ -79,7 +79,7 @@ func TestXmain(t *testing.T) {
 		{
 			name: "failed to load finch config because of invalid YAML",
 			wantErr: fmt.Errorf("failed to load config: %w",
-				fmt.Errorf("failed to unmarshal config file, using default values: %w",
+				fmt.Errorf("failed to unmarshal config file: %w",
 					&yaml.TypeError{Errors: []string{"line 1: cannot unmarshal !!str `this is...` into config.Finch"}},
 				),
 			),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -114,7 +114,7 @@ func Load(fs afero.Fs, cfgPath string, log flog.Logger, systemDeps LoadSystemDep
 
 	var cfg Finch
 	if err := yaml.Unmarshal(b, &cfg); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal config file, using default values: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal config file: %w", err)
 	}
 
 	defCfg := applyDefaults(&cfg, systemDeps, mem)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -96,7 +96,7 @@ cpus: 8
 			},
 			want: nil,
 			wantErr: fmt.Errorf(
-				"failed to unmarshal config file, using default values: %w",
+				"failed to unmarshal config file: %w",
 				&yaml.TypeError{Errors: []string{"line 1: cannot unmarshal !!str `this is...` into config.Finch"}},
 			),
 		},


### PR DESCRIPTION
Issue #, if available:
https://github.com/runfinch/finch/issues/118

*Description of changes:*
fix the misleading log when applying invalid config

*Testing done:*
make test-unit
make lint


- [ X ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
