### PR TITLE
fix: explicitly set permissions for socket_vmnet dependencies

### DIFF
--- a/pkg/dependency/vmnet/binaries.go
+++ b/pkg/dependency/vmnet/binaries.go
@@ -122,6 +122,14 @@ func (bin *binaries) Install() error {
 		return fmt.Errorf("error changing owner of files in directory %s, err: %w", installationPathBinDir, err)
 	}
 
+	// in most cases this should not be needed, as the permissions should be copied from the build artifacts,
+	// but the permissions can end up being wrong when Finch is built on a shell that has a restrictive umask.
+	chmodBinCmd := bin.cmdCreator.Create("sudo", "chmod", "755", bin.installationPathSocketVmnetExe())
+	_, err = chmodBinCmd.Output()
+	if err != nil {
+		return fmt.Errorf("error setting correct permissions for socket_vmnet binary, err: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/dependency/vmnet/sudoers_file.go
+++ b/pkg/dependency/vmnet/sudoers_file.go
@@ -75,6 +75,12 @@ func (s *sudoersFile) Install() error {
 		return fmt.Errorf("failed to write to the sudoers file: %w", err)
 	}
 
+	// explicitly set permissions to ensure that the file is readable by the user
+	_, err = s.execCmdCreator.Create("sudo", "chmod", "644", s.path()).Output()
+	if err != nil {
+		return fmt.Errorf("failed to set correct permissions for sudoers file: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Issue #, if available: https://github.com/runfinch/finch/issues/57

*Description of changes:*

Sets permissions explicitly for socket_vmnet dependencies, which will override a user's `umask` to ensure that Finch can use the files as needed.

*Testing done:*

```
$ umask 077
$ make
$ sudo rm -rf /opt/finch/bin/socket_vmnet*
$ sudo rm -rf /etc/sudoers.d/finch-lima
$ ./_output/bin/finch vm init
```

unit testing


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
