### PR TITLE
test: Improve test coverage for additional disk feature

### DIFF
--- a/e2e/vm/additional_disk_test.go
+++ b/e2e/vm/additional_disk_test.go
@@ -4,6 +4,8 @@
 package vm
 
 import (
+	"fmt"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/runfinch/common-tests/command"
@@ -12,32 +14,46 @@ import (
 
 const (
 	savedImage    = "public.ecr.aws/docker/library/alpine:latest"
-	containerName = "userDataTest"
+	containerName = "test-ctr"
+	volumeName    = "test-volume"
+	networkName   = "test-network"
 )
 
 var testAdditionalDisk = func(o *option.Option) {
 	ginkgo.Describe("Additional disk", ginkgo.Serial, func() {
 		ginkgo.It("Retains container user data after the VM is deleted", func() {
-			command.Run(o, "pull", savedImage)
+			command.Run(o, "volume", "create", volumeName)
+			ginkgo.DeferCleanup(command.Run, o, "volume", "rm", volumeName)
+			command.Run(o, "network", "create", networkName)
+			ginkgo.DeferCleanup(command.Run, o, "network", "rm", networkName)
+
+			command.Run(o, "run", "-d", "--name", containerName, "-v", fmt.Sprintf("%s:/tmp", volumeName),
+				savedImage, "sh", "-c", "echo foo > /tmp/test.txt; sleep infinity")
 			ginkgo.DeferCleanup(command.Run, o, "rmi", savedImage)
-			oldImagesOutput := command.StdoutStr(o, "images", "--format", "{{.Name}}")
-			gomega.Expect(oldImagesOutput).Should(gomega.ContainSubstring(savedImage))
+			ginkgo.DeferCleanup(command.Run, o, "rm", "-f", containerName)
 
-			command.Run(o, "run", "--name", containerName, savedImage)
-			ginkgo.DeferCleanup(command.Run, o, "rm", containerName)
-			oldPsOutput := command.StdoutStr(o, "ps", "--all", "--format", "{{.Names}}")
-			gomega.Expect(oldPsOutput).Should(gomega.ContainSubstring(containerName))
-
-			command.New(o, virtualMachineRootCmd, "stop").WithoutCheckingExitCode().WithTimeoutInSeconds(90).Run()
+			command.New(o, virtualMachineRootCmd, "stop").WithoutCheckingExitCode().WithTimeoutInSeconds(180).Run()
 			command.Run(o, virtualMachineRootCmd, "remove")
-
 			command.New(o, virtualMachineRootCmd, "init").WithTimeoutInSeconds(240).Run()
 
-			newImagesOutput := command.StdoutStr(o, "images", "--format", "{{.Name}}")
-			gomega.Expect(newImagesOutput).Should(gomega.Equal(oldImagesOutput))
+			imageOutput := command.StdoutAsLines(o, "images", "--format", "{{.Name}}")
+			gomega.Expect(imageOutput).Should(gomega.ContainElement(savedImage))
 
-			newPsOutput := command.StdoutStr(o, "ps", "--all", "--format", "{{.Names}}")
-			gomega.Expect(newPsOutput).Should(gomega.Equal(oldPsOutput))
+			psOutput := command.StdoutAsLines(o, "ps", "--all", "--format", "{{.Names}}")
+			gomega.Expect(psOutput).Should(gomega.ContainElement(containerName))
+
+			volumeOutput := command.StdoutAsLines(o, "volume", "ls", "--format", "{{.Name}}")
+			gomega.Expect(volumeOutput).Should(gomega.ContainElement(volumeName))
+
+			networkOutput := command.StdoutAsLines(o, "network", "ls", "--format", "{{.Name}}")
+			gomega.Expect(networkOutput).Should(gomega.ContainElement(networkName))
+
+			command.Run(o, "start", containerName)
+			gomega.Expect(command.StdoutStr(o, "exec", containerName, "cat", "/tmp/test.txt")).
+				Should(gomega.Equal("foo"))
+
+			gomega.Expect(command.StdoutStr(o, "run", "--rm", "-v", fmt.Sprintf("%s:/tmp", volumeName),
+				savedImage, "cat", "/tmp/test.txt")).Should(gomega.Equal("foo"))
 		})
 	})
 }


### PR DESCRIPTION
Issue #, if available:
Improving the e2e test coverage for additional disk.
*Description of changes:*
Adding test to retaining volume, network, and restart the container after the VM is removed
*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
