### PR TITLE
ci: add script to update rootfs URL

### DIFF
--- a/.github/bin/update-rootfs.sh
+++ b/.github/bin/update-rootfs.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -euxo pipefail
+
+DEPENDENCY_CLOUDFRONT_URL="https://deps.runfinch.com/"
+AARCH64_FILENAME_PATTERN="finch-rootfs-production-arm64-[0-9].*\.tar.zst$"
+AMD64_FILENAME_PATTERN="finch-rootfs-production-amd64-[0-9].*\.tar.zst$"
+
+while getopts d: flag
+do
+        case "${flag}" in
+            d) dependency_bucket=${OPTARG};;
+         esac
+done
+
+[[ -z "$dependency_bucket" ]] && { echo "Error: Dependency bucket not set"; exit 1; }
+
+aarch64Deps=$(aws s3 ls s3://${dependency_bucket}/ | grep "$AARCH64_FILENAME_PATTERN" | sort | tail -n 1 | awk '{print $4}')
+
+[[ -z "$aarch64Deps" ]] && { echo "Error: aarch64 dependency not found"; exit 1; }
+
+amd64Deps=$(aws s3 ls s3://${dependency_bucket}/ | grep "$AMD64_FILENAME_PATTERN" | sort | tail -n 1 | awk '{print $4}')
+
+[[ -z "$amd64Deps" ]] && { echo "Error: x86_64 dependency not found"; exit 1; }
+
+sed -E  -i.bak  's|^([[:blank:]]*FINCH_ROOTFS_URL[[:blank:]]*\?=[[:blank:]]*'${DEPENDENCY_CLOUDFRONT_URL}')('${AARCH64_FILENAME_PATTERN}')|\1'$aarch64Deps'|' Makefile
+sed -E  -i.bak  's|^([[:blank:]]*FINCH_ROOTFS_URL[[:blank:]]*\?=[[:blank:]]*'${DEPENDENCY_CLOUDFRONT_URL}')('${AMD64_FILENAME_PATTERN}')|\1'$amd64Deps'|'  Makefile

--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -29,6 +29,7 @@ jobs:
       - name: update dependencies url
         run: |
           ./.github/bin/update-lima-dep.sh -d ${{ secrets.DEPENDENCY_BUCKET_NAME }} -a {{ secrets.ARTIFACT_BUCKET_NAME }}
+          ./.github/bin/update-rootfs.sh -d ${{ secrets.DEPENDENCY_BUCKET_NAME }}
 
       - name: create PR
         uses: peter-evans/create-pull-request@v5

--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,18 @@ ifneq (,$(findstring arm64,$(ARCH)))
 	# From https://dl.fedoraproject.org/pub/fedora/linux/releases/37/Cloud/aarch64/images/
 	FINCH_OS_BASENAME ?= Fedora-Cloud-Base-38-1.6.aarch64-20230713205101.qcow2
 	LIMA_URL ?= https://deps.runfinch.com/aarch64/lima-and-qemu.macos-aarch64.1689037160.tar.gz
+
+	# TODO: Use Finch rootfs in Finch on Windows testing
+	FINCH_ROOTFS_URL ?= https://deps.runfinch.com/finch-rootfs-production-arm64-1690563031.tar.zst
 else ifneq (,$(findstring x86_64,$(ARCH)))
 	SUPPORTED_ARCH = true
 	LIMA_ARCH = x86_64
 	# From https://dl.fedoraproject.org/pub/fedora/linux/releases/37/Cloud/x86_64/images/
 	FINCH_OS_BASENAME ?= Fedora-Cloud-Base-38-1.6.x86_64-20230713205042.qcow2
 	LIMA_URL ?= https://deps.runfinch.com/x86-64/lima-and-qemu.macos-x86_64.1689037160.tar.gz
+
+	# TODO: Use Finch rootfs in Finch on Windows testing
+	FINCH_ROOTFS_URL ?= https://deps.runfinch.com/finch-rootfs-production-amd64-1690563027.tar.zst
 endif
 
 FINCH_OS_HASH := `shasum -a 256 $(OUTDIR)/os/$(FINCH_OS_BASENAME) | cut -d ' ' -f 1`


### PR DESCRIPTION
Issue #, if available: #492

*Description of changes:*

for Finch on Windows #492, we need to provide a rootfs to WSL2. This rootfs lives in our dependencies bucket, and will be updated from time-to-time for security patches, bug fixes, etc. This commit will automatically pull the most recent rootfs from the dependencies bucket as part of the update deps action.

TODO: similar change to finch-core.

*Testing done:*

locally run script with `FINCH_ROOTFS_URL ?= https://deps.runfinch.com/finch-rootfs-production-amd64-000000000.tar.zst` set in Makefile, observe update.



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
