### PR TITLE
ci: Add retry for release e2e tests

### DIFF
--- a/.github/workflows/build-and-test-pkg.yaml
+++ b/.github/workflows/build-and-test-pkg.yaml
@@ -212,7 +212,7 @@ jobs:
       - name: Run e2e tests
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 120
+          timeout_minutes: 180
           max_attempts: 3
           command: |
             git status
@@ -321,7 +321,7 @@ jobs:
       - name: Run e2e tests
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 120
+          timeout_minutes: 180
           max_attempts: 3
           command: |
             git status

--- a/.github/workflows/build-and-test-pkg.yaml
+++ b/.github/workflows/build-and-test-pkg.yaml
@@ -210,10 +210,14 @@ jobs:
           # Example workflow run https://github.com/runfinch/finch/actions/runs/4367457552/jobs/7638794529
           sudo installer -pkg Finch-${{ needs.get-tag-name.outputs.tag }}-aarch64.pkg -target /
       - name: Run e2e tests
-        run: |
-          git status
-          git clean -f -d
-          INSTALLED=true make test-e2e
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 120
+          max_attempts: 3
+          command: |
+            git status
+            git clean -f -d
+            INSTALLED=true make test-e2e
       - name: Silently uninstall
         run: echo 'y' | sudo bash /Applications/Finch/uninstall.sh
       - name: Delete installer
@@ -315,10 +319,14 @@ jobs:
           echo 'y' | sudo bash /Applications/Finch/uninstall.sh
           sudo installer -pkg Finch-${{ needs.get-tag-name.outputs.tag }}-x86_64.pkg -target /
       - name: Run e2e tests
-        run: |
-          git status
-          git clean -f -d
-          INSTALLED=true make test-e2e
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 120
+          max_attempts: 3
+          command: |
+            git status
+            git clean -f -d
+            INSTALLED=true make test-e2e
       - name: Silently uninstall
         run: echo 'y' | sudo bash /Applications/Finch/uninstall.sh
       - name: Delete installer

--- a/.github/workflows/release-homebrew.yaml
+++ b/.github/workflows/release-homebrew.yaml
@@ -144,7 +144,11 @@ jobs:
           brew reinstall --cask ./Casks/finch.rb
         shell: zsh {0}
       - name: Run e2e tests
-        run: INSTALLED=true make test-e2e
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 180
+          max_attempts: 3
+          command: INSTALLED=true make test-e2e
       - name: Silently uninstall
         if: ${{ always() }}
         run: |
@@ -258,7 +262,11 @@ jobs:
           brew reinstall --cask ./Casks/finch.rb
         shell: zsh {0}
       - name: Run e2e tests
-        run: INSTALLED=true make test-e2e
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 180
+          max_attempts: 3
+          command: INSTALLED=true make test-e2e
       - name: Silently uninstall
         if: ${{ always() }}
         run: |


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Used nick-fields/retry@v2 for e2e test retry to reduce manual effort in the release and nightly build validation

*Testing done:*
Tested with this branch


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
