### PR TITLE
ci: Preserve link when copy from build

### DIFF
--- a/installer-builder/tools/release-installer.sh
+++ b/installer-builder/tools/release-installer.sh
@@ -19,7 +19,7 @@ releaseInstaller() {
 
     echo "[2/12] Get Original Finch Build"
     mkdir -pv "./installer-builder/output/origin"
-    cp -r ./_output "./installer-builder/output/origin"
+    cp -rp ./_output "./installer-builder/output/origin"
 
     echo "[3/12] Extract Executables from Finch Build"
     bash ./installer-builder/tools/extract-executables.sh $ARCH


### PR DESCRIPTION
*Description of changes:*
Add 'p' flag to preserve original symbolic link when copying the build artifact

*Testing done:*
Tested locally


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
