### PR TITLE
ci: Add release automation action

### DIFF
--- a/.github/workflows/build-and-test-pkg.yaml
+++ b/.github/workflows/build-and-test-pkg.yaml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
           persist-credentials: false
           submodules: true
@@ -55,6 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
           persist-credentials: false
           submodules: true

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -24,10 +24,10 @@ jobs:
         with:
           GITHUB_REF_NAME: ${{ steps.latest-tag.outputs.tag }}
 
-      - name: Upload .pkg installer to the latest release
-        uses: ./.github/workflows/upload-installer-to-release.yaml
-        with:
-          GITHUB_REF_NAME: ${{ steps.latest-tag.outputs.tag }}
+      #- name: Upload .pkg installer to the latest release
+      #  uses: ./.github/workflows/upload-installer-to-release.yaml
+      #  with:
+      #    GITHUB_REF_NAME: ${{ steps.latest-tag.outputs.tag }}
 
-      - name: Homebrew release tests and cut PR
-        uses: ./.github/workflows/release-homebrew.yaml
+      #- name: Homebrew release tests and cut PR
+      #  uses: ./.github/workflows/release-homebrew.yaml

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -1,11 +1,9 @@
 name: Release Finch latest version
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
+  create:
     tags:
-      - '*'
+      - 'v*'
 
 jobs:
   release-finch-latest:

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -1,0 +1,33 @@
+name: Release Finch latest version
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+
+jobs:
+  release-finch-latest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+            fetch-depth: 0
+
+      - name: Get Finch latest tag
+        id: latest-tag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+
+      - name: Build and test .pkg
+        uses: ./.github/workflows/build-and-test-pkg.yaml
+        with:
+          GITHUB_REF_NAME: ${{ steps.latest-tag.outputs.tag }}
+
+      - name: Upload .pkg installer to the latest release
+        uses: ./.github/workflows/upload-installer-to-release.yaml
+        with:
+          GITHUB_REF_NAME: ${{ steps.latest-tag.outputs.tag }}
+
+      - name: Homebrew release tests and cut PR
+        uses: ./.github/workflows/release-homebrew.yaml

--- a/installer-builder/tools/release-installer.sh
+++ b/installer-builder/tools/release-installer.sh
@@ -11,7 +11,7 @@ NOTARIZATION_ACCOUNT=${6}
 NOTARIZATION_CREDENTIAL=${7}
 
 releaseInstaller() {
-    echo "Finch Installer Generation Started..."
+    echo "Finch-$FINCH_VERSION-$ARCH.pkg Installer Generation Started..."
     echo "[1/12] Clean Old Signing Artifact in S3 Buckets"
     cleanUpSigningArtifactInS3Buckets $ARCH $EXECUTABLE_BUCKET $PKG_BUCKET
     rm -rf "./installer-builder/output"
@@ -51,7 +51,7 @@ releaseInstaller() {
     echo "[12/12] Upload installer to S3 buckets"
     uploadNotarizedPkg $ARCH $FINCH_VERSION $INSTALLER_PRIVATE_BUCKET_NAME
 
-    echo "Finch .pkg Installer Generation Completed!"
+    echo "Finch-$FINCH_VERSION-$ARCH.pkg Installer Generation Completed!"
 }
 
 releaseInstaller


### PR DESCRIPTION
*Description of changes:*
This PR added a new passive action subscribe to main branch new tag creation.
New tag creation means Finch has a new release, the new workflow will trigger build pkg, upload pkg and homebrew release on the latest tag.

*Testing done:*
This is a new action and has cross branch/tag involved, needs some experiment  on main branch after check in.

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
