### PR TITLE
test: generalize support bundles e2e tests to work with installed Finch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
           # There may not be an automatic way (e.g., dependabot) to update a specific parameter of a Github Action,
           # so we will just update it manually whenever it makes sense (e.g., a feature that we want is added).
           version: v1.51.2
-          args: --fix=false
+          args: --fix=false --timeout=5m
   go-mod-tidy-check:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ test-e2e: test-e2e-vm-serial
 
 .PHONY: test-e2e-vm-serial
 test-e2e-vm-serial: test-e2e-container
-	go test -ldflags $(LDFLAGS) -timeout 30m ./e2e/vm -test.v -ginkgo.v --installed="$(INSTALLED)"
+	go test -ldflags $(LDFLAGS) -timeout 45m ./e2e/vm -test.v -ginkgo.v --installed="$(INSTALLED)"
 
 .PHONY: test-e2e-container
 test-e2e-container:
@@ -250,7 +250,7 @@ test-e2e-container:
 
 .PHONY: test-e2e-vm
 test-e2e-vm:
-	go test -ldflags $(LDFLAGS) -timeout 30m ./e2e/vm -test.v -ginkgo.v --installed="$(INSTALLED)"
+	go test -ldflags $(LDFLAGS) -timeout 45m ./e2e/vm -test.v -ginkgo.v --installed="$(INSTALLED)"
 
 .PHONY: gen-code
 # Since different projects may have different versions of tool binaries,

--- a/e2e/vm/support_bundle_test.go
+++ b/e2e/vm/support_bundle_test.go
@@ -166,9 +166,18 @@ var testSupportBundle = func(o *option.Option) {
 			gomega.Expect(bundleExists).Should(gomega.BeTrue())
 		})
 		ginkgo.It("Should generate a support bundle with a default file excluded with --exclude flag by absolute path", func() {
-			absPath, err := filepath.Abs("../../_output/lima/data/finch/serial.log")
+			includeFilename := fmt.Sprintf("tempTestfile%s", time.Now().Format("20060102150405"))
+			//nolint:gosec // this file is only used for testing purposes and it does not include any user input
+			_, err := os.Create(includeFilename)
 			gomega.Expect(err).Should(gomega.BeNil())
-			command.Run(o, "support-bundle", "generate", "--exclude", absPath)
+			defer func() {
+				err := os.Remove(includeFilename)
+				gomega.Expect(err).Should(gomega.BeNil())
+			}()
+
+			absPath, err := filepath.Abs(includeFilename)
+			gomega.Expect(err).Should(gomega.BeNil())
+			command.Run(o, "support-bundle", "generate", "--include", includeFilename, "--exclude", absPath)
 			entries, err := os.ReadDir(".")
 			gomega.Expect(err).Should(gomega.BeNil())
 			bundleExists := false
@@ -184,7 +193,7 @@ var testSupportBundle = func(o *option.Option) {
 
 					zipBaseName := path.Base(dirEntry.Name())
 					zipPrefix := strings.TrimSuffix(zipBaseName, path.Ext(zipBaseName))
-					_, err = reader.Open(path.Join(zipPrefix, "logs", "serial.log"))
+					_, err = reader.Open(path.Join(zipPrefix, "misc", includeFilename))
 					gomega.Expect(err).ShouldNot(gomega.BeNil())
 
 					err = os.Remove(dirEntry.Name())
@@ -194,7 +203,16 @@ var testSupportBundle = func(o *option.Option) {
 			gomega.Expect(bundleExists).Should(gomega.BeTrue())
 		})
 		ginkgo.It("Should generate a support bundle with a default file excluded with --exclude flag by relative path", func() {
-			command.Run(o, "support-bundle", "generate", "--exclude", "../../_output/lima/data/finch/serial.log")
+			includeFilename := fmt.Sprintf("tempTestfile%s", time.Now().Format("20060102150405"))
+			//nolint:gosec // this file is only used for testing purposes and it does not include any user input
+			_, err := os.Create(includeFilename)
+			gomega.Expect(err).Should(gomega.BeNil())
+			defer func() {
+				err := os.Remove(includeFilename)
+				gomega.Expect(err).Should(gomega.BeNil())
+			}()
+
+			command.Run(o, "support-bundle", "generate", "--include", includeFilename, "--exclude", path.Join(".", includeFilename))
 			entries, err := os.ReadDir(".")
 			gomega.Expect(err).Should(gomega.BeNil())
 			bundleExists := false
@@ -210,7 +228,7 @@ var testSupportBundle = func(o *option.Option) {
 
 					zipBaseName := path.Base(dirEntry.Name())
 					zipPrefix := strings.TrimSuffix(zipBaseName, path.Ext(zipBaseName))
-					_, err = reader.Open(path.Join(zipPrefix, "logs", "serial.log"))
+					_, err = reader.Open(path.Join(zipPrefix, "misc", includeFilename))
 					gomega.Expect(err).ShouldNot(gomega.BeNil())
 
 					err = os.Remove(dirEntry.Name())


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*

e2e tests were failing for installers because the `support-bundle generate --exclude` tests made assumptions about the relative path of a log file based on its location in a locally built version of Finch, which did not generalize to an installed version of Finch. this remedies that issue.

*Testing done:*

```
make test-e2e-vm
```


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
