### PR TITLE
ci: Add codeowner path to ci-docs.yaml file

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -15,12 +15,14 @@ on:
     paths:
       - '**.md'
       - 'contrib/**'
+      - '.github/CODEOWNERS'
   pull_request:
     branches:
       - main
     paths:
       - '**.md'
       - 'contrib/**'
+      - 'github/CODEOWNERS'
 
 jobs:
   gen-code-no-diff:

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -22,7 +22,7 @@ on:
     paths:
       - '**.md'
       - 'contrib/**'
-      - 'github/CODEOWNERS'
+      - '.github/CODEOWNERS'
 
 jobs:
   gen-code-no-diff:


### PR DESCRIPTION
Issue #, if available:
Add codeowners file path to `ci-docs.yaml` to prevent CI from getting blocked. 
*Description of changes:*
Fixes: 
*Testing done:*

N/A

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
