### PR TITLE
ci: Add schedule to update-deps workflow

### DIFF
--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -1,5 +1,7 @@
 name: Update dependencies
 on:
+  schedule:
+    - cron: '0 11 * * 2'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Schedule [update dependencies](https://github.com/runfinch/finch/blob/main/.github/workflows/update-deps.yaml) workflow which is currently triggered only by `workflow_dispatch`. This workflow will run after dependencies are built in `finch-core` by https://github.com/runfinch/finch-core/blob/main/.github/workflows/release.yaml(runs at 9 am UTC on Tuesday) at 11 am UTC on Tuesday. 
*Testing done:*
Yes. 
https://github.com/runfinch/finch/pull/291

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
