### PR TITLE
fix: Install build dependencies before build for github action: Upload build to S3

### DIFF
--- a/.github/workflows/upload-build-to-s3.yaml
+++ b/.github/workflows/upload-build-to-s3.yaml
@@ -53,6 +53,7 @@ jobs:
 
       - name: Make macos amd64 build
         run: |
+          brew install go lz4 automake autoconf libtool
           make clean
           make download-licenses 
           make FINCH_OS_IMAGE_LOCATION_ROOT=/Applications/Finch


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
The required dependencies are not installed for a new runner when trying to build Finch
*Testing done:*



- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
