### PR TITLE
ci: add cleanup commands to release homebrew workflow

### DIFF
--- a/.github/workflows/release-homebrew.yaml
+++ b/.github/workflows/release-homebrew.yaml
@@ -173,5 +173,5 @@ jobs:
         run: brew bump-cask-pr --version=${FINCH_VERSION} finch
         env:
           FINCH_VERSION: ${{ needs.get-latest-tag.outputs.version }}
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.FINCH_BOT_TOKEN }}
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
         

--- a/.github/workflows/release-homebrew.yaml
+++ b/.github/workflows/release-homebrew.yaml
@@ -54,7 +54,8 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.x
+          go-version-file: go.mod
+          cache: true
       - uses: actions/checkout@v3
         with:
           ref: ${{ env.FINCH_TAG }}
@@ -118,7 +119,8 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.x
+          go-version-file: go.mod
+          cache: true
       - uses: actions/checkout@v3
         with:
           ref: ${{ env.FINCH_TAG }}

--- a/.github/workflows/release-homebrew.yaml
+++ b/.github/workflows/release-homebrew.yaml
@@ -93,7 +93,7 @@ jobs:
         if: ${{ always() }}
         run: |
           cd $(brew --repo homebrew/cask)
-          brew uninstall --cask ./Casks/finch.rb
+          brew uninstall --zap --cask ./Casks/finch.rb
           if [ -d "/Applications/Finch" ]; then
             echo ERROR: Finch is not uninstalled
             exit 1

--- a/.github/workflows/release-homebrew.yaml
+++ b/.github/workflows/release-homebrew.yaml
@@ -60,6 +60,14 @@ jobs:
           ref: ${{ env.FINCH_TAG }}
       - name: Clean up previous files
         run: |
+          sudo rm -rf /opt/finch
+          sudo rm -rf ~/.finch
+          if pgrep '^qemu-system'; then
+            sudo pkill '^qemu-system'
+          fi
+          if pgrep '^socket_vmnet'; then
+            sudo pkill '^socket_vmnet'
+          fi
           cd $(brew --repo homebrew/cask) 
           brew uninstall --cask ./Casks/finch.rb || true
       - name: Set up Homebrew
@@ -116,6 +124,14 @@ jobs:
           ref: ${{ env.FINCH_TAG }}
       - name: Clean up previous files
         run: |
+          sudo rm -rf /opt/finch
+          sudo rm -rf ~/.finch
+          if pgrep '^qemu-system'; then
+            sudo pkill '^qemu-system'
+          fi
+          if pgrep '^socket_vmnet'; then
+            sudo pkill '^socket_vmnet'
+          fi
           cd $(brew --repo homebrew/cask) 
           brew uninstall --cask ./Casks/finch.rb || true
       - name: Set up Homebrew
@@ -138,7 +154,7 @@ jobs:
         if: ${{ always() }}
         run: |
           cd $(brew --repo homebrew/cask)
-          brew uninstall --cask ./Casks/finch.rb
+          brew uninstall --zap --cask ./Casks/finch.rb
           if [ -d "/Applications/Finch" ]; then
             echo ERROR: Finch is not uninstalled
             exit 1
@@ -146,7 +162,7 @@ jobs:
 
   pr-to-homebrew:
     needs: [get-latest-tag, macos-arm64-test-installer, macos-amd64-test-installer]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Add cleanup commands to delete the ~/.finch folder created by the previous workflow run. Otherwise it fails when previous workflow run is cancelled.

*Testing done:*
https://github.com/runfinch/finch/actions/runs/4349228997/jobs/7599448045


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
