### PR TITLE
test: increase vm init/start timeouts

### DIFF
--- a/e2e/vm/config_test.go
+++ b/e2e/vm/config_test.go
@@ -83,7 +83,7 @@ var testConfig = func(o *option.Option, installed bool) {
 				writeFile(limaConfigFilePath, origLimaCfg)
 
 				command.New(o, virtualMachineRootCmd, "stop").WithoutCheckingExitCode().WithTimeoutInSeconds(90).Run()
-				command.New(o, virtualMachineRootCmd, "start").WithTimeoutInSeconds(600).Run()
+				command.New(o, virtualMachineRootCmd, "start").WithTimeoutInSeconds(240).Run()
 			})
 		})
 
@@ -199,7 +199,7 @@ additional_directories:
 
 			limaConfigFilePath := resetVM(o, installed)
 			writeFile(finchConfigFilePath, []byte("memory: 4GiB\ncpus: 6\nvmType: vz\nrosetta: false"))
-			initCmdSession := command.New(o, virtualMachineRootCmd, "init").WithTimeoutInSeconds(240).Run()
+			initCmdSession := command.New(o, virtualMachineRootCmd, "init").WithTimeoutInSeconds(600).Run()
 			gomega.Expect(initCmdSession).Should(gexec.Exit(0))
 
 			gomega.Expect(limaConfigFilePath).Should(gomega.BeARegularFile())

--- a/e2e/vm/config_test.go
+++ b/e2e/vm/config_test.go
@@ -47,7 +47,7 @@ func updateAndApplyConfig(o *option.Option, configBytes []byte) *gexec.Session {
 	writeFile(finchConfigFilePath, configBytes)
 
 	command.New(o, virtualMachineRootCmd, "stop").WithoutCheckingExitCode().WithTimeoutInSeconds(90).Run()
-	return command.New(o, virtualMachineRootCmd, "start").WithoutCheckingExitCode().WithTimeoutInSeconds(120).Run()
+	return command.New(o, virtualMachineRootCmd, "start").WithoutCheckingExitCode().WithTimeoutInSeconds(240).Run()
 }
 
 // testConfig updates the finch config file and ensures that its settings are applied properly.
@@ -199,7 +199,7 @@ additional_directories:
 
 			limaConfigFilePath := resetVM(o, installed)
 			writeFile(finchConfigFilePath, []byte("memory: 4GiB\ncpus: 6\nvmType: vz\nrosetta: false"))
-			initCmdSession := command.New(o, virtualMachineRootCmd, "init").WithTimeoutInSeconds(120).Run()
+			initCmdSession := command.New(o, virtualMachineRootCmd, "init").WithTimeoutInSeconds(240).Run()
 			gomega.Expect(initCmdSession).Should(gexec.Exit(0))
 
 			gomega.Expect(limaConfigFilePath).Should(gomega.BeARegularFile())

--- a/e2e/vm/lifecycle_test.go
+++ b/e2e/vm/lifecycle_test.go
@@ -27,7 +27,7 @@ var testVMLifecycle = func(o *option.Option) {
 				command.Run(o, "images")
 				command.New(o, virtualMachineRootCmd, "stop", "--force").WithTimeoutInSeconds(90).Run()
 				command.RunWithoutSuccessfulExit(o, "images")
-				command.New(o, virtualMachineRootCmd, "start").WithTimeoutInSeconds(120).Run()
+				command.New(o, virtualMachineRootCmd, "start").WithTimeoutInSeconds(240).Run()
 			})
 
 			ginkgo.It("should be able to force remove the virtual machine", func() {
@@ -55,7 +55,7 @@ var testVMLifecycle = func(o *option.Option) {
 			})
 
 			ginkgo.It("should be able to start the virtual machine", func() {
-				command.New(o, virtualMachineRootCmd, "start").WithTimeoutInSeconds(120).Run()
+				command.New(o, virtualMachineRootCmd, "start").WithTimeoutInSeconds(240).Run()
 				command.Run(o, "images")
 				command.New(o, virtualMachineRootCmd, "stop").WithTimeoutInSeconds(90).Run()
 			})


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Been seeing a few test runs fail because of vm init timeouts. Trying to increase the timeout from 120 to 240 seconds to see if it helps.

*Testing done:*
- local testing


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
