### PR TITLE
ci: Replace all GITHUB_REF_NAME with github.ref_name

### DIFF
--- a/.github/workflows/build-and-test-pkg.yaml
+++ b/.github/workflows/build-and-test-pkg.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: generate pkg
         run: |
-          ./installer-builder/tools/release-installer.sh aarch64 ${GITHUB_REF_NAME} ${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }} ${{ secrets.EXECUTABLE_BUCKET }} ${{ secrets.PKG_BUCKET }} ${{ secrets.NOTARIZATION_ACCOUNT }} ${{ secrets.NOTARIZATION_CREDENTIAL }}
+          ./installer-builder/tools/release-installer.sh aarch64 ${{ github.ref_name }} ${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }} ${{ secrets.EXECUTABLE_BUCKET }} ${{ secrets.PKG_BUCKET }} ${{ secrets.NOTARIZATION_ACCOUNT }} ${{ secrets.NOTARIZATION_CREDENTIAL }}
         shell: zsh {0}
 
   macos-x86-64-pkg-build:
@@ -80,7 +80,7 @@ jobs:
 
       - name: generate pkg
         run: |
-          ./installer-builder/tools/release-installer.sh x86_64 ${GITHUB_REF_NAME} ${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }} ${{ secrets.EXECUTABLE_BUCKET }} ${{ secrets.PKG_BUCKET }} ${{ secrets.NOTARIZATION_ACCOUNT }} ${{ secrets.NOTARIZATION_CREDENTIAL }}
+          ./installer-builder/tools/release-installer.sh x86_64 ${{ github.ref_name }} ${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }} ${{ secrets.EXECUTABLE_BUCKET }} ${{ secrets.PKG_BUCKET }} ${{ secrets.NOTARIZATION_ACCOUNT }} ${{ secrets.NOTARIZATION_CREDENTIAL }}
         shell: zsh {0}
 
   macos-aarch64-pkg-test:
@@ -129,10 +129,10 @@ jobs:
           aws-region: ${{ secrets.REGION }}
       - name: Download from S3
         run: |
-          aws s3 cp s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-${GITHUB_REF_NAME}-aarch64.pkg Finch-${GITHUB_REF_NAME}-aarch64.pkg
+          aws s3 cp s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-${{ github.ref_name }}-aarch64.pkg Finch-${{ github.ref_name }}-aarch64.pkg
         shell: zsh {0}
       - name: Silently install
-        run: sudo installer -pkg Finch-${GITHUB_REF_NAME}-aarch64.pkg -target /
+        run: sudo installer -pkg Finch-${{ github.ref_name }}-aarch64.pkg -target /
       - name: Install Rosetta 2
         run: echo "A" | softwareupdate --install-rosetta || true 
       - name: Build project
@@ -178,13 +178,13 @@ jobs:
           # Need to reinstall because there were errors on arm64 11.7 and arm64 12.6 hosts after running multiple instances tests,
           # that caused the VM initialization failure in the e2e test. 
           # Example workflow run https://github.com/runfinch/finch/actions/runs/4367457552/jobs/7638794529
-          sudo installer -pkg Finch-${GITHUB_REF_NAME}-aarch64.pkg -target /
+          sudo installer -pkg Finch-${{ github.ref_name }}-aarch64.pkg -target /
       - name: Run e2e tests
         run: INSTALLED=true make test-e2e
       - name: Silently uninstall
         run: echo 'y' | sudo bash /Applications/Finch/uninstall.sh
       - name: Delete installer
-        run: rm -rf Finch-${GITHUB_REF_NAME}-aarch64.pkg
+        run: rm -rf Finch-${{ github.ref_name }}-aarch64.pkg
 
   macos-x86-64-pkg-test:
     strategy:
@@ -232,11 +232,11 @@ jobs:
           aws-region: ${{ secrets.REGION }}
       - name: Download from S3
         run: |
-          aws s3 cp s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-${GITHUB_REF_NAME}-x86_64.pkg Finch-${GITHUB_REF_NAME}-x86_64.pkg
+          aws s3 cp s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-${{ github.ref_name }}-x86_64.pkg Finch-${{ github.ref_name }}-x86_64.pkg
         shell: zsh {0}
       - name: Silently install
         run: |
-          sudo installer -pkg Finch-${GITHUB_REF_NAME}-x86_64.pkg -target /
+          sudo installer -pkg Finch-${{ github.ref_name }}-x86_64.pkg -target /
       - name: Install Rosetta 2
         run: echo "A" | softwareupdate --install-rosetta || true 
       - name: Build project
@@ -279,10 +279,10 @@ jobs:
         run: |
           sudo rm -rf ./_output
           echo 'y' | sudo bash /Applications/Finch/uninstall.sh
-          sudo installer -pkg Finch-${GITHUB_REF_NAME}-x86_64.pkg -target /
+          sudo installer -pkg Finch-${{ github.ref_name }}-x86_64.pkg -target /
       - name: Run e2e tests
         run: INSTALLED=true make test-e2e
       - name: Silently uninstall
         run: echo 'y' | sudo bash /Applications/Finch/uninstall.sh
       - name: Delete installer
-        run: rm -rf Finch-${GITHUB_REF_NAME}-x86_64.pkg
+        run: rm -rf Finch-${{ github.ref_name }}-x86_64.pkg

--- a/.github/workflows/upload-installer-to-release.yaml
+++ b/.github/workflows/upload-installer-to-release.yaml
@@ -18,8 +18,8 @@ jobs:
           aws-region: ${{ secrets.REGION }}
       - name: Download installers
         run: |
-          aws s3 cp s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-${GITHUB_REF_NAME}-aarch64.pkg Finch-${GITHUB_REF_NAME}-aarch64.pkg
-          aws s3 cp s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-${GITHUB_REF_NAME}-x86_64.pkg Finch-${GITHUB_REF_NAME}-x86_64.pkg
+          aws s3 cp s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-${{ github.ref_name }}-aarch64.pkg Finch-${{ github.ref_name }}-aarch64.pkg
+          aws s3 cp s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-${{ github.ref_name }}-x86_64.pkg Finch-${{ github.ref_name }}-x86_64.pkg
         shell: zsh {0}
       - name: Upload installers to release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
*Description of changes:*
Currently our github actions are mixing up the usage of ${{ github.ref_name }} and GITHUB_REF_NAME.
This PR is to make it consistent to ${{ github.ref_name }} because the ${{ github.ref_name }} is a github context and GITHUB_REF_NAME is a github variable.
It is Ok for existing workflows although they are mixed, but we are going to have a new workflow which invokes multiple existing workflows in a sequential way, and have to make them run on the latest tag. The new workflow's trigger point is that when the main branch has a new tag (version) create, and it needs to execute other workflows with the latest tag instead of the main branch to generate a new release for that tag.
Due to the above reason, making the mixed usage consistent to github context can make it easier to set up with only one step.

*Testing done:*
Have run related actions and they can read ${{ github.ref_name }} with no issue.


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
