### PR TITLE
fix: configure aws creds in sync submodules/deps action

### DIFF
--- a/.github/workflows/sync-submodules-and-deps.yaml
+++ b/.github/workflows/sync-submodules-and-deps.yaml
@@ -16,6 +16,13 @@ jobs:
           submodules: recursive
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: ${{ secrets.REGION }}
+          role-to-assume: ${{ secrets.ROLE }}
+          role-session-name: sync-submodules-and-deps-session
+
       - name: Update submodules
         run: |
           git submodule update --remote


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*

#511 removed the duplicate action in finch/finch-core for updating deps; however, now need AWS creds in this action for the dependency updates.

*Testing done:*

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
