### PR TITLE
ci: explicitly set shell when running commands

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,11 +111,14 @@ jobs:
       - name: Install Rosetta 2
         run: echo "A" | softwareupdate --install-rosetta || true 
       - run: brew install go lz4 automake autoconf libtool 
+        shell: zsh
       - name: Build project
         run: |
           export PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH"
           make
+        shell: zsh
       - run: make test-e2e
+        shell: zsh
   mdlint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
 - I noticed that the CI failures that we've been seeing all happen on M1 macOS and are related to brew not being in the path. This might be happening because brew is installed/configured in a non-default path, and the PATH setup that does happen as part of brew's install all happens in ZSH specific files (`~/.zprofile`/`~/.zshrc`), and the scripts are all being executed with bash if you check the failed CI run logs

*Testing done:*
 - local testing
   - this is a little hard to test locally, so we're just going to have to see if the runs work on this PR



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
