### PR TITLE
ci(lint): add "exp" to PR title lint

### DIFF
--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -15,5 +15,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5
+        with:
+          # List from https://github.com/commitizen/conventional-commit-types/blob/master/index.json
+          # with custom types added at the end.
+          # Custom types should also be added in release-please.yaml changelog-types.
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+            exp
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
  - Previously we added exp to release-please.yaml in #323, but lint-pr-title has [its own configuration for custom types](https://github.com/amannn/action-semantic-pull-request).
    - Not doing this causes issue ([seen here](https://github.com/runfinch/finch/actions/runs/4547098114/jobs/8016553677)) with PR titles using exp

*Testing done:*
  - N/A


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
