### PR TITLE
ci: Rename action and set up nightly build

### DIFF
--- a/.github/workflows/build-and-test-pkg.yaml
+++ b/.github/workflows/build-and-test-pkg.yaml
@@ -1,7 +1,10 @@
 name: Build, test and upload .pkg to S3
 
+# The scheduler runs at 9 am UTC every day.
 on:
   workflow_dispatch:
+  shcedule:
+    - cron: '0 9 * * *'
 env:
   GO111MODULE: on
 

--- a/.github/workflows/build-and-test-pkg.yaml
+++ b/.github/workflows/build-and-test-pkg.yaml
@@ -1,4 +1,4 @@
-name: Upload build to s3
+name: Build, test and upload .pkg to S3
 
 on:
   workflow_dispatch:

--- a/installer-builder/templates/entitlements.plist
+++ b/installer-builder/templates/entitlements.plist
@@ -15,8 +15,8 @@
     <key>com.apple.security.virtualization</key>
     <true/>
     <key>com.apple.security.network.server</key>
-	<true/>
-	<key>com.apple.security.network.client</key>
-	<true/>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
*Description of changes:*
Rename the action.
Set up the installer build and test every day at 9 am UTC (2 am PDT) to validate latest main branch.

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
