### PR TITLE
fix: changes persistent disk path to prevent collisions

### DIFF
--- a/pkg/disk/disk_test.go
+++ b/pkg/disk/disk_test.go
@@ -58,6 +58,7 @@ func TestUserDataDiskManager_InitializeUserDataDisk(t *testing.T) {
 				cmd.EXPECT().Run().Return(nil)
 
 				dfs.EXPECT().Stat(finch.UserDataDiskPath(homeDir)).Return(nil, fs.ErrNotExist)
+				dfs.EXPECT().Stat(path.Dir(finch.UserDataDiskPath(homeDir))).Return(nil, nil)
 				dfs.EXPECT().Rename(limaPath, finch.UserDataDiskPath(homeDir)).Return(nil)
 
 				dfs.EXPECT().Stat(limaPath).Return(nil, fs.ErrNotExist)
@@ -89,6 +90,7 @@ func TestUserDataDiskManager_InitializeUserDataDisk(t *testing.T) {
 				dfs.EXPECT().ReadlinkIfPossible(limaPath).Return("", nil)
 
 				dfs.EXPECT().Stat(finch.UserDataDiskPath(homeDir)).Return(nil, fs.ErrNotExist)
+				dfs.EXPECT().Stat(path.Dir(finch.UserDataDiskPath(homeDir))).Return(nil, nil)
 				dfs.EXPECT().Rename(limaPath, finch.UserDataDiskPath(homeDir)).Return(nil)
 
 				dfs.EXPECT().Stat(limaPath).Return(nil, fs.ErrNotExist)

--- a/pkg/path/finch.go
+++ b/pkg/path/finch.go
@@ -5,6 +5,7 @@
 package path
 
 import (
+	"crypto/sha256"
 	"fmt"
 
 	"github.com/runfinch/finch/pkg/system"
@@ -20,13 +21,18 @@ func (Finch) ConfigFilePath(homeDir string) string {
 
 // UserDataDiskPath returns the path to the permanent storage location of the Finch
 // user data disk.
-func (Finch) UserDataDiskPath(homeDir string) string {
-	return fmt.Sprintf("%s/.finch/.datadisk", homeDir)
+func (w Finch) UserDataDiskPath(homeDir string) string {
+	return fmt.Sprintf("%s/.finch/.disks/%s", homeDir, w.generatePathSum())
 }
 
 // LimaHomePath returns the path that should be set to LIMA_HOME for Finch.
 func (w Finch) LimaHomePath() string {
 	return fmt.Sprintf("%s/lima/data", w)
+}
+
+// LimaInstancePath returns the path to the Lima instance of the Finch VM.
+func (w Finch) LimaInstancePath() string {
+	return fmt.Sprintf("%s/lima/data/finch", w)
 }
 
 // LimactlPath returns the limactl path.
@@ -58,6 +64,11 @@ func (w Finch) LimaOverrideConfigPath() string {
 // LimaSSHPrivateKeyPath returns the lima user key path.
 func (w Finch) LimaSSHPrivateKeyPath() string {
 	return fmt.Sprintf("%s/lima/data/_config/user", w)
+}
+
+func (w Finch) generatePathSum() string {
+	sum := sha256.Sum256([]byte(w.LimaInstancePath()))
+	return fmt.Sprintf("%x", sum[:8])
 }
 
 // FinchFinderDeps provides all the dependencies FindFinch needs to find Finch.

--- a/pkg/path/finch_test.go
+++ b/pkg/path/finch_test.go
@@ -27,7 +27,7 @@ func TestFinch_UserDataDiskPath(t *testing.T) {
 	t.Parallel()
 
 	res := mockFinch.UserDataDiskPath("homeDir")
-	assert.Equal(t, res, "homeDir/.finch/.datadisk")
+	assert.Equal(t, res, fmt.Sprintf("homeDir/.finch/.disks/%s", mockFinch.generatePathSum()))
 }
 
 func TestFinch_LimaHomePath(t *testing.T) {
@@ -35,6 +35,13 @@ func TestFinch_LimaHomePath(t *testing.T) {
 
 	res := mockFinch.LimaHomePath()
 	assert.Equal(t, res, "mock_finch/lima/data")
+}
+
+func TestFinch_LimaInstancePath(t *testing.T) {
+	t.Parallel()
+
+	res := mockFinch.LimaInstancePath()
+	assert.Equal(t, res, "mock_finch/lima/data/finch")
 }
 
 func TestFinch_LimactlPath(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Sam Berning <bernings@amazon.com>

Issue #, if available:

*Description of changes:*

It was possible for two different finch VMs in different locations to use the same persistent disk, causing the disk to corrupt. This changes the path to a sha256 sum of the installation location.

*Testing done:*

Unit testing, manual testing to confirm the disk is created in the right location.

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
