### PR TITLE
fix: convert from ns/op to s/op in tooltips

### DIFF
--- a/dev/bench/common/common.js
+++ b/dev/bench/common/common.js
@@ -118,7 +118,7 @@ function renderAllChars(dataSets, platform) {
                     label: item => {
                         let label = item.value;
                         const { range, unit } = dataset[item.index].bench;
-                        label += ' ' + unit;
+                        label += ' ' + (unit === 'ns/op' ? 's/op' : unit);
                         if (range) {
                             label += ' (' + range + ')';
                         }


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*

*Testing done:*

https://github.com/runfinch/finch/issues/488

Follow up fix of previous change. https://github.com/runfinch/finch/pull/470

Changing to s/op for better readability.

- [ X ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
