### PR TITLE
docs(README.md): fix macos installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Download a release package for your architecture from the [project's GitHub rele
 #### Installing Finch via [brew](https://brew.sh/)
 
 ```sh
-brew install --cask finch
+arch -arm64 brew install --cask finch
 ```
 
 Once the installation is complete, `finch vm init` is required once to set up the underlying system. This initial setup usually takes about a minute.


### PR DESCRIPTION
Issue #, if available:

If we are requiring M1 for finch, we should include the `homebrew` flags for rosetta, since finch fails to install
unless you include `arch -arm64` before `brew install --cask finch`.

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
