### PR TITLE
fix: add stricter check for DOCKER_CONFIG var

### DIFF
--- a/pkg/config/nerdctl_config_applier.go
+++ b/pkg/config/nerdctl_config_applier.go
@@ -69,7 +69,16 @@ func updateEnvironment(fs afero.Fs, user string) error {
 	}
 
 	profStr := string(profBuf)
-	if !strings.Contains(profStr, "export DOCKER_CONFIG") {
+	proStrs := strings.Split(profStr, "\n")
+	var hasVar = false
+	for _, str := range proStrs {
+		if strings.HasPrefix(str, fmt.Sprintf("export DOCKER_CONFIG=\"/Users/%s/.finch\"", user)) {
+			hasVar = true
+			break
+		}
+	}
+
+	if !hasVar {
 		profBufWithDockerCfg := fmt.Sprintf("%s\nexport DOCKER_CONFIG=\"/Users/%s/.finch\"\n", profStr, user)
 		if err := afero.WriteFile(fs, profileFilePath, []byte(profBufWithDockerCfg), 0o644); err != nil {
 			return fmt.Errorf("failed to write to profile file: %w", err)


### PR DESCRIPTION
Signed-off-by: Justin Alvarez <alvajus@amazon.com>

Issue #, if available: Closes #126 

*Description of changes:*
- Previously, this code was just checking for any substring containing `export DOCKER_CONFIG`, now we check for a line starting with the fully configured DOCKER_CONFIG variable (like `export DOCKER_CONFIG="/Users/justin/.finch"`)

*Testing done:*
- added unit test for this scenario
- I want to test this practically, but its difficult to change the user on my mac and keep the same VM. Thinking of ways to test before merging


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
