### PR TITLE
test: add vm init and start benchmarking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,6 +252,13 @@ test-e2e-container:
 test-e2e-vm:
 	go test -ldflags $(LDFLAGS) -timeout 45m ./e2e/vm -test.v -ginkgo.v --installed="$(INSTALLED)"
 
+.PHONY: test-benchmark
+test-benchmark: test-benchmark-vm
+
+.PHONY: test-benchmark-vm
+test-benchmark-vm:
+	cd benchmark/vm && go test -ldflags $(LDFLAGS) -bench=. -benchmem --installed="$(INSTALLED)"
+
 .PHONY: gen-code
 # Since different projects may have different versions of tool binaries,
 # GOBIN is introduced to maintain a set of tool binaries dedicated to our project use.

--- a/benchmark/vm/vm_test.go
+++ b/benchmark/vm/vm_test.go
@@ -35,8 +35,8 @@ func BenchmarkVMInit(b *testing.B) {
 		b.StartTimer()
 		assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "init").Run()) //nolint:gosec // testing only
 		b.StopTimer()
-		assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "stop").Run())   //nolint:gosec // testing only
-		assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "remove").Run()) //nolint:gosec // testing only
+		assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "stop", "-f").Run())   //nolint:gosec // testing only
+		assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "remove", "-f").Run()) //nolint:gosec // testing only
 	}
 }
 
@@ -45,16 +45,16 @@ func BenchmarkVMStart(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "init").Run()) //nolint:gosec // testing only
-	assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "stop").Run()) //nolint:gosec // testing only
+	assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "init").Run())       //nolint:gosec // testing only
+	assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "stop", "-f").Run()) //nolint:gosec // testing only
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		b.StartTimer()
 		assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "start").Run()) //nolint:gosec // testing only
 		b.StopTimer()
-		assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "stop").Run()) //nolint:gosec // testing only
+		assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "stop", "-f").Run()) //nolint:gosec // testing only
 	}
-	assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "remove").Run()) //nolint:gosec // testing only
+	assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "remove", "-f").Run()) //nolint:gosec // testing only
 }
 
 func getSubject() (string, error) {

--- a/benchmark/vm/vm_test.go
+++ b/benchmark/vm/vm_test.go
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package vm runs tests related to the virtual machine.
+package vm
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	virtualMachineRootCmd = "vm"
+)
+
+// InstalledTestSubject is the test subject when Finch is installed.
+const InstalledTestSubject = "finch"
+
+// Installed indicates whether the tests are run against installed application.
+var Installed = flag.Bool("installed", false, "the flag to show whether the tests are run against installed application")
+
+func BenchmarkVMInit(b *testing.B) {
+	subject, err := getSubject()
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "init").Run()) //nolint:gosec // testing only
+		b.StopTimer()
+		assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "stop").Run())   //nolint:gosec // testing only
+		assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "remove").Run()) //nolint:gosec // testing only
+	}
+}
+
+func BenchmarkVMStart(b *testing.B) {
+	subject, err := getSubject()
+	if err != nil {
+		b.Fatal(err)
+	}
+	assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "init").Run()) //nolint:gosec // testing only
+	assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "stop").Run()) //nolint:gosec // testing only
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "start").Run()) //nolint:gosec // testing only
+		b.StopTimer()
+		assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "stop").Run()) //nolint:gosec // testing only
+	}
+	assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "remove").Run()) //nolint:gosec // testing only
+}
+
+func getSubject() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get the current working directory: %w", err)
+	}
+
+	subject := filepath.Join(wd, "../../_output/bin/finch")
+	if *Installed {
+		subject = InstalledTestSubject
+	}
+	return subject, nil
+}


### PR DESCRIPTION
*Description of changes:*

Basic vm init and start benchmarking without automation, mainly for barebone example.

More scenarios like finch pull/build can be added later on top of this.

It can be added to CI later by integrating this continuous benchmark Github [action](https://github.com/marketplace/actions/continuous-benchmark), which can report in every PR and also persistent diagram.

*Testing done:*
Ran `make test-benchmark` locally

```
➜  finch git:(main) ✗ INSTALLED=true make test-benchmark
cd benchmark/vm && go test -ldflags "-X github.com/runfinch/finch/pkg/version.Version=v0.4.1-47-g5f12ef3.modified -X github.com/runfinch/finch/pkg/version.GitCommit=5f12ef322d08cfaaf4a23eddd2859a8fb98f0ee1.m" -bench=. -benchmem --installed="true"
goos: darwin
goarch: arm64
pkg: github.com/runfinch/finch/benchmark/vm
BenchmarkVMInit-8              1        69722391084 ns/op           8920 B/op         58 allocs/op
BenchmarkVMStart-8             1        18059120667 ns/op           9024 B/op         54 allocs/op
PASS
ok      github.com/runfinch/finch/benchmark/vm  191.405s

```


- [ X ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
