### PR TITLE
fix!: persists nerdctl user data

### DIFF
--- a/finch.yaml
+++ b/finch.yaml
@@ -149,7 +149,11 @@ provision:
   script: |
     #!/bin/bash
     sudo chown $USER /mnt/lima-finch
-    sudo mount --bind /mnt/lima-finch ~/.local/share/containerd
+    mkdir -p /mnt/lima-finch/containerd
+    mkdir -p /mnt/lima-finch/nerdctl
+    mkdir -p ~/.local/share/nerdctl
+    sudo mount --bind /mnt/lima-finch/containerd ~/.local/share/containerd
+    sudo mount --bind /mnt/lima-finch/nerdctl ~/.local/share/nerdctl
     systemctl --user restart containerd.service
 
 # Probe scripts to check readiness.


### PR DESCRIPTION
Signed-off-by: Sam Berning <bernings@amazon.com>

Issue #, if available: https://github.com/runfinch/finch/issues/180

*Description of changes:*

Changes format of persistent disk to support saving nerdctl user data

*Testing done:*

```
$ finch run --name test-container -v ~/scratch:/scratch alpine ls /scratch
$ finch vm stop
$ finch vm remove
$ finch vm init
$ finch start --attach test-container
```

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
