### PR TITLE
chore: Update Go linter to v1.53.3 and resolve errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,9 +54,9 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Pin the version in case all the builds start to fail at the same time.
-          # There may not be an automatic way (e.g., dependabot) to update a specific parameter of a Github Action,
+          # There may not be an automatic way (e.g., dependabot) to update a specific parameter of a GitHub Action,
           # so we will just update it manually whenever it makes sense (e.g., a feature that we want is added).
-          version: v1.51.2
+          version: v1.53.3
           args: --fix=false --timeout=5m
   go-mod-tidy-check:
     runs-on: ubuntu-latest

--- a/cmd/finch/support_bundle.go
+++ b/cmd/finch/support_bundle.go
@@ -60,7 +60,7 @@ func newGenerateSupportBundleAction(
 	}
 }
 
-func (gsa *generateSupportBundleAction) runAdapter(cmd *cobra.Command, args []string) error {
+func (gsa *generateSupportBundleAction) runAdapter(cmd *cobra.Command, _ []string) error {
 	additionalFiles, err := cmd.Flags().GetStringArray("include")
 	if err != nil {
 		return err

--- a/cmd/finch/version.go
+++ b/cmd/finch/version.go
@@ -68,7 +68,7 @@ func newVersionAction(creator command.LimaCmdCreator, logger flog.Logger, stdOut
 	return &versionAction{creator: creator, logger: logger, stdOut: stdOut}
 }
 
-func (va *versionAction) runAdapter(cmd *cobra.Command, args []string) error {
+func (va *versionAction) runAdapter(_ *cobra.Command, _ []string) error {
 	return va.run()
 }
 

--- a/cmd/finch/virtual_machine.go
+++ b/cmd/finch/virtual_machine.go
@@ -71,7 +71,7 @@ func newPostVMStartInitAction(
 	return &postVMStartInitAction{creator: creator, logger: logger, fs: fs, privateKeyPath: privateKeyPath, nca: nca}
 }
 
-func (p *postVMStartInitAction) runAdapter(cmd *cobra.Command, args []string) error {
+func (p *postVMStartInitAction) runAdapter(_ *cobra.Command, _ []string) error {
 	return p.run()
 }
 

--- a/cmd/finch/virtual_machine_init.go
+++ b/cmd/finch/virtual_machine_init.go
@@ -66,7 +66,7 @@ func newInitVMAction(
 	}
 }
 
-func (iva *initVMAction) runAdapter(cmd *cobra.Command, args []string) error {
+func (iva *initVMAction) runAdapter(_ *cobra.Command, _ []string) error {
 	return iva.run()
 }
 

--- a/cmd/finch/virtual_machine_remove.go
+++ b/cmd/finch/virtual_machine_remove.go
@@ -35,7 +35,7 @@ func newRemoveVMAction(creator command.LimaCmdCreator, logger flog.Logger) *remo
 	return &removeVMAction{creator: creator, logger: logger}
 }
 
-func (rva *removeVMAction) runAdapter(cmd *cobra.Command, args []string) error {
+func (rva *removeVMAction) runAdapter(cmd *cobra.Command, _ []string) error {
 	force, err := cmd.Flags().GetBool("force")
 	if err != nil {
 		return err

--- a/cmd/finch/virtual_machine_start.go
+++ b/cmd/finch/virtual_machine_start.go
@@ -60,7 +60,7 @@ func newStartVMAction(
 	}
 }
 
-func (sva *startVMAction) runAdapter(cmd *cobra.Command, args []string) error {
+func (sva *startVMAction) runAdapter(_ *cobra.Command, _ []string) error {
 	return sva.run()
 }
 

--- a/cmd/finch/virtual_machine_status.go
+++ b/cmd/finch/virtual_machine_status.go
@@ -34,7 +34,7 @@ func newStatusVMAction(creator command.LimaCmdCreator, logger flog.Logger, stdou
 	return &statusVMAction{creator: creator, logger: logger, stdout: stdout}
 }
 
-func (sva *statusVMAction) runAdapter(cmd *cobra.Command, args []string) error {
+func (sva *statusVMAction) runAdapter(_ *cobra.Command, _ []string) error {
 	return sva.run()
 }
 

--- a/cmd/finch/virtual_machine_stop.go
+++ b/cmd/finch/virtual_machine_stop.go
@@ -34,7 +34,7 @@ func newStopVMAction(creator command.LimaCmdCreator, logger flog.Logger) *stopVM
 	return &stopVMAction{creator: creator, logger: logger}
 }
 
-func (sva *stopVMAction) runAdapter(cmd *cobra.Command, args []string) error {
+func (sva *stopVMAction) runAdapter(cmd *cobra.Command, _ []string) error {
 	force, err := cmd.Flags().GetBool("force")
 	if err != nil {
 		return err


### PR DESCRIPTION
Issue #, if available:
N/A

*Description of changes:*
Updates golangci-lint in CI to v1.53.3 release and resolves linting errors for unused arguments.

*Testing done:*
```make lint```

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
