### PR TITLE
refactor: replace os calls with afero.Fs ones in nerdctlCommand

### DIFF
--- a/cmd/finch/main.go
+++ b/cmd/finch/main.go
@@ -90,7 +90,7 @@ var newApp = func(logger flog.Logger, fp path.Finch, fs afero.Fs, fc *config.Fin
 	)
 
 	// append nerdctl commands
-	allCommands := initializeNerdctlCommands(lcc, logger)
+	allCommands := initializeNerdctlCommands(lcc, logger, fs)
 	// append finch specific commands
 	allCommands = append(allCommands,
 		newVersionCommand(lcc, logger, stdOut),
@@ -124,8 +124,8 @@ func virtualMachineCommands(
 	)
 }
 
-func initializeNerdctlCommands(lcc command.LimaCmdCreator, logger flog.Logger) []*cobra.Command {
-	nerdctlCommandCreator := newNerdctlCommandCreator(lcc, system.NewStdLib(), logger)
+func initializeNerdctlCommands(lcc command.LimaCmdCreator, logger flog.Logger, fs afero.Fs) []*cobra.Command {
+	nerdctlCommandCreator := newNerdctlCommandCreator(lcc, system.NewStdLib(), logger, fs)
 	var allNerdctlCommands []*cobra.Command
 	for cmdName, cmdDescription := range nerdctlCmds {
 		allNerdctlCommands = append(allNerdctlCommands, nerdctlCommandCreator.create(cmdName, cmdDescription))


### PR DESCRIPTION
## Summary

PR fixes https://github.com/runfinch/finch/pull/158#discussion_r1101922922. Besides that, it also adds a new test case, namely `"with --env-file flag, but the specified file does not exist"`, which becomes easier to add after the refactoring.

## Notes

`gosec` is removed from `//nolint:errcheck,gosec` because `gosec` checks things like `os.Open` but not `fs.Open`, where `fs` is of type `afero.Fs`. Updated the `noling` comment accordingly.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
