### PR TITLE
ci: Fetch submodules while checkout

### DIFF
--- a/.github/workflows/upload-build-to-s3.yaml
+++ b/.github/workflows/upload-build-to-s3.yaml
@@ -23,6 +23,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          submodules: true
 
       - name: Make macos arm64 build
         run: |
@@ -50,6 +51,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          submodules: true
 
       - name: Make macos amd64 build
         run: |


### PR DESCRIPTION
Signed-off-by: Vishwas Siravara <siravara@amazon.com>

Issue #, if available:

*Description of changes:*
Fetch submodules (finch-core) while checking out code in order to build `socket_vmnet`. 
*Testing done:*
Yes. 


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
