### PR TITLE
fix: print debug logs when lima disk command fails

### DIFF
--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -116,7 +116,10 @@ func (m *userDataDiskManager) limaDiskExists() bool {
 
 func (m *userDataDiskManager) createLimaDisk() error {
 	cmd := m.lcc.CreateWithoutStdio("disk", "create", diskName, "--size", diskSize)
-	return cmd.Run()
+	if logs, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to create disk, debug logs:\n%s", logs)
+	}
+	return nil
 }
 
 func (m *userDataDiskManager) attachPersistentDiskToLimaDisk() error {
@@ -165,5 +168,8 @@ func (m *userDataDiskManager) limaDiskIsLocked() bool {
 
 func (m *userDataDiskManager) unlockLimaDisk() error {
 	cmd := m.lcc.CreateWithoutStdio("disk", "unlock", diskName)
-	return cmd.Run()
+	if logs, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to unlock disk, debug logs:\n%s", logs)
+	}
+	return nil
 }

--- a/pkg/disk/disk_test.go
+++ b/pkg/disk/disk_test.go
@@ -55,7 +55,7 @@ func TestUserDataDiskManager_InitializeUserDataDisk(t *testing.T) {
 				cmd.EXPECT().Output().Return([]byte(""), nil)
 
 				lcc.EXPECT().CreateWithoutStdio(mockCreateArgs).Return(cmd)
-				cmd.EXPECT().Run().Return(nil)
+				cmd.EXPECT().CombinedOutput().Return(nil, nil)
 
 				dfs.EXPECT().Stat(finch.UserDataDiskPath(homeDir)).Return(nil, fs.ErrNotExist)
 				dfs.EXPECT().Stat(path.Dir(finch.UserDataDiskPath(homeDir))).Return(nil, nil)
@@ -107,7 +107,7 @@ func TestUserDataDiskManager_InitializeUserDataDisk(t *testing.T) {
 				cmd.EXPECT().Output().Return([]byte(""), nil)
 
 				lcc.EXPECT().CreateWithoutStdio(mockCreateArgs).Return(cmd)
-				cmd.EXPECT().Run().Return(nil)
+				cmd.EXPECT().CombinedOutput().Return(nil, nil)
 
 				dfs.EXPECT().Stat(finch.UserDataDiskPath(homeDir)).Return(nil, nil)
 
@@ -130,7 +130,7 @@ func TestUserDataDiskManager_InitializeUserDataDisk(t *testing.T) {
 
 				dfs.EXPECT().Stat(lockPath).Return(nil, nil)
 				lcc.EXPECT().CreateWithoutStdio(mockUnlockArgs).Return(cmd)
-				cmd.EXPECT().Run().Return(nil)
+				cmd.EXPECT().CombinedOutput().Return(nil, nil)
 			},
 		},
 	}


### PR DESCRIPTION
## Before

```sh
➜  finch git:(main) ✗ ./_output/bin/finch vm init
FATA[0000] exit status 1
```

## After

```sh
➜  finch git:(disk-combined-output) ✗ ./_output/bin/finch vm init
FATA[0000] failed to create disk, debug logs:
time="2023-03-07T13:35:02-08:00" level=fatal msg="disk \"finch\" already exists (\"/Users/davidhyc/dev/runfinch/finch/_output/lima/data/_disks/finch\")"
```

## Notes

The concept behind this PR is from: https://github.com/runfinch/finch/blob/674b3794fe5f5902c264d5327024fb92e147e60f/cmd/finch/virtual_machine_init.go#L97-L101

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.