### PR TITLE
test: Use common-tests release v0.6.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/onsi/gomega v1.27.5
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/sftp v1.13.5
-	github.com/runfinch/common-tests v0.6.4
+	github.com/runfinch/common-tests v0.6.5
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/afero v1.9.5
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -340,8 +340,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/runfinch/common-tests v0.6.4 h1:pcBQBUmjS09L25S4e5tUzJvRg3OinCmn3f1t++tQcng=
-github.com/runfinch/common-tests v0.6.4/go.mod h1:/lEtd8e5vQuK1NjVCeCPl09T/XVF7owDeQCAiOP6rtw=
+github.com/runfinch/common-tests v0.6.5 h1:n6wJ1eIVHCKt20jczMqmrNwwclVfGrSQ1vdjgiXyWx4=
+github.com/runfinch/common-tests v0.6.5/go.mod h1:/lEtd8e5vQuK1NjVCeCPl09T/XVF7owDeQCAiOP6rtw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=


### PR DESCRIPTION
Issue #, if available:
261
*Description of changes:*
Use common-test release v0.6.5 which addressed the compose down e2e failure due to volume in use error.
*Testing done:*
Yes


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
