### PR TITLE
test: increase vm stop timeout to 90s

### DIFF
--- a/e2e/container/container_test.go
+++ b/e2e/container/container_test.go
@@ -31,7 +31,7 @@ func TestContainer(t *testing.T) {
 	}, func(bytes []byte) {})
 
 	ginkgo.SynchronizedAfterSuite(func() {
-		command.New(o, "vm", "stop").WithTimeoutInSeconds(60).Run()
+		command.New(o, "vm", "stop").WithTimeoutInSeconds(90).Run()
 		command.New(o, "vm", "remove").WithTimeoutInSeconds(60).Run()
 	}, func() {})
 

--- a/e2e/vm/additional_disk_test.go
+++ b/e2e/vm/additional_disk_test.go
@@ -28,7 +28,7 @@ var testAdditionalDisk = func(o *option.Option) {
 			oldPsOutput := command.StdoutStr(o, "ps", "--all", "--format", "{{.Names}}")
 			gomega.Expect(oldPsOutput).Should(gomega.ContainSubstring(containerName))
 
-			command.New(o, virtualMachineRootCmd, "stop").WithoutCheckingExitCode().WithTimeoutInSeconds(60).Run()
+			command.New(o, virtualMachineRootCmd, "stop").WithoutCheckingExitCode().WithTimeoutInSeconds(90).Run()
 			command.Run(o, virtualMachineRootCmd, "remove")
 
 			command.New(o, virtualMachineRootCmd, "init").WithTimeoutInSeconds(240).Run()

--- a/e2e/vm/config_test.go
+++ b/e2e/vm/config_test.go
@@ -43,7 +43,7 @@ func writeFile(filePath string, buf []byte) {
 func updateAndApplyConfig(o *option.Option, configBytes []byte) *gexec.Session {
 	writeFile(finchConfigFilePath, configBytes)
 
-	command.New(o, virtualMachineRootCmd, "stop").WithoutCheckingExitCode().WithTimeoutInSeconds(60).Run()
+	command.New(o, virtualMachineRootCmd, "stop").WithoutCheckingExitCode().WithTimeoutInSeconds(90).Run()
 	return command.New(o, virtualMachineRootCmd, "start").WithoutCheckingExitCode().WithTimeoutInSeconds(120).Run()
 }
 
@@ -79,7 +79,7 @@ var testConfig = func(o *option.Option, installed bool) {
 				writeFile(finchConfigFilePath, origFinchCfg)
 				writeFile(limaConfigFilePath, origLimaCfg)
 
-				command.New(o, virtualMachineRootCmd, "stop").WithoutCheckingExitCode().WithTimeoutInSeconds(60).Run()
+				command.New(o, virtualMachineRootCmd, "stop").WithoutCheckingExitCode().WithTimeoutInSeconds(90).Run()
 				command.New(o, virtualMachineRootCmd, "start").WithTimeoutInSeconds(120).Run()
 			})
 		})

--- a/e2e/vm/lifecycle_test.go
+++ b/e2e/vm/lifecycle_test.go
@@ -25,7 +25,7 @@ var testVMLifecycle = func(o *option.Option) {
 
 			ginkgo.It("should be able to stop the virtual machine", func() {
 				command.Run(o, "images")
-				command.New(o, virtualMachineRootCmd, "stop").WithTimeoutInSeconds(60).Run()
+				command.New(o, virtualMachineRootCmd, "stop").WithTimeoutInSeconds(90).Run()
 				command.RunWithoutSuccessfulExit(o, "images")
 			})
 		})
@@ -46,7 +46,7 @@ var testVMLifecycle = func(o *option.Option) {
 			})
 
 			ginkgo.It("should be able to remove the virtual machine", func() {
-				command.New(o, virtualMachineRootCmd, "stop").WithTimeoutInSeconds(60).Run()
+				command.New(o, virtualMachineRootCmd, "stop").WithTimeoutInSeconds(90).Run()
 				command.New(o, virtualMachineRootCmd, "remove").WithTimeoutInSeconds(60).Run()
 				command.RunWithoutSuccessfulExit(o, "images")
 			})

--- a/e2e/vm/vm_test.go
+++ b/e2e/vm/vm_test.go
@@ -33,7 +33,7 @@ func TestVM(t *testing.T) {
 	}, func(bytes []byte) {})
 
 	ginkgo.SynchronizedAfterSuite(func() {
-		command.New(o, "vm", "stop").WithTimeoutInSeconds(60).Run()
+		command.New(o, "vm", "stop").WithTimeoutInSeconds(90).Run()
 		command.New(o, "vm", "remove").WithTimeoutInSeconds(60).Run()
 	}, func() {})
 


### PR DESCRIPTION
Signed-off-by: Sam Berning <bernings@amazon.com>

Issue #, if available: https://github.com/runfinch/finch/issues/140

*Description of changes:*

Increases the `finch vm stop` timeout in e2e tests to 90 seconds.

In our CI/CD we've been seeing timeouts on most runs on ARM 11.7 instances, and occasionally on ARM 12.6 instances. Out of the 19 times that the `finch vm stop` command runs per run of the e2e tests, it tends to timeout only once or twice at most.

I've observed a couple of times on my local machine that `finch vm stop` can take 40-50 seconds, so it's reasonable to believe that increasing the timeout by another 30 seconds would eliminate most of these timeouts.

*Testing done:*

```
make test-e2e
```

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
