### PR TITLE
refactor: minor optimization to not fetch qemu packages if they are already installed

### DIFF
--- a/pkg/config/lima_config_applier.go
+++ b/pkg/config/lima_config_applier.go
@@ -154,7 +154,18 @@ func toggleUserModeEmulationInstallationScript(limaCfg *limayaml.LimaYAML, enabl
 			Mode: "system",
 			Script: fmt.Sprintf(`%s
 #!/bin/bash
-dnf install -y --setopt=install_weak_deps=False qemu-user-static-aarch64 qemu-user-static-arm qemu-user-static-x86
+qemu_pkgs=""
+if [ ! -f /usr/bin/qemu-aarch64-static ]; then
+  qemu_pkgs="$qemu_pkgs qemu-user-static-aarch64"
+elif [ ! -f /usr/bin/qemu-aarch64-static ]; then
+  qemu_pkgs="$qemu_pkgs qemu-user-static-arm"
+elif [ ! -f  /usr/bin/qemu-aarch64-static ]; then
+  qemu_pkgs="$qemu_pkgs qemu-user-static-x86"
+fi
+
+if [[ $qemu_pkgs ]]; then
+  dnf install -y --setopt=install_weak_deps=False ${qemu_pkgs}
+fi
 `, userModeEmulationProvisioningScriptHeader),
 		})
 	} else if hasScript && !enabled {

--- a/pkg/config/lima_config_applier_test.go
+++ b/pkg/config/lima_config_applier_test.go
@@ -200,7 +200,18 @@ provision:
   script: |
     # cross-arch tools
     #!/bin/bash
-    dnf install -y --setopt=install_weak_deps=False qemu-user-static-aarch64 qemu-user-static-arm qemu-user-static-x86
+    qemu_pkgs=""
+    if [ ! -f /usr/bin/qemu-aarch64-static ]; then
+      qemu_pkgs="$qemu_pkgs qemu-user-static-aarch64"
+    elif [ ! -f /usr/bin/qemu-aarch64-static ]; then
+      qemu_pkgs="$qemu_pkgs qemu-user-static-arm"
+    elif [ ! -f  /usr/bin/qemu-aarch64-static ]; then
+      qemu_pkgs="$qemu_pkgs qemu-user-static-x86"
+    fi
+
+    if [[ $qemu_pkgs ]]; then
+      dnf install -y --setopt=install_weak_deps=False ${qemu_pkgs}
+    fi
 `), 0o600)
 				require.NoError(t, err)
 			},

--- a/pkg/config/lima_config_applier_test.go
+++ b/pkg/config/lima_config_applier_test.go
@@ -70,7 +70,18 @@ func TestDiskLimaConfigApplier_Apply(t *testing.T) {
 				require.Equal(t, "system", limaCfg.Provision[0].Mode)
 				require.Equal(t, `# cross-arch tools
 #!/bin/bash
-dnf install -y --setopt=install_weak_deps=False qemu-user-static-aarch64 qemu-user-static-arm qemu-user-static-x86
+qemu_pkgs=""
+if [ ! -f /usr/bin/qemu-aarch64-static ]; then
+  qemu_pkgs="$qemu_pkgs qemu-user-static-aarch64"
+elif [ ! -f /usr/bin/qemu-aarch64-static ]; then
+  qemu_pkgs="$qemu_pkgs qemu-user-static-arm"
+elif [ ! -f  /usr/bin/qemu-aarch64-static ]; then
+  qemu_pkgs="$qemu_pkgs qemu-user-static-x86"
+fi
+
+if [[ $qemu_pkgs ]]; then
+  dnf install -y --setopt=install_weak_deps=False ${qemu_pkgs}
+fi
 `, limaCfg.Provision[0].Script)
 			},
 			want: nil,
@@ -100,7 +111,18 @@ provision:
   script: |
     # cross-arch tools
     #!/bin/bash
-    dnf install -y --setopt=install_weak_deps=False qemu-user-static-aarch64 qemu-user-static-arm qemu-user-static-x86
+    qemu_pkgs=""
+    if [ ! -f /usr/bin/qemu-aarch64-static ]; then
+      qemu_pkgs="$qemu_pkgs qemu-user-static-aarch64"
+    elif [ ! -f /usr/bin/qemu-aarch64-static ]; then
+      qemu_pkgs="$qemu_pkgs qemu-user-static-arm"
+    elif [ ! -f  /usr/bin/qemu-aarch64-static ]; then
+      qemu_pkgs="$qemu_pkgs qemu-user-static-x86"
+    fi
+
+    if [[ $qemu_pkgs ]]; then
+      dnf install -y --setopt=install_weak_deps=False ${qemu_pkgs}
+    fi
 `), 0o600)
 				require.NoError(t, err)
 				cmd.EXPECT().Output().Return([]byte("13.0.0"), nil)
