### PR TITLE
build: make finch-core a submodule instead of downloading archives

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,7 @@ jobs:
           # We need to get all the git tags to make version injection work. See VERSION in Makefile for more detail.
           fetch-depth: 0
           persist-credentials: false
+          submodules: true
       - name: Clean up previous files
         run: |
           sudo rm -rf /opt/finch

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,5 @@ _vde_output/
 **/*.img
 tmp/
 .vscode/
-finch-core/
 tools_bin/
 test-coverage.*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/finch-core"]
+	path = deps/finch-core
+	url = https://github.com/runfinch/finch-core.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ export PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH"
 
 Clone the repo and make sure to include the submodules by adding `--recurse-submodules`. For example:
 
-```
+```shell
 git clone --recurse-submodules https://github.com/runfinch/finch.git
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,9 +127,15 @@ export PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH"
 
 ### Build
 
+Clone the repo and make sure to include the submodules by adding `--recurse-submodules`. For example:
+
+```
+git clone --recurse-submodules https://github.com/runfinch/finch.git
+```
+
 After cloning the repo, run `make` to build the binary.
 
-The binary in _output can be directly used. E.g. initializing the vm and display the version
+The binary in `_output` can be directly used. E.g. initializing the vm and display the version
 
 ```sh
 ./_output/bin/finch vm init

--- a/Makefile
+++ b/Makefile
@@ -34,13 +34,13 @@ ifneq (,$(findstring arm64,$(ARCH)))
 	SUPPORTED_ARCH = true
 	LIMA_ARCH = aarch64
 	# From https://dl.fedoraproject.org/pub/fedora/linux/releases/37/Cloud/aarch64/images/
-	FINCH_OS_BASENAME ?= Fedora-Cloud-Base-37-1.7.aarch64.qcow2
+	FINCH_OS_BASENAME ?= Fedora-Cloud-Base-37-1.7.aarch64-20230124190350.qcow2
 	LIMA_URL ?= https://deps.runfinch.com/aarch64/lima-and-qemu.macos-aarch64.1673290784.tar.gz
 else ifneq (,$(findstring x86_64,$(ARCH)))
 	SUPPORTED_ARCH = true
 	LIMA_ARCH = x86_64
 	# From https://dl.fedoraproject.org/pub/fedora/linux/releases/37/Cloud/x86_64/images/
-	FINCH_OS_BASENAME ?= Fedora-Cloud-Base-37-1.7.x86_64.qcow2
+	FINCH_OS_BASENAME ?= Fedora-Cloud-Base-37-1.7.x86_64-20230124181550.qcow2
 	LIMA_URL ?= https://deps.runfinch.com/x86-64/lima-and-qemu.macos-x86_64.1673290501.tar.gz
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,6 @@ VDE_INSTALL ?= /opt/finch
 UNAME := $(shell uname -m)
 ARCH ?= $(UNAME)
 SUPPORTED_ARCH = false
-CORE_URL ?= https://artifact.runfinch.com/finch-core-0.1.1.tar.gz
-CORE_FILENAME := finch-core
-CORE_OUTDIR := $(CURDIR)/$(CORE_FILENAME)/_output
 CORE_VDE_PREFIX ?= $(OUTDIR)/dependencies/vde/opt/finch
 LICENSEDIR := $(OUTDIR)/license-files
 VERSION := $(shell git describe --match 'v[0-9]*' --dirty='.modified' --always --tags)
@@ -61,20 +58,14 @@ all: arch-test finch finch-core finch.yaml networks.yaml config.yaml lima-and-qe
 
 .PHONY: finch-core
 finch-core:
-	mkdir -p $(CURDIR)/$(CORE_FILENAME)
-	curl -L $(CORE_URL) > "$(CURDIR)/$(CORE_FILENAME).tar.gz"
-	tar -zvxf $(CURDIR)/finch-core.tar.gz -C $(CORE_FILENAME) --strip-component=1
-	rm "$(CORE_FILENAME).tar.gz"
-
-	cd $(CURDIR)/$(CORE_FILENAME) && \
+	cd deps/finch-core && \
 		FINCH_OS_x86_URL="$(FINCH_OS_x86_URL)" \
 		FINCH_OS_AARCH64_URL="$(FINCH_OS_AARCH64_URL)" \
 		VDE_TEMP_PREFIX=$(CORE_VDE_PREFIX) \
 		$(MAKE)
 
 	mkdir -p _output
-	cd $(CORE_FILENAME)/_output && tar c * | tar Cvx  $(OUTDIR)
-	rm -r $(CURDIR)/$(CORE_FILENAME)
+	cd deps/finch-core/_output && tar c * | tar Cvx  $(OUTDIR)
 	rm -rf $(OUTDIR)/lima-template
 
 .PHONY: lima-and-qemu
@@ -292,7 +283,6 @@ mdlint-ctr:
 .PHONY: clean
 clean:
 	-@rm -rf $(OUTDIR) 2>/dev/null || true
-	-@rm -rf $(CORE_FILENAME) 2>/dev/null || true
 	-@rm ./*.tar.gz 2>/dev/null || true
 	-@rm ./*.qcow2 2>/dev/null || true
 	-@rm ./test-coverage.* 2>/dev/null || true


### PR DESCRIPTION
Signed-off-by: Justin Alvarez <alvajus@amazon.com>

Issue #, if available: Supersedes #185, resolves #21

*Description of changes:*
- make finch-core a submodule instead of downloading the release tarball
  - removes the extra step of uploading / downloading tar files from the internet at build time
  - makes it easier/possible to reference the submodules of finch-core directly

*Testing done:*
- local build and e2e tests

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
