### PR TITLE
test: add benchmarking for container run and image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,12 +252,13 @@ test-e2e-container:
 test-e2e-vm:
 	go test -ldflags $(LDFLAGS) -timeout 45m ./e2e/vm -test.v -ginkgo.v --installed="$(INSTALLED)"
 
-.PHONY: test-benchmark
-test-benchmark: test-benchmark-vm
-
 .PHONY: test-benchmark-vm
 test-benchmark-vm:
 	cd benchmark/vm && go test -ldflags $(LDFLAGS) -bench=. -benchmem --installed="$(INSTALLED)"
+
+.PHONY: test-benchmark-container
+test-benchmark-container:
+	cd benchmark/container && go test -ldflags $(LDFLAGS) -bench=. -benchmem --installed="$(INSTALLED)"
 
 .PHONY: gen-code
 # Since different projects may have different versions of tool binaries,

--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package benchmark runs benchmark tests of Finch.
+package benchmark
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// InstalledTestSubject is the test subject when Finch is installed.
+const InstalledTestSubject = "finch"
+
+// Installed indicates whether the tests are run against installed application.
+var Installed = flag.Bool("installed", false, "the flag to show whether the tests are run against installed application")
+
+// GetSubject returns the testing subject based on INSTALLED flag.
+func GetSubject() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get the current working directory: %w", err)
+	}
+
+	subject := filepath.Join(wd, "../../_output/bin/finch")
+	if *Installed {
+		subject = InstalledTestSubject
+	}
+	return subject, nil
+}

--- a/benchmark/container/container_test.go
+++ b/benchmark/container/container_test.go
@@ -1,0 +1,65 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package container runs benchmark tests related to container development of Finch.
+package container
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/runfinch/finch/benchmark"
+)
+
+const (
+	virtualMachineRootCmd = "vm"
+	alpineImage           = "public.ecr.aws/docker/library/alpine:latest"
+	testImageName         = "test:tag"
+	testContainerName     = "ctr-test"
+)
+
+func BenchmarkContainerRun(b *testing.B) {
+	subject, err := benchmark.GetSubject()
+	if err != nil {
+		b.Fatal(err)
+	}
+	assert.NoError(b, exec.Command(subject, "pull", alpineImage).Run()) //nolint:gosec // testing only
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		assert.NoError(b, exec.Command(subject, "run", "--name", testContainerName, alpineImage).Run()) //nolint:gosec // testing only
+		b.StopTimer()
+		assert.NoError(b, exec.Command(subject, "rm", "--force", testContainerName).Run()) //nolint:gosec // testing only
+	}
+	assert.NoError(b, exec.Command(subject, "rmi", "--force", alpineImage).Run()) //nolint:gosec // testing only
+}
+
+func BenchmarkImageBuild(b *testing.B) {
+	subject, err := benchmark.GetSubject()
+	if err != nil {
+		b.Fatal(err)
+	}
+	homeDir, err := os.UserHomeDir()
+	assert.NoError(b, err)
+	tempDir, err := os.MkdirTemp(homeDir, "finch-test")
+	assert.NoError(b, err)
+	dockerFilePath := filepath.Join(tempDir, "Dockerfile")
+	err = os.WriteFile(dockerFilePath, []byte(fmt.Sprintf(`FROM %s
+			CMD ["echo", "finch-test-dummy-output"]
+			`, alpineImage)), 0o644)
+	assert.NoError(b, err)
+	buildContext := filepath.Dir(dockerFilePath)
+	defer os.RemoveAll(buildContext) //nolint:errcheck // testing only
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		assert.NoError(b, exec.Command(subject, "build", "--tag", testImageName, buildContext).Run()) //nolint:gosec // testing only
+		b.StopTimer()
+		assert.NoError(b, exec.Command(subject, "rmi", "--force", testImageName).Run()) //nolint:gosec // testing only
+	}
+}

--- a/benchmark/vm/vm_test.go
+++ b/benchmark/vm/vm_test.go
@@ -1,32 +1,24 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package vm runs tests related to the virtual machine.
+// Package vm runs benchmark tests related to the virtual machine of Finch.
 package vm
 
 import (
-	"flag"
-	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/runfinch/finch/benchmark"
 )
 
 const (
 	virtualMachineRootCmd = "vm"
 )
 
-// InstalledTestSubject is the test subject when Finch is installed.
-const InstalledTestSubject = "finch"
-
-// Installed indicates whether the tests are run against installed application.
-var Installed = flag.Bool("installed", false, "the flag to show whether the tests are run against installed application")
-
 func BenchmarkVMInit(b *testing.B) {
-	subject, err := getSubject()
+	subject, err := benchmark.GetSubject()
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -41,7 +33,7 @@ func BenchmarkVMInit(b *testing.B) {
 }
 
 func BenchmarkVMStart(b *testing.B) {
-	subject, err := getSubject()
+	subject, err := benchmark.GetSubject()
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -55,17 +47,4 @@ func BenchmarkVMStart(b *testing.B) {
 		assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "stop", "-f").Run()) //nolint:gosec // testing only
 	}
 	assert.NoError(b, exec.Command(subject, virtualMachineRootCmd, "remove", "-f").Run()) //nolint:gosec // testing only
-}
-
-func getSubject() (string, error) {
-	wd, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("failed to get the current working directory: %w", err)
-	}
-
-	subject := filepath.Join(wd, "../../_output/bin/finch")
-	if *Installed {
-		subject = InstalledTestSubject
-	}
-	return subject, nil
 }


### PR DESCRIPTION
https://github.com/runfinch/finch/issues/345

*Description of changes:*
add benchmarking for container run and image build

*Testing done:*
Need to run in vm running state. There is no one vm-benchmark target yet, need to refactor vm lifecycle script to make it work.
```
➜  finch git:(main) ✗ make test-benchmark-container 
cd benchmark/container && go test -ldflags "-X github.com/runfinch/finch/pkg/version.Version=v0.5.0-10-gd485ae2 -X github.com/runfinch/finch/pkg/version.GitCommit=d485ae2f5a5f381c73afff748c6a32ab63bef586" -bench=. -benchmem --installed="false"
goos: darwin
goarch: arm64
pkg: github.com/runfinch/finch/benchmark/container
BenchmarkContainerRun-8                3         654182097 ns/op            6653 B/op         29 allocs/op
BenchmarkImageBuild-8                  1        4763285792 ns/op            6760 B/op         30 allocs/op
PASS
ok      github.com/runfinch/finch/benchmark/container   23.386s

```


- [ X ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
