### PR TITLE
ci: use the Go version in go.mod instead of a hard-coded one

### DIFF
--- a/.github/workflows/release-installer.yaml
+++ b/.github/workflows/release-installer.yaml
@@ -41,7 +41,8 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.x
+          go-version-file: go.mod
+          cache: true
       - uses: actions/checkout@v3
       - name: Clean up previous files
         run: |
@@ -88,7 +89,8 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.x
+          go-version-file: go.mod
+          cache: true
       - uses: actions/checkout@v3
       - name: Clean up previous files
         run: |


### PR DESCRIPTION
## Summary

PR is a follow-up of #257.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
