### PR TITLE
fix: print debug logs after newline

### DIFF
--- a/cmd/finch/virtual_machine_init.go
+++ b/cmd/finch/virtual_machine_init.go
@@ -96,7 +96,7 @@ func (iva *initVMAction) run() error {
 	iva.logger.Info("Initializing and starting Finch virtual machine...")
 	logs, err := limaCmd.CombinedOutput()
 	if err != nil {
-		iva.logger.Errorf("Finch virtual machine failed to start, debug logs: %s", logs)
+		iva.logger.Errorf("Finch virtual machine failed to start, debug logs:\n%s", logs)
 		return err
 	}
 	iva.logger.Info("Finch virtual machine started successfully")

--- a/cmd/finch/virtual_machine_init_test.go
+++ b/cmd/finch/virtual_machine_init_test.go
@@ -289,7 +289,7 @@ func TestInitVMAction_run(t *testing.T) {
 					mockBaseYamlFilePath, "--tty=false").Return(command)
 
 				logger.EXPECT().Info("Initializing and starting Finch virtual machine...")
-				logger.EXPECT().Errorf("Finch virtual machine failed to start, debug logs: %s", logs)
+				logger.EXPECT().Errorf("Finch virtual machine failed to start, debug logs:\n%s", logs)
 			},
 		},
 	}

--- a/cmd/finch/virtual_machine_remove.go
+++ b/cmd/finch/virtual_machine_remove.go
@@ -81,7 +81,7 @@ func (rva *removeVMAction) removeVM(force bool) error {
 	}
 	logs, err := limaCmd.CombinedOutput()
 	if err != nil {
-		rva.logger.Errorf("Finch virtual machine failed to remove, debug logs: %s", logs)
+		rva.logger.Errorf("Finch virtual machine failed to remove, debug logs:\n%s", logs)
 		return err
 	}
 	rva.logger.Info("Finch virtual machine removed successfully")

--- a/cmd/finch/virtual_machine_remove_test.go
+++ b/cmd/finch/virtual_machine_remove_test.go
@@ -159,7 +159,7 @@ func TestRemoveVMAction_run(t *testing.T) {
 				command.EXPECT().CombinedOutput().Return(logs, errors.New("failed to remove instance"))
 				creator.EXPECT().CreateWithoutStdio("remove", limaInstanceName).Return(command)
 				logger.EXPECT().Info("Removing existing Finch virtual machine...")
-				logger.EXPECT().Errorf("Finch virtual machine failed to remove, debug logs: %s", logs)
+				logger.EXPECT().Errorf("Finch virtual machine failed to remove, debug logs:\n%s", logs)
 			},
 			force: false,
 		},

--- a/cmd/finch/virtual_machine_start.go
+++ b/cmd/finch/virtual_machine_start.go
@@ -88,7 +88,7 @@ func (sva *startVMAction) run() error {
 	sva.logger.Info("Starting existing Finch virtual machine...")
 	logs, err := limaCmd.CombinedOutput()
 	if err != nil {
-		sva.logger.Errorf("Finch virtual machine failed to start, debug logs: %s", logs)
+		sva.logger.Errorf("Finch virtual machine failed to start, debug logs:\n%s", logs)
 		return err
 	}
 	sva.logger.Info("Finch virtual machine started successfully")

--- a/cmd/finch/virtual_machine_start_test.go
+++ b/cmd/finch/virtual_machine_start_test.go
@@ -305,7 +305,7 @@ func TestStartVMAction_run(t *testing.T) {
 				lcc.EXPECT().CreateWithoutStdio("start", limaInstanceName).Return(command)
 
 				logger.EXPECT().Info("Starting existing Finch virtual machine...")
-				logger.EXPECT().Errorf("Finch virtual machine failed to start, debug logs: %s", logs)
+				logger.EXPECT().Errorf("Finch virtual machine failed to start, debug logs:\n%s", logs)
 			},
 		},
 	}

--- a/cmd/finch/virtual_machine_stop.go
+++ b/cmd/finch/virtual_machine_stop.go
@@ -79,7 +79,7 @@ func (sva *stopVMAction) stopVM(force bool) error {
 	}
 	logs, err := limaCmd.CombinedOutput()
 	if err != nil {
-		sva.logger.Errorf("Finch virtual machine failed to stop, debug logs: %s", logs)
+		sva.logger.Errorf("Finch virtual machine failed to stop, debug logs:\n%s", logs)
 		return err
 	}
 	sva.logger.Info("Finch virtual machine stopped successfully")

--- a/cmd/finch/virtual_machine_stop_test.go
+++ b/cmd/finch/virtual_machine_stop_test.go
@@ -158,7 +158,7 @@ func TestStopVMAction_run(t *testing.T) {
 				command.EXPECT().CombinedOutput().Return(logs, errors.New("error"))
 				creator.EXPECT().CreateWithoutStdio("stop", limaInstanceName).Return(command)
 				logger.EXPECT().Info("Stopping existing Finch virtual machine...")
-				logger.EXPECT().Errorf("Finch virtual machine failed to stop, debug logs: %s", logs)
+				logger.EXPECT().Errorf("Finch virtual machine failed to stop, debug logs:\n%s", logs)
 			},
 			force: false,
 		},


### PR DESCRIPTION
## Why

It increases readability because debug logs can be multi-line.

## Before

```sh
➜  finch git:(main) ./_output/bin/finch vm init
INFO[0000] Initializing and starting Finch virtual machine...
ERRO[0000] Finch virtual machine failed to start, debug logs: time="2023-03-07T14:50:40-08:00" level=info msg="Terminal is not available, proceeding without opening an editor"
time="2023-03-07T14:50:40-08:00" level=fatal msg="field `images[0].digest` is invalid: sha256:156de3fd8a0c7e80dea9054aa9a0873e111efc16e5d8519929f913a1ca5ae9: invalid checksum digest length"
FATA[0000] exit status 1
```

## After

```sh
➜  finch git:(debug-logs-newline) ✗ ./_output/bin/finch vm init
INFO[0000] Initializing and starting Finch virtual machine...
ERRO[0000] Finch virtual machine failed to start, debug logs:
time="2023-03-07T14:49:45-08:00" level=info msg="Terminal is not available, proceeding without opening an editor"
time="2023-03-07T14:49:45-08:00" level=fatal msg="field `images[0].digest` is invalid: sha256:156de3fd8a0c7e80dea9054aa9a0873e111efc16e5d8519929f913a1ca5ae9: invalid checksum digest length"
FATA[0000] exit status 1
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
