### PR TITLE
feat: adds a --force flag to vm stop and remove

### DIFF
--- a/e2e/vm/lifecycle_test.go
+++ b/e2e/vm/lifecycle_test.go
@@ -23,6 +23,20 @@ var testVMLifecycle = func(o *option.Option) {
 				gomega.Expect(command.StdoutStr(o, virtualMachineRootCmd, "status")).To(gomega.Equal("Running"))
 			})
 
+			ginkgo.It("should be able to force stop the virtual machine", func() {
+				command.Run(o, "images")
+				command.New(o, virtualMachineRootCmd, "stop", "--force").WithTimeoutInSeconds(90).Run()
+				command.RunWithoutSuccessfulExit(o, "images")
+				command.New(o, virtualMachineRootCmd, "start").WithTimeoutInSeconds(120).Run()
+			})
+
+			ginkgo.It("should be able to force remove the virtual machine", func() {
+				command.Run(o, "images")
+				command.New(o, virtualMachineRootCmd, "remove", "--force").WithTimeoutInSeconds(60).Run()
+				command.RunWithoutSuccessfulExit(o, "images")
+				command.New(o, virtualMachineRootCmd, "init").WithTimeoutInSeconds(600).Run()
+			})
+
 			ginkgo.It("should be able to stop the virtual machine", func() {
 				command.Run(o, "images")
 				command.New(o, virtualMachineRootCmd, "stop").WithTimeoutInSeconds(90).Run()
@@ -43,11 +57,17 @@ var testVMLifecycle = func(o *option.Option) {
 			ginkgo.It("should be able to start the virtual machine", func() {
 				command.New(o, virtualMachineRootCmd, "start").WithTimeoutInSeconds(120).Run()
 				command.Run(o, "images")
+				command.New(o, virtualMachineRootCmd, "stop").WithTimeoutInSeconds(90).Run()
 			})
 
 			ginkgo.It("should be able to remove the virtual machine", func() {
-				command.New(o, virtualMachineRootCmd, "stop").WithTimeoutInSeconds(90).Run()
 				command.New(o, virtualMachineRootCmd, "remove").WithTimeoutInSeconds(60).Run()
+				command.RunWithoutSuccessfulExit(o, "images")
+				command.New(o, virtualMachineRootCmd, "init").WithTimeoutInSeconds(600).Run()
+				command.New(o, virtualMachineRootCmd, "stop").WithTimeoutInSeconds(90).Run()
+			})
+			ginkgo.It("should be able to force remove the virtual machine", func() {
+				command.New(o, virtualMachineRootCmd, "remove", "--force").WithTimeoutInSeconds(60).Run()
 				command.RunWithoutSuccessfulExit(o, "images")
 			})
 		})


### PR DESCRIPTION
Signed-off-by: Sam Berning <bernings@amazon.com>

Issue #, if available: https://github.com/runfinch/finch/issues/171

*Description of changes:*

Adds a force flag to `finch vm stop` and `finch vm remove`. This gives us a native way to recover from "unrecognized system status" as seen in https://github.com/runfinch/finch/issues/171.

*Testing done:*

Unit testing, E2E testing.

Force "unrecognized system status" by messing with the Lima instance
```
$ ./_output/bin/finch vm stop         
FATA[0000] unrecognized system status                   
$ ./_output/bin/finch vm stop --force
INFO[0000] Forcibly stopping Finch virtual machine...   
INFO[0001] Finch virtual machine stopped successfully   
$ ./_output/bin/finch vm start       
INFO[0000] Starting existing Finch virtual machine...   
INFO[0038] Finch virtual machine started successfully
```
```
$ ./_output/bin/finch vm stop         
FATA[0000] unrecognized system status                   
$ ./_output/bin/finch vm remove --force
INFO[0000] Forcibly removing Finch virtual machine...   
INFO[0000] Finch virtual machine removed successfully   
$ ./_output/bin/finch vm status        
Nonexistent
```


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
