### PR TITLE
fix: Stop lima process in postinstall and uninstall

### DIFF
--- a/installer-builder/darwin/Resources/uninstall.sh
+++ b/installer-builder/darwin/Resources/uninstall.sh
@@ -15,6 +15,10 @@ while true; do
 done
 
 echo "Application uninstalling process started"
+sudo pkill '^socket_vmnet'
+sudo pkill '^qemu-system-'
+sudo pkill '^limactl'
+
 if [ "$$(readlink "/usr/local/bin/finch")" = "/Applications/Finch/bin/finch" ]; then sudo rm /usr/local/bin/finch; fi
 
 echo "[1/3] [DONE] Successfully deleted shortcut links"
@@ -36,9 +40,6 @@ then
 else
   echo "[3/3] [ERROR] Could not delete application" >&2
 fi
-
-sudo pkill '^socket_vmnet'
-sudo pkill '^qemu-system-'
 
 echo "Application uninstall process finished"
 exit 0

--- a/installer-builder/darwin/scripts/postinstall
+++ b/installer-builder/darwin/scripts/postinstall
@@ -2,6 +2,10 @@
 
 echo "Post installation process started..."
 
+sudo pkill '^socket_vmnet'
+sudo pkill '^qemu-system-'
+sudo pkill '^limactl'
+
 #change permissions in home directory
 echo "Change permissions for product home directory."
 cd /Applications/Finch
@@ -11,8 +15,6 @@ chmod -R 755 /Applications/Finch/dependencies/lima-socket_vmnet/opt/finch
 
 #clean old artifacts
 sudo ln -sf /Applications/Finch/bin/finch /usr/local/bin/finch
-sudo pkill '^socket_vmnet'
-sudo pkill '^qemu-system-'
 sudo rm -rf "/Applications/Finch/lima/data/finch/"
 sudo rm -rf "/Applications/Finch/lima/data/_config/override.yaml"
 sudo rm -rf "/Applications/Finch/lima/data/_config/user"


### PR DESCRIPTION
*Description of changes:*
Unstopped lima process can prevent new installation and finch vm init successfully.
Add kill limactl to post-installation and uninstall script to fix the issue.

*Testing done:*
Tested locally.

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
