### PR TITLE
ci: Fix upload build workflow

### DIFF
--- a/.github/workflows/upload-build-to-s3.yaml
+++ b/.github/workflows/upload-build-to-s3.yaml
@@ -50,7 +50,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           submodules: true
-          
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod

--- a/.github/workflows/upload-build-to-s3.yaml
+++ b/.github/workflows/upload-build-to-s3.yaml
@@ -16,15 +16,15 @@ jobs:
     runs-on: ['self-hosted', 'macos', 'arm64', '11.7']
     timeout-minutes: 60
     steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version-file: go.mod
-          cache: true
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           persist-credentials: false
           submodules: true
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+          cache: true
 
       - name: Make macos arm64 build
         run: |
@@ -45,15 +45,16 @@ jobs:
     runs-on: ['self-hosted', 'macos', 'amd64', '10.15']
     timeout-minutes: 60
     steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version-file: go.mod
-          cache: true
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           persist-credentials: false
           submodules: true
+          
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+          cache: true
 
       - name: Make macos amd64 build
         run: |


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Change order of steps in building finch binary in `upload-build-to-s3` action by  placing `actions/checkout` before `actions/setup-go` since `actions/setup-go` uses `go.mod` file from the project. 
*Testing done:*



- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
