### PR TITLE
ci: Remove 10.15 runner for test

### DIFF
--- a/.github/workflows/release-homebrew.yaml
+++ b/.github/workflows/release-homebrew.yaml
@@ -154,7 +154,6 @@ jobs:
       matrix:
         os:
           [
-            [self-hosted, macos, amd64, 10.15, release],
             [self-hosted, macos, amd64, 11.7, release],
             [self-hosted, macos, amd64, 12.6, release],
             [self-hosted, macos, amd64, 13.0, release],

--- a/.github/workflows/release-installer.yaml
+++ b/.github/workflows/release-installer.yaml
@@ -127,7 +127,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [
-              [self-hosted, macos, amd64, 10.15, release], 
               [self-hosted, macos, amd64, 11.7, release], 
               [self-hosted, macos, amd64, 12.6, release], 
               [self-hosted, macos, amd64, 13.0, release]


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Remove OS 10.15 version test since breaking change not supported in 10.15
*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
