### PR TITLE
fix: Restart buildkit after containerd when provisioning

### DIFF
--- a/finch.yaml
+++ b/finch.yaml
@@ -176,7 +176,9 @@ provision:
     mkdir -p  ~/.local/share/cni
     sudo mount --bind /mnt/lima-finch/cni  ~/.local/share/cni
 
-    sudo systemctl restart containerd.service  
+    sudo systemctl restart containerd.service
+    # Restart buildkit to ensure it's using the correct containerd UUID
+    sudo systemctl restart buildkit.service
 
 # Probe scripts to check readiness.
 # 🟢 Builtin default: null

--- a/finch.yaml
+++ b/finch.yaml
@@ -176,9 +176,9 @@ provision:
     mkdir -p  ~/.local/share/cni
     sudo mount --bind /mnt/lima-finch/cni  ~/.local/share/cni
 
+    # Make sure buildkit is restarted with containerd, so it uses the correct UUID
+    sudo systemctl add-requires buildkit.service containerd.service
     sudo systemctl restart containerd.service
-    # Restart buildkit to ensure it's using the correct containerd UUID
-    sudo systemctl restart buildkit.service
 
 # Probe scripts to check readiness.
 # 🟢 Builtin default: null


### PR DESCRIPTION
Issue #, if available: Fixes #412 

*Description of changes:*
- Previously, only containerd was restarted after configuring it to use the data on the persistent disk. This changes the UUID of the server worker. BuildKit also needs to be restarted to use the proper UUID. See issue for why this is important.

*Testing done:*
- Local testing


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
