### PR TITLE
fix: Configure Buildkit Namespace as Env Variable

### DIFF
--- a/finch.yaml
+++ b/finch.yaml
@@ -185,3 +185,15 @@ video:
   # on performance on macOS hosts: https://gitlab.com/qemu-project/qemu/-/issues/334
   # 🟢 Builtin default: "none"
   display: null
+
+# Extra environment variables that will be loaded into the VM at start up.
+# These variables are consumed by internal init scripts, and also added
+# to /etc/environment.
+# If you set any of "ftp_proxy", "http_proxy", "https_proxy", or "no_proxy", then
+# Lima will automatically set an uppercase variant to the same value as well.
+# 🟢 Builtin default: null
+env:
+  # Containerd namespace is used by the lima cidata script
+  # 40-install-containerd.sh. Specifically this variable is defining the
+  # Buildkit Workers Containerd namespace. 
+  CONTAINERD_NAMESPACE: finch


### PR DESCRIPTION


Signed-off-by: Olly Pomeroy <opomer@amazon.co.uk>

Issue #, if available: https://github.com/runfinch/finch/issues/71

*Description of changes:*
Adding the [env](https://github.com/lima-vm/lima/blob/master/examples/default.yaml#L345) section to the lima vm configuration, and the defining a CONTAINERND_NAMESPACE variable.

The containerd-rootless-setup.sh script in nerdctl takes a CONTAINERND_NAMESPACE variable when configuring the buildkit containerd worker namespace. This variable is defined here in lima so that it is passed into the containerd-rootless-setup.sh script, used by the CIDATA scripts while provisioning the VM.

This variable is passed into CIDATA [here](https://github.com/lima-vm/lima/blob/master/pkg/cidata/cidata.TEMPLATE.d/boot/40-install-containerd.sh#L88) and is used within the containerd-rootless-setup.sh script [here](https://github.com/containerd/nerdctl/blob/main/extras/rootless/containerd-rootless-setuptool.sh#L301). 

*Testing done:*

Built locally and verified the Variable is being consumed.

```
$ buildctl --addr=unix:///run/user/504/buildkit-finch/buildkitd.sock debug workers -v
ID:             34w45gxhe8bfdr76y9jxvdo16
Platforms:      linux/arm64,linux/amd64
Labels:
        org.mobyproject.buildkit.worker.containerd.namespace:   finch
        org.mobyproject.buildkit.worker.containerd.uuid:        a6e1dad3-4843-4ab4-b595-a912b5a3e76f
        org.mobyproject.buildkit.worker.executor:               containerd
        org.mobyproject.buildkit.worker.hostname:               lima-finch
        org.mobyproject.buildkit.worker.network:                host
        org.mobyproject.buildkit.worker.snapshotter:            overlayfs
GC Policy rule#0:
        All:            false
        Filters:        type==source.local,type==exec.cachemount,type==source.git.checkout
        Keep Duration:  48h0m0s
        Keep Bytes:     512MB
GC Policy rule#1:
        All:            false
        Keep Duration:  1440h0m0s
        Keep Bytes:     10GB
GC Policy rule#2:
        All:            false
        Keep Bytes:     10GB
GC Policy rule#3:
        All:            true
        Keep Bytes:     10GB
```

Also tested this solves the [issue](https://github.com/runfinch/finch/issues/71):

```
$ cat Dockerfile.one 
FROM debian
RUN apt-get update

$ cat Dockerfile.two 
FROM mydebian
RUN apt-get install curl -y

$ ../finch/_output/bin/finch build -t mydebian -f Dockerfile.one .
[+] Building 0.9s (6/6) FINISHED                                                                                                                                                                                
 => [internal] load .dockerignore                                                                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                                                                            0.0s
 => [internal] load build definition from Dockerfile.one                                                                                                                                                   0.0s
 => => transferring dockerfile: 72B                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/debian:latest                                                                                                                                           0.8s
 => [1/2] FROM docker.io/library/debian@sha256:c66c0e5dc607baefefda1d9e64a3b3a317e4189c540c8eac0c1a06186fe353a1                                                                                            0.0s
 => => resolve docker.io/library/debian@sha256:c66c0e5dc607baefefda1d9e64a3b3a317e4189c540c8eac0c1a06186fe353a1                                                                                            0.0s
 => CACHED [2/2] RUN apt-get update                                                                                                                                                                        0.0s
 => exporting to image                                                                                                                                                                                     0.0s
 => => exporting layers                                                                                                                                                                                    0.0s
 => => exporting manifest sha256:1ea8c95744126d9a451938b8db0fa7da10042f35e21f16a011361076975b34ba                                                                                                          0.0s
 => => exporting config sha256:bc9337720dfc88a9ee7388eb364c8b5bc7486b082577cda7d17f578fa2079c5a                                                                                                            0.0s
 => => naming to docker.io/library/mydebian:latest                                                                                                                                                         0.0s
 => => unpacking to docker.io/library/mydebian:latest                                                                                                                                                      0.0s

$ ../finch/_output/bin/finch image ls
REPOSITORY    TAG       IMAGE ID        CREATED           PLATFORM       SIZE         BLOB SIZE
mydebian      latest    1ea8c9574412    21 seconds ago    linux/arm64    146.0 MiB    64.3 MiB

$ ../finch/_output/bin/finch build -t mydebian2 -f Dockerfile.two .
[+] Building 4.6s (6/6) FINISHED                                                                                                                                                                                
 => [internal] load .dockerignore                                                                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                                                                            0.0s
 => [internal] load build definition from Dockerfile.two                                                                                                                                                   0.0s
 => => transferring dockerfile: 83B                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/mydebian:latest                                                                                                                                         0.9s
 => CACHED [1/2] FROM docker.io/library/mydebian@sha256:1ea8c95744126d9a451938b8db0fa7da10042f35e21f16a011361076975b34ba                                                                                   0.5s
 => => resolve docker.io/library/mydebian@sha256:1ea8c95744126d9a451938b8db0fa7da10042f35e21f16a011361076975b34ba                                                                                          0.5s
 => [2/2] RUN apt-get install curl -y                                                                                                                                                                      2.7s
 => exporting to image                                                                                                                                                                                     0.4s 
 => => exporting layers                                                                                                                                                                                    0.3s 
 => => exporting manifest sha256:b3110f4faff6ac2334d9989c7dab34cb288d03ecb6ef6bd83c2eb02255e39e44                                                                                                          0.0s 
 => => exporting config sha256:570d3e1d79d7ecc8bb54fbb9603c216b39489f036d703fc76891b566a9c358ec                                                                                                            0.0s 
 => => naming to docker.io/library/mydebian2:latest                                                                                                                                                        0.0s 
 => => unpacking to docker.io/library/mydebian2:latest                                                                                                                                                     0.1s 
```


- [ X ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
