### PR TITLE
refactor: use the idiomatic errors.Join

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
           # Pin the version in case all the builds start to fail at the same time.
           # There may not be an automatic way (e.g., dependabot) to update a specific parameter of a Github Action,
           # so we will just update it manually whenever it makes sense (e.g., a feature that we want is added).
-          version: v1.50.0
+          version: v1.51.2
           args: --fix=false
   go-mod-tidy-check:
     runs-on: ubuntu-latest

--- a/cmd/finch/virtual_machine_init_test.go
+++ b/cmd/finch/virtual_machine_init_test.go
@@ -254,9 +254,11 @@ func TestInitVMAction_run(t *testing.T) {
 				logger.EXPECT().Debugf("Status of virtual machine: %s", "")
 
 				lca.EXPECT().Apply().Return(errors.New("load config fails"))
-				logger.EXPECT().Errorf("Dependency error: %v", fmt.Errorf("failed to install dependencies: %v",
-					[]error{fmt.Errorf("%s: %v", "mock_error_msg", []error{errors.New("dependency error occurs")})},
-				))
+				logger.EXPECT().Errorf("Dependency error: %v",
+					fmt.Errorf("failed to install dependencies: %w",
+						errors.Join(fmt.Errorf("%s: %w", "mock_error_msg", errors.Join(errors.New("dependency error occurs")))),
+					),
+				)
 			},
 		},
 		{

--- a/cmd/finch/virtual_machine_start_test.go
+++ b/cmd/finch/virtual_machine_start_test.go
@@ -264,9 +264,11 @@ func TestStartVMAction_run(t *testing.T) {
 
 				lca.EXPECT().Apply().Return(errors.New("load config fails"))
 
-				logger.EXPECT().Errorf("Dependency error: %v", fmt.Errorf("failed to install dependencies: %v",
-					[]error{fmt.Errorf("%s: %v", "mock_error_msg", []error{errors.New("dependency error occurs")})},
-				))
+				logger.EXPECT().Errorf("Dependency error: %v",
+					fmt.Errorf("failed to install dependencies: %w",
+						errors.Join(fmt.Errorf("%s: %w", "mock_error_msg", errors.Join(errors.New("dependency error occurs")))),
+					),
+				)
 			},
 		},
 		{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/runfinch/finch
 
-go 1.18
+go 1.20
 
 require (
 	github.com/docker/docker v23.0.1+incompatible

--- a/pkg/dependency/dependency.go
+++ b/pkg/dependency/dependency.go
@@ -6,6 +6,7 @@
 package dependency
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/runfinch/finch/pkg/flog"
@@ -53,13 +54,12 @@ func (g *Group) installOptional(logger flog.Logger) error {
 		}
 		err := dep.Install()
 		if err != nil {
-			// TODO: switch to https://github.com/uber-go/multierr
 			errs = append(errs, err)
 		}
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("%s: %v", g.errMsg, errs)
+		return fmt.Errorf("%s: %w", g.errMsg, errors.Join(errs...))
 	}
 
 	return nil
@@ -76,13 +76,12 @@ func InstallOptionalDeps(groups []*Group, logger flog.Logger) error {
 	for _, group := range groups {
 		err := group.installOptional(logger)
 		if err != nil {
-			// TODO: switch to https://github.com/uber-go/multierr
 			errs = append(errs, err)
 		}
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("failed to install dependencies: %v", errs)
+		return fmt.Errorf("failed to install dependencies: %w", errors.Join(errs...))
 	}
 
 	return nil

--- a/pkg/dependency/dependency_test.go
+++ b/pkg/dependency/dependency_test.go
@@ -87,7 +87,7 @@ func TestGroup_instalOptional(t *testing.T) {
 			mockSvc: func(l *mocks.Logger) {
 				l.EXPECT().Infoln("description")
 			},
-			want: fmt.Errorf("%s: %v", "error message", []error{errors.New("installation failed")}),
+			want: fmt.Errorf("%s: %w", "error message", errors.Join(errors.New("installation failed"))),
 		},
 	}
 
@@ -185,8 +185,10 @@ func TestInstallOptionalDeps(t *testing.T) {
 			mockSvc: func(l *mocks.Logger) {
 				l.EXPECT().Infoln("dep group 1 description")
 			},
-			want: fmt.Errorf("failed to install dependencies: %v",
-				[]error{fmt.Errorf("%s: %v", "dep group 1 error message", []error{errors.New("installation failed")})},
+			want: fmt.Errorf("failed to install dependencies: %w",
+				errors.Join(
+					fmt.Errorf("%s: %w", "dep group 1 error message", errors.Join(errors.New("installation failed"))),
+				),
 			),
 		},
 	}


### PR DESCRIPTION
## Summary

`errors.Join` is [introduced in Go 1.20](https://go.dev/blog/go1.20#standard-library-additions), and it natively supports `errors.As` and `errors.Is`.

## Notes

- There should be no user impact, just more idiomatic code.
- [Go 1.20 support was just added to homebrew](https://github.com/Homebrew/homebrew-core/pull/122082#issuecomment-1439167606) today, so our CI should work fine.
- Bump `golangci-lint` to [`v1.51.2`](https://github.com/golangci/golangci-lint/releases/tag/v1.51.2) (i.e., the latest version) because [the corresponding job was failing](https://github.com/runfinch/finch/actions/runs/4238412752/jobs/7365461867), and I noticed that `make lint` passes locally, and the version of my `golangci-lint` is `v1.51.2`. It's likely related to the `go 1.18` -> `go 1.20` version bump in `go.mod`, but I don't bother digging into it as it's working now anyways.
- Thought about whether a separate PR should be created to bump the Go version first, but since that version means the minimum version needed to build the module, it might make more sense to include the version bump in the first PR that uses any new feature (i.e., `errors.Join`) introduced in the new version (i.e., `Go 1.20`).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
