### PR TITLE
ci: Add workflow to sync finch submodules

### DIFF
--- a/.github/bin/update-os-image.sh
+++ b/.github/bin/update-os-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+set -euxo pipefail
 # Set OS hash directory in finch-core as base directory for searching latest OS images.
 OS_BASE_IMAGE_HASH_DIR="./deps/finch-core/hashes/"
 

--- a/.github/bin/update-os-image.sh
+++ b/.github/bin/update-os-image.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -x
+# Set OS hash directory in finch-core as base directory for searching latest OS images.
+OS_BASE_IMAGE_HASH_DIR="./deps/finch-core/hashes/"
+
+OS_AARCH64_FILENAME_PATTERN="Fedora-Cloud-Base-.*-.*.aarch64-.*.qcow2"
+
+OS_X86_64_FILENAME_PATTERN="Fedora-Cloud-Base-.*-.*.x86_64-.*.qcow2"
+
+
+# Use wildcard patterns to search for the two files and assign their paths to variables
+AARCH64_FILEPATH=$(find "$OS_BASE_IMAGE_HASH_DIR" -name "Fedora-Cloud-Base-*-*.aarch64-*.qcow2.sha512" -print -quit)
+X86_64_FILEPATH=$(find "$OS_BASE_IMAGE_HASH_DIR" -name "Fedora-Cloud-Base-*-*.x86_64-*.qcow2.sha512" -print -quit)
+
+# Extract the file names without the path and remove the ".sha512" extension
+AARCH64_OS_BASE_IMAGE=$(basename "$AARCH64_FILEPATH" .sha512)
+X86_64_OS_BASE_IMAGE=$(basename "$X86_64_FILEPATH" .sha512)
+
+echo "AARCH64 base image: ${AARCH64_OS_BASE_IMAGE}"
+echo "X86_64 base image: ${X86_64_OS_BASE_IMAGE}"
+
+# Replace occurrences of FINCH_OS_BASENAME in the Makefile with the file names
+sed -E -i.bak 's|^([[:blank:]]*FINCH_OS_BASENAME[[:blank:]]*\?=[[:blank:]]*)('"${OS_AARCH64_FILENAME_PATTERN}"')|\1'"$AARCH64_OS_BASE_IMAGE"'|' Makefile
+sed -E -i.bak 's|^([[:blank:]]*FINCH_OS_BASENAME[[:blank:]]*\?=[[:blank:]]*)('"${OS_X86_64_FILENAME_PATTERN}"')|\1'"$X86_64_OS_BASE_IMAGE"'|' Makefile

--- a/.github/workflows/sync-submodules.yaml
+++ b/.github/workflows/sync-submodules.yaml
@@ -24,6 +24,5 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: bump submodules
           signoff: true
           title: 'build(deps): Bump submodules'

--- a/.github/workflows/sync-submodules.yaml
+++ b/.github/workflows/sync-submodules.yaml
@@ -1,0 +1,28 @@
+name: Sync Submodules
+
+# Pulls changes from the main branch of submodules daily at 9:00 UTC and opens a PR.
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update sub modules
+        run: |
+          git submodule update --remote
+
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: bump submodules
+          signoff: true
+          title: 'build(deps): Bump submodules'

--- a/.github/workflows/sync-submodules.yaml
+++ b/.github/workflows/sync-submodules.yaml
@@ -18,6 +18,7 @@ jobs:
       - name: Update sub modules
         run: |
           git submodule update --remote
+          ./.github/bin/update-os-image.sh
 
       - name: Create PR
         uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
Issue #, if available: N/A

*Description of changes:*
Add workflow to update submodules in `finch`. 

#### Details
1. Workflow runs daily at 9am UTC. 
2. Has a `workflow_dispatch` trigger for manually running the workflow in addition to the regular daily cadence. 
*Testing done:*
Yes. See https://github.com/vsiravar/finch-public/pull/2
Test with updating `FINCH_OS_BASENAME` : https://github.com/vsiravar/finch-public/pull/4/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
