### PR TITLE
ci: fix the job to create Homebrew PR

### DIFF
--- a/.github/workflows/release-homebrew.yaml
+++ b/.github/workflows/release-homebrew.yaml
@@ -145,7 +145,7 @@ jobs:
           fi
 
   pr-to-homebrew:
-    needs: [macos-arm64-test-installer, macos-amd64-test-installer]
+    needs: [get-latest-tag, macos-arm64-test-installer, macos-amd64-test-installer]
     runs-on: ubuntu-latest
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Add the job `get-latest-tag` to the prerequisites of `pr-to-homebrew` to fix the bug that it couldn't get the Finch version.
*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