@@ -169,7 +191,18 @@ rosetta:
 				require.Equal(t, "system", limaCfg.Provision[0].Mode)
 				require.Equal(t, `# cross-arch tools
 #!/bin/bash
-dnf install -y --setopt=install_weak_deps=False qemu-user-static-aarch64 qemu-user-static-arm qemu-user-static-x86
+qemu_pkgs=""
+if [ ! -f /usr/bin/qemu-aarch64-static ]; then
+  qemu_pkgs="$qemu_pkgs qemu-user-static-aarch64"
+elif [ ! -f /usr/bin/qemu-aarch64-static ]; then
+  qemu_pkgs="$qemu_pkgs qemu-user-static-arm"
+elif [ ! -f  /usr/bin/qemu-aarch64-static ]; then
+  qemu_pkgs="$qemu_pkgs qemu-user-static-x86"
+fi
+
+if [[ $qemu_pkgs ]]; then
+  dnf install -y --setopt=install_weak_deps=False ${qemu_pkgs}
+fi
 `, limaCfg.Provision[0].Script)
 			},
 			want: nil,
@@ -229,7 +262,18 @@ provision:
 				require.Equal(t, "system", limaCfg.Provision[0].Mode)
 				require.Equal(t, `# cross-arch tools
 #!/bin/bash
-dnf install -y --setopt=install_weak_deps=False qemu-user-static-aarch64 qemu-user-static-arm qemu-user-static-x86
+qemu_pkgs=""
+if [ ! -f /usr/bin/qemu-aarch64-static ]; then
+  qemu_pkgs="$qemu_pkgs qemu-user-static-aarch64"
+elif [ ! -f /usr/bin/qemu-aarch64-static ]; then
+  qemu_pkgs="$qemu_pkgs qemu-user-static-arm"
+elif [ ! -f  /usr/bin/qemu-aarch64-static ]; then
+  qemu_pkgs="$qemu_pkgs qemu-user-static-x86"
+fi
+
+if [[ $qemu_pkgs ]]; then
+  dnf install -y --setopt=install_weak_deps=False ${qemu_pkgs}
+fi
 `, limaCfg.Provision[0].Script)
 			},
 			want: nil,
@@ -269,7 +313,18 @@ dnf install -y --setopt=install_weak_deps=False qemu-user-static-aarch64 qemu-us
 				require.Equal(t, "system", limaCfg.Provision[0].Mode)
 				require.Equal(t, `# cross-arch tools
 #!/bin/bash
-dnf install -y --setopt=install_weak_deps=False qemu-user-static-aarch64 qemu-user-static-arm qemu-user-static-x86
+qemu_pkgs=""
+if [ ! -f /usr/bin/qemu-aarch64-static ]; then
+  qemu_pkgs="$qemu_pkgs qemu-user-static-aarch64"
+elif [ ! -f /usr/bin/qemu-aarch64-static ]; then
+  qemu_pkgs="$qemu_pkgs qemu-user-static-arm"
+elif [ ! -f  /usr/bin/qemu-aarch64-static ]; then
+  qemu_pkgs="$qemu_pkgs qemu-user-static-x86"
+fi
+
+if [[ $qemu_pkgs ]]; then
+  dnf install -y --setopt=install_weak_deps=False ${qemu_pkgs}
+fi
 `, limaCfg.Provision[0].Script)
 			},
 			want: nil,
@@ -339,7 +394,18 @@ dnf install -y --setopt=install_weak_deps=False qemu-user-static-aarch64 qemu-us
 				require.Equal(t, "system", limaCfg.Provision[0].Mode)
 				require.Equal(t, `# cross-arch tools
 #!/bin/bash
-dnf install -y --setopt=install_weak_deps=False qemu-user-static-aarch64 qemu-user-static-arm qemu-user-static-x86
+qemu_pkgs=""
+if [ ! -f /usr/bin/qemu-aarch64-static ]; then
+  qemu_pkgs="$qemu_pkgs qemu-user-static-aarch64"
+elif [ ! -f /usr/bin/qemu-aarch64-static ]; then
+  qemu_pkgs="$qemu_pkgs qemu-user-static-arm"
+elif [ ! -f  /usr/bin/qemu-aarch64-static ]; then
+  qemu_pkgs="$qemu_pkgs qemu-user-static-x86"
+fi
+
+if [[ $qemu_pkgs ]]; then
+  dnf install -y --setopt=install_weak_deps=False ${qemu_pkgs}
+fi
 `, limaCfg.Provision[0].Script)
 			},
 			want: nil,


### PR DESCRIPTION
Issue #, if available: N/A

*Description of changes:*
  - Check if executables are already present before trying to install packages. Saves a potentially useless and costly dnf cache refresh.

*Testing done:*
  - local testing


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
