### PR TITLE
feat: add workflow for uploading installers to release assets

### DIFF
--- a/.github/workflows/release-installer.yaml
+++ b/.github/workflows/release-installer.yaml
@@ -107,21 +107,4 @@ jobs:
         run: echo 'y' | sudo bash /Applications/Finch/uninstall.sh
       - name: Delete installer
         run: rm -rf Finch-${GITHUB_REF_NAME}-x86_64.pkg
-  
-  upload-installers:
-    needs: [get-latest-tag, macos-arm64-test-installer, macos-amd64-test-installer]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download installers
-        run: |
-          aws s3 cp s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-${GITHUB_REF_NAME}-aarch64.pkg Finch-${GITHUB_REF_NAME}-aarch64.pkg
-          aws s3 cp s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-${GITHUB_REF_NAME}-x86_64.pkg Finch-${GITHUB_REF_NAME}-x86_64.pkg
-      - name: Upload installers to release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ needs.get-latest-tag.outputs.tag }}
-          files: |
-            Finch-${GITHUB_REF_NAME}-aarch64.pkg
-            Finch-${GITHUB_REF_NAME}-x86_64.pkg
-
 

--- a/.github/workflows/release-installer.yaml
+++ b/.github/workflows/release-installer.yaml
@@ -107,4 +107,3 @@ jobs:
         run: echo 'y' | sudo bash /Applications/Finch/uninstall.sh
       - name: Delete installer
         run: rm -rf Finch-${GITHUB_REF_NAME}-x86_64.pkg
-

--- a/.github/workflows/release-installer.yaml
+++ b/.github/workflows/release-installer.yaml
@@ -107,3 +107,21 @@ jobs:
         run: echo 'y' | sudo bash /Applications/Finch/uninstall.sh
       - name: Delete installer
         run: rm -rf Finch-${GITHUB_REF_NAME}-x86_64.pkg
+  
+  upload-installers:
+    needs: [get-latest-tag, macos-arm64-test-installer, macos-amd64-test-installer]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download installers
+        run: |
+          aws s3 cp s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-${GITHUB_REF_NAME}-aarch64.pkg Finch-${GITHUB_REF_NAME}-aarch64.pkg
+          aws s3 cp s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-${GITHUB_REF_NAME}-x86_64.pkg Finch-${GITHUB_REF_NAME}-x86_64.pkg
+      - name: Upload installers to release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.get-latest-tag.outputs.tag }}
+          files: |
+            Finch-${GITHUB_REF_NAME}-aarch64.pkg
+            Finch-${GITHUB_REF_NAME}-x86_64.pkg
+
+

--- a/.github/workflows/upload-installer-to-release.yaml
+++ b/.github/workflows/upload-installer-to-release.yaml
@@ -23,7 +23,8 @@ jobs:
       - name: Upload installers to release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${GITHUB_REF_NAME}
+          tag_name: ${{  github.ref_name }}
           files: |
-            Finch-${GITHUB_REF_NAME}-aarch64.pkg
-            Finch-${GITHUB_REF_NAME}-x86_64.pkg
+            echo "Run with tag ${{  github.ref_name }}"
+            Finch-${{  github.ref_name }}-aarch64.pkg
+            Finch-${{  github.ref_name }}-x86_64.pkg

--- a/.github/workflows/upload-installer-to-release.yaml
+++ b/.github/workflows/upload-installer-to-release.yaml
@@ -23,7 +23,9 @@ jobs:
       - name: Upload installers to release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{  github.ref_name }}
+          tag_name: ${{ github.ref_name }}
           files: |
-            Finch-${{  github.ref_name }}-aarch64.pkg
-            Finch-${{  github.ref_name }}-x86_64.pkg
+            Finch-${{ github.ref_name }}-aarch64.pkg
+            Finch-${{ github.ref_name }}-x86_64.pkg
+      - name: Delete installers
+        run: rm -rf Finch-${{ github.ref_name }}-aarch64.pkg Finch-${{ github.ref_name }}-x86_64.pkg

--- a/.github/workflows/upload-installer-to-release.yaml
+++ b/.github/workflows/upload-installer-to-release.yaml
@@ -1,4 +1,4 @@
-#TODO: 
+#TODO: merge this workflow to the release-installer.yaml after the issue on arm hosts is fixed
 name: Upload installer
 on:
   workflow_dispatch: # Trigger this workflow from tag
@@ -25,6 +25,5 @@ jobs:
         with:
           tag_name: ${{  github.ref_name }}
           files: |
-            echo "Run with tag ${{  github.ref_name }}"
             Finch-${{  github.ref_name }}-aarch64.pkg
             Finch-${{  github.ref_name }}-x86_64.pkg

--- a/.github/workflows/upload-installer-to-release.yaml
+++ b/.github/workflows/upload-installer-to-release.yaml
@@ -4,11 +4,12 @@ on:
 
 permissions:
   id-token: write   # This is required for requesting the JWT
-  contents: read    # This is required for actions/checkout
 
 jobs:         
   upload-installers:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/upload-installer-to-release.yaml
+++ b/.github/workflows/upload-installer-to-release.yaml
@@ -1,6 +1,6 @@
 name: Upload installer
 on:
-  workflow_dispatch:
+  workflow_dispatch: # Trigger this workflow from tag
 
 permissions:
   id-token: write   # This is required for requesting the JWT
@@ -23,7 +23,7 @@ jobs:
       - name: Upload installers to release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ needs.get-latest-tag.outputs.tag }}
+          tag_name: ${GITHUB_REF_NAME}
           files: |
             Finch-${GITHUB_REF_NAME}-aarch64.pkg
             Finch-${GITHUB_REF_NAME}-x86_64.pkg

--- a/.github/workflows/upload-installer-to-release.yaml
+++ b/.github/workflows/upload-installer-to-release.yaml
@@ -1,0 +1,29 @@
+name: Upload installer
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkout
+
+jobs:         
+  upload-installers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.ROLE }}
+          role-session-name: download-installer-session
+          aws-region: ${{ secrets.REGION }}
+      - name: Download installers
+        run: |
+          aws s3 cp s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-${GITHUB_REF_NAME}-aarch64.pkg Finch-${GITHUB_REF_NAME}-aarch64.pkg
+          aws s3 cp s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-${GITHUB_REF_NAME}-x86_64.pkg Finch-${GITHUB_REF_NAME}-x86_64.pkg
+      - name: Upload installers to release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.get-latest-tag.outputs.tag }}
+          files: |
+            Finch-${GITHUB_REF_NAME}-aarch64.pkg
+            Finch-${GITHUB_REF_NAME}-x86_64.pkg

--- a/.github/workflows/upload-installer-to-release.yaml
+++ b/.github/workflows/upload-installer-to-release.yaml
@@ -1,15 +1,14 @@
+#TODO: 
 name: Upload installer
 on:
   workflow_dispatch: # Trigger this workflow from tag
 
 permissions:
   id-token: write   # This is required for requesting the JWT
-
+  contents: write   # This is required for uploading the release assets
 jobs:         
   upload-installers:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
This workflow is to be run after the `release-installer.yaml` workflow completes. And after this workflow completes, the next step is to run the `release-homebrew.yaml` workflow. All the three workflows should be merged together once this [issue](https://github.com/runfinch/finch/issues/106) is fixed.
*Testing done:*
Tested the workflow within my own fork.


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
