### PR TITLE
ci: Remove 10.15 support

### DIFF
--- a/.github/workflows/upload-build-to-s3.yaml
+++ b/.github/workflows/upload-build-to-s3.yaml
@@ -42,7 +42,7 @@ jobs:
           if-no-files-found: error
 
   macos-x86_64-build:
-    runs-on: ['self-hosted', 'macos', 'amd64', '10.15']
+    runs-on: ['self-hosted', 'macos', 'amd64', '11.7']
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Remove 10.15 runner support as 10.15 is deprecated officially

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
