### PR TITLE
ci: Update .app installer path

### DIFF
--- a/.github/workflows/release-installer.yaml
+++ b/.github/workflows/release-installer.yaml
@@ -23,7 +23,7 @@ jobs:
   # 1. Ssh to the arm64 hosts.
   # 2. Run `cd ar/_work/finch/finch`.
   # 3. Run `INSTALLED=true make test-e2e` to complete the installer e2e tests.
-  # 4. Run `sudo /Applications/Finch/uninstall.sh` to uninstall Finch.
+  # 4. Run `sudo bash /Applications/Finch.app/Contents/Resources/resources/uninstall.sh` to uninstall Finch.
   # 5. Run `rm -rf Finch-<version>-aarch64.pkg` to delete the pkg.
   macos-arm64-test-installer:
     strategy:
@@ -67,7 +67,7 @@ jobs:
       - name: Run e2e tests
         run: INSTALLED=true make test-e2e
       - name: Silently uninstall
-        run: echo 'y' | sudo bash /Applications/Finch/uninstall.sh
+        run: echo 'y' | sudo bash /Applications/Finch.app/Contents/Resources/resources/uninstall.sh 
       - name: Delete installer
         run: rm -rf Finch-${GITHUB_REF_NAME}-aarch64.pkg
 
@@ -115,6 +115,6 @@ jobs:
       - name: Run e2e tests
         run: INSTALLED=true make test-e2e
       - name: Silently uninstall
-        run: echo 'y' | sudo bash /Applications/Finch/uninstall.sh
+        run: echo 'y' | sudo bash /Applications/Finch.app/Contents/Resources/resources/uninstall.sh 
       - name: Delete installer
         run: rm -rf Finch-${GITHUB_REF_NAME}-x86_64.pkg

--- a/.github/workflows/upload-build-to-s3.yaml
+++ b/.github/workflows/upload-build-to-s3.yaml
@@ -30,7 +30,7 @@ jobs:
           brew install go lz4 automake autoconf libtool
           make clean
           make download-licenses 
-          make FINCH_OS_IMAGE_LOCATION_ROOT=/Applications/Finch
+          make FINCH_OS_IMAGE_LOCATION_ROOT=/Applications/Finch.app/Contents/Resources/resources
           tar -zcvf finch.arm64."$(date '+%s').tar.gz" _output
 
       - name: Upload macos arm64 build
@@ -58,7 +58,7 @@ jobs:
           brew install go lz4 automake autoconf libtool
           make clean
           make download-licenses 
-          make FINCH_OS_IMAGE_LOCATION_ROOT=/Applications/Finch
+          make FINCH_OS_IMAGE_LOCATION_ROOT=/Applications/Finch.app/Contents/Resources/resources
           tar -zcvf finch.amd64."$(date '+%s').tar.gz" _output
 
       - name: Upload macos amd64 build


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
After change Finch to .app structure, github action params need update to new path: image path and uninstall script path
*Testing done:*



- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
