### PR TITLE
ci: Increase the test timeout due to retry

### DIFF
--- a/.github/workflows/build-and-test-pkg.yaml
+++ b/.github/workflows/build-and-test-pkg.yaml
@@ -125,7 +125,7 @@ jobs:
     needs:
       - get-tag-name
       - macos-aarch64-pkg-build
-    timeout-minutes: 60
+    timeout-minutes: 180
     env:
       ACCESS_TOKEN: ${{ secrets.FINCH_BOT_TOKEN }}
     steps:
@@ -236,7 +236,7 @@ jobs:
     needs:
       - get-tag-name
       - macos-x86-64-pkg-build
-    timeout-minutes: 60
+    timeout-minutes: 180
     env:
       ACCESS_TOKEN: ${{ secrets.FINCH_BOT_TOKEN }}
     steps:

--- a/.github/workflows/release-homebrew.yaml
+++ b/.github/workflows/release-homebrew.yaml
@@ -48,7 +48,7 @@ jobs:
             [self-hosted, macos, arm64, 13, release],
           ]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 180
     env:
       FINCH_TAG: ${{ needs.get-latest-tag.outputs.tag }}
       FINCH_VERSION: ${{ needs.get-latest-tag.outputs.version }}
@@ -171,7 +171,7 @@ jobs:
             [self-hosted, macos, amd64, 13, release],
           ]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 180
     env:
       FINCH_TAG: ${{ needs.get-latest-tag.outputs.tag }}
       FINCH_VERSION: ${{ needs.get-latest-tag.outputs.version }}


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Increase the test timeout to 3 hours because it can have at most 3 retries.
One test run can currently take about 45 - 60 mins

*Testing done:*
Tested via previous nightly build


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
