### PR TITLE
ci: Updated runner labels, removed minor os version

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -46,7 +46,13 @@ jobs:
   e2e-tests:
     strategy:
       matrix:
-        os: [[self-hosted, macos, amd64, 13], [self-hosted, macos, amd64, 12.6], [self-hosted, macos, arm64, 13], [self-hosted, macos, arm64, 12.6]]
+        os: 
+          [
+            [self-hosted, macos, amd64, 13, test], 
+            [self-hosted, macos, amd64, 12, test], 
+            [self-hosted, macos, arm64, 13, test], 
+            [self-hosted, macos, arm64, 12, test]
+          ]
     runs-on: ${{ matrix.os }} 
     steps:
       - run: echo "Skipping CI for docs & contrib files"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [[self-hosted, macos, amd64, 13], [self-hosted, macos, amd64, 12.6], [self-hosted, macos, arm64, 13], [self-hosted, macos, arm64, 12.6]]
+        os: 
+          [
+            [self-hosted, macos, amd64, 13, test], 
+            [self-hosted, macos, amd64, 12, test], 
+            [self-hosted, macos, arm64, 13, test], 
+            [self-hosted, macos, arm64, 12, test]
+          ]
     runs-on: ${{ matrix.os }} 
     steps:
       - uses: actions/checkout@v3
@@ -108,7 +114,6 @@ jobs:
       - name: Build project
         run: |
           export PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH"
-          which libtool
           make
       - run: make test-e2e
   mdlint:

--- a/.github/workflows/release-homebrew.yaml
+++ b/.github/workflows/release-homebrew.yaml
@@ -42,9 +42,9 @@ jobs:
       matrix:
         os:
           [
-            [self-hosted, macos, arm64, 11.7, release],
-            [self-hosted, macos, arm64, 12.6, release],
-            [self-hosted, macos, arm64, 13.0, release],
+            [self-hosted, macos, arm64, 11, release],
+            [self-hosted, macos, arm64, 12, release],
+            [self-hosted, macos, arm64, 13, release],
           ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -154,9 +154,9 @@ jobs:
       matrix:
         os:
           [
-            [self-hosted, macos, amd64, 11.7, release],
-            [self-hosted, macos, amd64, 12.6, release],
-            [self-hosted, macos, amd64, 13.0, release],
+            [self-hosted, macos, amd64, 11, release],
+            [self-hosted, macos, amd64, 12, release],
+            [self-hosted, macos, amd64, 13, release],
           ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60

--- a/.github/workflows/release-installer.yaml
+++ b/.github/workflows/release-installer.yaml
@@ -30,9 +30,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [
-              [self-hosted, macos, arm64, 11.7, release], 
-              [self-hosted, macos, arm64, 12.6, release], 
-              [self-hosted, macos, arm64, 13.0, release]
+              [self-hosted, macos, arm64, 11, release], 
+              [self-hosted, macos, arm64, 12, release], 
+              [self-hosted, macos, arm64, 13, release]
             ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -127,9 +127,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [
-              [self-hosted, macos, amd64, 11.7, release], 
-              [self-hosted, macos, amd64, 12.6, release], 
-              [self-hosted, macos, amd64, 13.0, release]
+              [self-hosted, macos, amd64, 11, release], 
+              [self-hosted, macos, amd64, 12, release], 
+              [self-hosted, macos, amd64, 13, release]
             ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60

--- a/.github/workflows/upload-build-to-s3.yaml
+++ b/.github/workflows/upload-build-to-s3.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   macos-aarch64-build:
-    runs-on: ['self-hosted', 'macos', 'arm64', '11.7']
+    runs-on: [self-hosted, macos, arm64, 11, release]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
@@ -42,7 +42,7 @@ jobs:
           if-no-files-found: error
 
   macos-x86_64-build:
-    runs-on: ['self-hosted', 'macos', 'amd64', '11.7']
+    runs-on: [self-hosted, macos, amd64, 11.7, release]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Updated runner labels to be split into 2 categories: "release" and "test"
- Updated runner labels to only reference the major version of macOS

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
