### PR TITLE
fix: persists network user data

### DIFF
--- a/finch.yaml
+++ b/finch.yaml
@@ -149,18 +149,25 @@ provision:
   script: |
     #!/bin/bash
     sudo chown $USER /mnt/lima-finch
-    # https://github.com/containerd/nerdctl/blob/main/extras/rootless/containerd-rootless.sh#L146
+
+    # https://github.com/containerd/nerdctl/blob/cffdf87ff4d648a5344eea1406bb95ca3ad7eaa4/extras/rootless/containerd-rootless.sh#L144-L146
+    # XDG_DATA_HOME & ~/.local/share: https://github.com/containerd/nerdctl/blob/cffdf87ff4d648a5344eea1406bb95ca3ad7eaa4/extras/rootless/containerd-rootless.sh#L51
     mkdir -p /mnt/lima-finch/containerd ~/.local/share/containerd
     sudo mount --bind /mnt/lima-finch/containerd ~/.local/share/containerd
+
     # https://github.com/containerd/nerdctl/blob/main/docs/dir.md#dataroot
     mkdir -p /mnt/lima-finch/nerdctl ~/.local/share/nerdctl
     sudo mount --bind /mnt/lima-finch/nerdctl ~/.local/share/nerdctl
+
     # https://github.com/containerd/nerdctl/blob/main/docs/dir.md#netconfpath
     mkdir -p /mnt/lima-finch/cni-config ~/.config/cni
     sudo mount --bind /mnt/lima-finch/cni-config ~/.config/cni
-    # https://github.com/containerd/nerdctl/blob/main/extras/rootless/containerd-rootless.sh#L150
+
+    # https://github.com/containerd/nerdctl/blob/cffdf87ff4d648a5344eea1406bb95ca3ad7eaa4/extras/rootless/containerd-rootless.sh#L148-L150
+    # XDG_DATA_HOME & ~/.local/share: https://github.com/containerd/nerdctl/blob/cffdf87ff4d648a5344eea1406bb95ca3ad7eaa4/extras/rootless/containerd-rootless.sh#L51
     mkdir -p /mnt/lima-finch/cni-local ~/.local/share/cni
     sudo mount --bind /mnt/lima-finch/cni-local ~/.local/share/cni
+
     systemctl --user restart containerd.service
 
 # Probe scripts to check readiness.

--- a/finch.yaml
+++ b/finch.yaml
@@ -149,11 +149,18 @@ provision:
   script: |
     #!/bin/bash
     sudo chown $USER /mnt/lima-finch
-    mkdir -p /mnt/lima-finch/containerd
-    mkdir -p /mnt/lima-finch/nerdctl
-    mkdir -p ~/.local/share/nerdctl
+    # https://github.com/containerd/nerdctl/blob/main/extras/rootless/containerd-rootless.sh#L146
+    mkdir -p /mnt/lima-finch/containerd ~/.local/share/containerd
     sudo mount --bind /mnt/lima-finch/containerd ~/.local/share/containerd
+    # https://github.com/containerd/nerdctl/blob/main/docs/dir.md#dataroot
+    mkdir -p /mnt/lima-finch/nerdctl ~/.local/share/nerdctl
     sudo mount --bind /mnt/lima-finch/nerdctl ~/.local/share/nerdctl
+    # https://github.com/containerd/nerdctl/blob/main/docs/dir.md#netconfpath
+    mkdir -p /mnt/lima-finch/cni-config ~/.config/cni
+    sudo mount --bind /mnt/lima-finch/cni-config ~/.config/cni
+    # https://github.com/containerd/nerdctl/blob/main/extras/rootless/containerd-rootless.sh#L150
+    mkdir -p /mnt/lima-finch/cni-local ~/.local/share/cni
+    sudo mount --bind /mnt/lima-finch/cni-local ~/.local/share/cni
     systemctl --user restart containerd.service
 
 # Probe scripts to check readiness.


### PR DESCRIPTION
Signed-off-by: Sam Berning <bernings@amazon.com>

Issue #, if available: https://github.com/runfinch/finch/issues/180

*Description of changes:*

Persists the `cni` user data stored in `~/.local/share/cni` and in `~/.config/cni`

*Testing done:*

Manual testing

```
$ finch network create samtest --subnet 10.8.0.0/24
$ finch run --network=samtest --name hello public.ecr.aws/amazonlinux/amazonlinux:2 sleep 1
$ finch vm stop
$ finch vm remove
$ finch vm init
$ finch start hello
```


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
