### PR TITLE
fix: parse --add-host special ip with equal sign

### DIFF
--- a/cmd/finch/nerdctl.go
+++ b/cmd/finch/nerdctl.go
@@ -112,8 +112,14 @@ func (nc *nerdctlCommand) run(cmdName string, args []string) error {
 			}
 			skip = shouldSkip
 			fileEnvs = append(fileEnvs, addEnvs...)
-		case arg == "--add-host":
-			args[i+1] = resolveIP(args[i+1], nc.logger)
+		case strings.HasPrefix(arg, "--add-host"):
+			switch arg {
+			case "--add-host":
+				args[i+1] = resolveIP(args[i+1], nc.logger)
+			default:
+				resolvedIP := resolveIP(arg[11:], nc.logger)
+				arg = fmt.Sprintf("%s%s", arg[0:11], resolvedIP)
+			}
 			nerdctlArgs = append(nerdctlArgs, arg)
 		default:
 			nerdctlArgs = append(nerdctlArgs, arg)


### PR DESCRIPTION
https://github.com/runfinch/finch/issues/209

*Description of changes:*

parse --add-host special ip with equal sign, like `--add-host=name:host-gateway`

*Testing done:*

unit tests and e2e tests


- [ X ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
