### PR TITLE
docs: Adding instructions of how to authenticate to GCR/AR in FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,21 @@ This section contains frequently-asked questions regarding working with Finch.
 LIMA_HOME=/Applications/Finch/lima/data /Applications/Finch/lima/bin/limactl shell finch
 ```
 
+#### How to authenticate to GCR(Google Container Registry) or AR(Artifact Registry)?
+Create a [GCP Service Account](https://cloud.google.com/iam/docs/service-accounts-create#creating), grant `Owner` role, and download the key as a JSON file to the $HOME directory.
+
+Then shell into the VM by running the following command:
+```sh
+LIMA_HOME=/Applications/Finch/lima/data /Applications/Finch/lima/bin/limactl shell finch
+```
+
+In the VM, go to the directory where the above key JSON file exists and run command:
+```sh 
+cat <your_key_json> | nerdctl login -u _json_key --password-stdin gcr.io
+```
+
+Exit to the host operating system by running `exit` in the VM. Then you can push and pull images by using Finch.
+
 ## What's next?
 
 We are excited to start this project in the open, and we'd love to hear from you. If you have ideas or find bugs please open an issue. Please feel free to start a discussion if you have something you'd like to propose or brainstorm. Pull requests are welcome, as well! See the [CONTRIBUTING](CONTRIBUTING.md) doc for more info on contributing, and the path to reviewer and maintainer roles for those interested.

--- a/README.md
+++ b/README.md
@@ -118,15 +118,20 @@ LIMA_HOME=/Applications/Finch/lima/data /Applications/Finch/lima/bin/limactl she
 ```
 
 #### How to authenticate to GCR(Google Container Registry) or AR(Artifact Registry)?
+
+_Note that it's a temporary workaround way, the feature is tracked in this [ticket](https://github.com/runfinch/finch/issues/309)._
+
 Create a [GCP Service Account](https://cloud.google.com/iam/docs/service-accounts-create#creating), grant `Owner` role, and download the key as a JSON file to the $HOME directory.
 
 Then shell into the VM by running the following command:
+
 ```sh
 LIMA_HOME=/Applications/Finch/lima/data /Applications/Finch/lima/bin/limactl shell finch
 ```
 
 In the VM, go to the directory where the above key JSON file exists and run command:
-```sh 
+
+```sh
 cat <your_key_json> | nerdctl login -u _json_key --password-stdin gcr.io
 ```
 


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Users are not able to authenticate to GCR/AR either by using service account key or authentication plugin.

Authenticating through service account key will save the credentials to an invalid path in the host OS - `/root/.docker/config.json`.

Authenticating through auth plugin - `gcloud auth configure-docker` is not working now. It is supported for nerdctl but that would require us to install gcloud cli and docker in the VM. The implementation of auth plugin would need more analysis.

More info: https://cloud.google.com/artifact-registry/docs/docker/authentication

This PR is to provide an instruction that gives users a quick workaround way to authenticate to GCR/AR.   

*Testing done:*
Manual testing


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
