### PR TITLE
docs: updated readme example to clone https

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you're new to containers, that is so exciting! Give the command above a try a
 To build an image, try a quick example from the finch client repository.
 
 ```sh
-git clone git@github.com:runfinch/finch.git
+git clone https://github.com/runfinch/finch.git
 cd finch/contrib/hello-finch
 finch build . -t hello-finch
 ..


### PR DESCRIPTION
Signed-off-by: Weike Qu <weikequ@amazon.com>

Issue #, if available:

*Description of changes:*
- If user had not set up ssh on their computer and tried to follow the example, the git clone command `git clone git@github.com:runfinch/finch.git` in the quick example would fail. 
- This changes the reference to use https instead of ssh.

*Testing done:*
- Tested on ec2 instances without ssh set up


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
