### PR TITLE
fix: quote recursive calls to make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ finch-core:
 		FINCH_OS_x86_URL="$(FINCH_OS_x86_URL)" \
 		FINCH_OS_AARCH64_URL="$(FINCH_OS_AARCH64_URL)" \
 		VDE_TEMP_PREFIX=$(CORE_VDE_PREFIX) \
-		$(MAKE)
+		"$(MAKE)"
 
 	mkdir -p _output
 	cd deps/finch-core/_output && tar c * | tar Cvx  $(OUTDIR)
@@ -77,7 +77,7 @@ local-core:
 		FINCH_OS_x86_URL="$(FINCH_OS_x86_URL)" \
 		FINCH_OS_AARCH64_URL="$(FINCH_OS_AARCH64_URL)" \
 		VDE_TEMP_PREFIX=$(CORE_VDE_PREFIX) \
-		$(MAKE) lima lima-socket-vmnet
+		"$(MAKE)" lima lima-socket-vmnet
 
 	mkdir -p _output
 	cd deps/finch-core/_output && tar c * | tar Cvx  $(OUTDIR)


### PR DESCRIPTION


Issue #, if available:

*Description of changes:*

$(MAKE) is used for calling `make` recursively. On a Windows machine, `make` might be at some location containing a space or special character, like `/c/Program Files (x86)/GnuWin32/bin/make` . Wrap in quotes as "$(MAKE)" to prevent errors.

*Testing done:*

`make` on Mac Apple Silicon and `make` on Windows EC2 instance.

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
