### PR TITLE
ci(release): move exp before build

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -35,13 +35,13 @@ jobs:
                 "hidden":false
               },
               {
-                "type":"build",
-                "section":"Build System or External Dependencies",
+                "type":"exp",
+                "section":"Experimental",
                 "hidden":false
               },
               {
-                "type":"exp",
-                "section":"Experimental",
+                "type":"build",
+                "section":"Build System or External Dependencies",
                 "hidden":false
               }
             ]


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
  - move exp before build as experimental features are more important than build system / dependency upgrades

*Testing done:*
  - N/A



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
