### PR TITLE
chore: remove FINCH_DOCKER_COMPAT

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,60 +139,6 @@ jobs:
           git clean -f -d
           REGISTRY=${{ steps.vars.outputs.has_creds == true && env.REGISTRY || '' }} make test-e2e
         shell: zsh {0}
-  e2e-tests-for-docker-compat:
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          [
-            [self-hosted, macos, amd64, 13, test],
-            [self-hosted, macos, arm64, 13, test],
-          ]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          # We need to get all the git tags to make version injection work. See VERSION in Makefile for more detail.
-          fetch-depth: 0
-          persist-credentials: false
-          submodules: true
-      - name: Set output variables
-        id: vars
-        run: |
-          has_creds=${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name }}
-          echo "has_creds=$has_creds" >> $GITHUB_OUTPUT
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v2.2.0
-        if: steps.vars.outputs.has_creds == true
-        with:
-          role-to-assume: ${{ secrets.ROLE }}
-          role-session-name: credhelper-test-docker-compat
-          aws-region: ${{ secrets.REGION }}
-      - name: Clean up previous files
-        run: |
-          sudo rm -rf /opt/finch
-          sudo rm -rf ~/.finch
-          sudo rm -rf ./_output
-          if pgrep '^qemu-system'; then
-            sudo pkill '^qemu-system'
-          fi
-          if pgrep '^socket_vmnet'; then
-            sudo pkill '^socket_vmnet'
-          fi
-      - name: Install Rosetta 2
-        run: echo "A" | softwareupdate --install-rosetta || true
-      - run: brew install go lz4 automake autoconf libtool
-        shell: zsh {0}
-      - name: Build project
-        run: |
-          export PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH"
-          make
-        shell: zsh {0}
-      - run: |
-          git status
-          git clean -f -d
-          FINCH_DOCKER_COMPAT=1 REGISTRY=${{ steps.vars.outputs.has_creds == true && env.REGISTRY || '' }} make test-e2e
-        shell: zsh {0}
   mdlint:
     runs-on: ubuntu-latest
     steps:

--- a/cmd/finch/nerdctl.go
+++ b/cmd/finch/nerdctl.go
@@ -6,9 +6,7 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	dockerops "github.com/docker/docker/opts"
@@ -87,11 +85,7 @@ func (nc *nerdctlCommand) run(cmdName string, args []string) error {
 	var (
 		nerdctlArgs, envs, fileEnvs []string
 		skip                        bool
-		volumes                     []string
 	)
-
-	dockerCompat := isDockerCompatEnvSet(nc.systemDeps)
-	firstVolumeIndex := -1
 
 	for i, arg := range args {
 		// parsing environment values from the command line may pre-fetch and
@@ -127,31 +121,8 @@ func (nc *nerdctlCommand) run(cmdName string, args []string) error {
 				arg = fmt.Sprintf("%s%s", arg[0:11], resolvedIP)
 			}
 			nerdctlArgs = append(nerdctlArgs, arg)
-		case strings.HasPrefix(arg, "-v") || strings.HasPrefix(arg, "--volume"):
-			// TODO: remove the case branch when the Nerdctl fix is released to Finch.
-			// Nerdctl tracking issue: https://github.com/containerd/nerdctl/issues/2254.
-			if dockerCompat {
-				if firstVolumeIndex == -1 {
-					firstVolumeIndex = i
-				}
-				volume, shouldSkip := getVolume(arg, args[i+1])
-				volumes = append(volumes, volume)
-				skip = shouldSkip
-			} else {
-				nerdctlArgs = append(nerdctlArgs, arg)
-			}
 		default:
 			nerdctlArgs = append(nerdctlArgs, arg)
-		}
-	}
-
-	if dockerCompat {
-		// Need to insert to the middle to prevent messing up the subcommands at the beginning and the image ref at the end.
-		// The first volume index is a good middle position.
-		volumes = sortVolumes(volumes)
-		for i, vol := range volumes {
-			position := firstVolumeIndex + i*2
-			nerdctlArgs = append(nerdctlArgs[:position], append([]string{"-v", vol}, nerdctlArgs[position:]...)...)
 		}
 	}
 
@@ -334,20 +305,6 @@ func handleEnvFile(fs afero.Fs, systemDeps NerdctlCommandSystemDeps, arg, arg2 s
 	return skip, envs, nil
 }
 
-// getVolume extracts the volume string from a command line argument.
-// It handles both "--volume=" and "-v=" prefixes.
-// The function returns the extracted volume string and a boolean value indicating whether the volume was found in the next argument.
-// If the volume string was found in the provided 'arg' string (with "--volume=" or "-v=" prefix), it returns the volume and 'false'.
-// If the volume string wasn't in the 'arg', it assumes it's in the 'nextArg' string and returns 'nextArg' and 'true'.
-func getVolume(arg, nextArg string) (string, bool) {
-	for _, prefix := range []string{"--volume=", "-v="} {
-		if strings.HasPrefix(arg, prefix) {
-			return arg[len(prefix):], false
-		}
-	}
-	return nextArg, true
-}
-
 func resolveIP(host string, logger flog.Logger) string {
 	parts := strings.SplitN(host, ":", 2)
 	// If the IP Address is a string called "host-gateway", replace this value with the IP address that can be used to
@@ -359,50 +316,6 @@ func resolveIP(host string, logger flog.Logger) string {
 		return fmt.Sprintf("%s:%s", parts[0], resolvedIP)
 	}
 	return host
-}
-
-func sortVolumes(volumes []string) []string {
-	type volume struct {
-		original    string
-		destination string
-	}
-
-	volumeSlices := make([]volume, 0)
-	for _, vol := range volumes {
-		splitVol := strings.Split(vol, ":")
-		if len(splitVol) >= 2 {
-			volumeSlices = append(volumeSlices, volume{
-				original:    vol,
-				destination: splitVol[1],
-			})
-		} else {
-			// Still need to put the volume string back if it is in other format.
-			volumeSlices = append(volumeSlices, volume{
-				original:    vol,
-				destination: "",
-			})
-		}
-	}
-	sort.Slice(volumeSlices, func(i, j int) bool {
-		// Consistent with the less function in Docker.
-		// https://github.com/moby/moby/blob/0db417451313474133c5ed62bbf95e2d3c92444d/daemon/volumes.go#L45
-		c1 := strings.Count(filepath.Clean(volumeSlices[i].destination), string(os.PathSeparator))
-		c2 := strings.Count(filepath.Clean(volumeSlices[j].destination), string(os.PathSeparator))
-		return c1 < c2
-	})
-	sortedVolumes := make([]string, 0)
-	for _, vol := range volumeSlices {
-		sortedVolumes = append(sortedVolumes, vol.original)
-	}
-	return sortedVolumes
-}
-
-// isDockerCompatEnvSet checks if the FINCH_DOCKER_COMPAT environment variable is set, so that callers can
-// modify behavior to match docker instead of nerdctl.
-// Intended to be used for temporary workarounds until changes are merged upstream.
-func isDockerCompatEnvSet(systemDeps NerdctlCommandSystemDeps) bool {
-	_, s := systemDeps.LookupEnv("FINCH_DOCKER_COMPAT")
-	return s
 }
 
 var nerdctlCmds = map[string]string{

--- a/cmd/finch/nerdctl_test.go
+++ b/cmd/finch/nerdctl_test.go
@@ -56,7 +56,6 @@ func TestNerdctlCommand_runAdaptor(t *testing.T) {
 				ncsd.EXPECT().LookupEnv("AWS_ACCESS_KEY_ID").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SECRET_ACCESS_KEY").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SESSION_TOKEN").Return("", false)
-				ncsd.EXPECT().LookupEnv("FINCH_DOCKER_COMPAT").Return("", false)
 				ncsd.EXPECT().LookupEnv("COSIGN_PASSWORD").Return("", false)
 				c := mocks.NewCommand(ctrl)
 				lcc.EXPECT().Create("shell", limaInstanceName, "sudo", "-E", nerdctlCmdName, "info").Return(c)
@@ -111,7 +110,6 @@ func TestNerdctlCommand_run(t *testing.T) {
 				ncsd.EXPECT().LookupEnv("AWS_ACCESS_KEY_ID").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SECRET_ACCESS_KEY").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SESSION_TOKEN").Return("", false)
-				ncsd.EXPECT().LookupEnv("FINCH_DOCKER_COMPAT").Return("", false)
 				ncsd.EXPECT().LookupEnv("COSIGN_PASSWORD").Return("", false)
 				c := mocks.NewCommand(ctrl)
 				lcc.EXPECT().Create("shell", limaInstanceName, "sudo", "-E", nerdctlCmdName, "build", "-t", "demo", ".").Return(c)
@@ -216,7 +214,6 @@ func TestNerdctlCommand_run(t *testing.T) {
 				ncsd.EXPECT().LookupEnv("AWS_ACCESS_KEY_ID").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SECRET_ACCESS_KEY").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SESSION_TOKEN").Return("", false)
-				ncsd.EXPECT().LookupEnv("FINCH_DOCKER_COMPAT").Return("", false)
 				logger.EXPECT().SetLevel(flog.Debug)
 				ncsd.EXPECT().LookupEnv("COSIGN_PASSWORD").Return("", false)
 				c := mocks.NewCommand(ctrl)
@@ -244,7 +241,6 @@ func TestNerdctlCommand_run(t *testing.T) {
 				ncsd.EXPECT().LookupEnv("AWS_ACCESS_KEY_ID").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SECRET_ACCESS_KEY").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SESSION_TOKEN").Return("", false)
-				ncsd.EXPECT().LookupEnv("FINCH_DOCKER_COMPAT").Return("", false)
 				c := mocks.NewCommand(ctrl)
 				ncsd.EXPECT().LookupEnv("ARG2")
 				ncsd.EXPECT().LookupEnv("ARG3")
@@ -272,7 +268,6 @@ func TestNerdctlCommand_run(t *testing.T) {
 				lcc.EXPECT().CreateWithoutStdio("ls", "-f", "{{.Status}}", limaInstanceName).Return(getVMStatusC)
 				getVMStatusC.EXPECT().Output().Return([]byte("Running"), nil)
 				logger.EXPECT().Debugf("Status of virtual machine: %s", "Running")
-				ncsd.EXPECT().LookupEnv("FINCH_DOCKER_COMPAT").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_ACCESS_KEY_ID").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SECRET_ACCESS_KEY").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SESSION_TOKEN").Return("", false)
@@ -308,7 +303,6 @@ func TestNerdctlCommand_run(t *testing.T) {
 				ncsd.EXPECT().LookupEnv("AWS_ACCESS_KEY_ID").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SECRET_ACCESS_KEY").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SESSION_TOKEN").Return("", false)
-				ncsd.EXPECT().LookupEnv("FINCH_DOCKER_COMPAT").Return("", false)
 				c := mocks.NewCommand(ctrl)
 				ncsd.EXPECT().LookupEnv("ARG2")
 				ncsd.EXPECT().LookupEnv("NOTSETARG")
@@ -342,7 +336,6 @@ func TestNerdctlCommand_run(t *testing.T) {
 				ncsd.EXPECT().LookupEnv("AWS_ACCESS_KEY_ID").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SECRET_ACCESS_KEY").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SESSION_TOKEN").Return("", false)
-				ncsd.EXPECT().LookupEnv("FINCH_DOCKER_COMPAT").Return("", false)
 				c := mocks.NewCommand(ctrl)
 				ncsd.EXPECT().LookupEnv("ARG2").Return("val2", true)
 				ncsd.EXPECT().LookupEnv("NOTSETARG")
@@ -370,7 +363,6 @@ func TestNerdctlCommand_run(t *testing.T) {
 				lcc.EXPECT().CreateWithoutStdio("ls", "-f", "{{.Status}}", limaInstanceName).Return(getVMStatusC)
 				getVMStatusC.EXPECT().Output().Return([]byte("Running"), nil)
 				logger.EXPECT().Debugf("Status of virtual machine: %s", "Running")
-				ncsd.EXPECT().LookupEnv("FINCH_DOCKER_COMPAT").Return("", false)
 			},
 		},
 		{
@@ -393,7 +385,6 @@ func TestNerdctlCommand_run(t *testing.T) {
 				ncsd.EXPECT().LookupEnv("AWS_ACCESS_KEY_ID").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SECRET_ACCESS_KEY").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SESSION_TOKEN").Return("", false)
-				ncsd.EXPECT().LookupEnv("FINCH_DOCKER_COMPAT").Return("", false)
 				logger.EXPECT().Debugf(`Resolving special IP "host-gateway" to %q for host %q`, "192.168.5.2", "name")
 				ncsd.EXPECT().LookupEnv("COSIGN_PASSWORD").Return("", false)
 				c := mocks.NewCommand(ctrl)
@@ -422,7 +413,6 @@ func TestNerdctlCommand_run(t *testing.T) {
 				ncsd.EXPECT().LookupEnv("AWS_ACCESS_KEY_ID").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SECRET_ACCESS_KEY").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SESSION_TOKEN").Return("", false)
-				ncsd.EXPECT().LookupEnv("FINCH_DOCKER_COMPAT").Return("", false)
 				ncsd.EXPECT().LookupEnv("COSIGN_PASSWORD").Return("", false)
 				c := mocks.NewCommand(ctrl)
 				lcc.EXPECT().Create("shell", limaInstanceName, "sudo", "-E", nerdctlCmdName, "run",
@@ -450,7 +440,6 @@ func TestNerdctlCommand_run(t *testing.T) {
 				ncsd.EXPECT().LookupEnv("AWS_ACCESS_KEY_ID").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SECRET_ACCESS_KEY").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SESSION_TOKEN").Return("", false)
-				ncsd.EXPECT().LookupEnv("FINCH_DOCKER_COMPAT").Return("", false)
 				ncsd.EXPECT().LookupEnv("COSIGN_PASSWORD").Return("", false)
 				c := mocks.NewCommand(ctrl)
 				lcc.EXPECT().Create("shell", limaInstanceName, "sudo", "-E", nerdctlCmdName, "run",
@@ -478,7 +467,6 @@ func TestNerdctlCommand_run(t *testing.T) {
 				ncsd.EXPECT().LookupEnv("AWS_ACCESS_KEY_ID").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SECRET_ACCESS_KEY").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SESSION_TOKEN").Return("", false)
-				ncsd.EXPECT().LookupEnv("FINCH_DOCKER_COMPAT").Return("", false)
 				logger.EXPECT().Debugf(`Resolving special IP "host-gateway" to %q for host %q`, "192.168.5.2", "name")
 				ncsd.EXPECT().LookupEnv("COSIGN_PASSWORD").Return("", false)
 				c := mocks.NewCommand(ctrl)
@@ -507,7 +495,6 @@ func TestNerdctlCommand_run(t *testing.T) {
 				ncsd.EXPECT().LookupEnv("AWS_ACCESS_KEY_ID").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SECRET_ACCESS_KEY").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SESSION_TOKEN").Return("", false)
-				ncsd.EXPECT().LookupEnv("FINCH_DOCKER_COMPAT").Return("", false)
 				ncsd.EXPECT().LookupEnv("COSIGN_PASSWORD").Return("", false)
 
 				c := mocks.NewCommand(ctrl)
@@ -517,7 +504,7 @@ func TestNerdctlCommand_run(t *testing.T) {
 			},
 		},
 		{
-			name:    "with multiple nested volumes when FINCH_DOCKER_COMPAT is not set",
+			name:    "with multiple nested volumes",
 			cmdName: "run",
 			args: []string{
 				"--rm", "-v", "/tmp:/tmp1/tmp2:rro", "--volume", "/tmp:/tmp1:rprivate,rro", "-v=/tmp:/tmp1/tmp2/tmp3/tmp4:rro",
@@ -539,7 +526,6 @@ func TestNerdctlCommand_run(t *testing.T) {
 				ncsd.EXPECT().LookupEnv("AWS_ACCESS_KEY_ID").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SECRET_ACCESS_KEY").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SESSION_TOKEN").Return("", false)
-				ncsd.EXPECT().LookupEnv("FINCH_DOCKER_COMPAT").Return("", false)
 				ncsd.EXPECT().LookupEnv("COSIGN_PASSWORD").Return("", false)
 				c := mocks.NewCommand(ctrl)
 				lcc.EXPECT().Create("shell", limaInstanceName, "sudo", "-E", nerdctlCmdName, "run",
@@ -549,39 +535,7 @@ func TestNerdctlCommand_run(t *testing.T) {
 			},
 		},
 		{
-			name:    "with multiple nested volumes when FINCH_DOCKER_COMPAT is set",
-			cmdName: "run",
-			args: []string{
-				"--rm", "-v", "/tmp:/tmp1/tmp2:rro", "--volume", "/tmp:/tmp1:rprivate,rro", "-v=/tmp:/tmp1/tmp2/tmp3/tmp4:rro",
-				"--volume=/tmp:/tmp1/tmp3/tmp4:rshared", "-v", "volume", "alpine:latest",
-			},
-			wantErr: nil,
-			mockSvc: func(
-				t *testing.T,
-				lcc *mocks.LimaCmdCreator,
-				ncsd *mocks.NerdctlCommandSystemDeps,
-				logger *mocks.Logger,
-				ctrl *gomock.Controller,
-				fs afero.Fs,
-			) {
-				getVMStatusC := mocks.NewCommand(ctrl)
-				lcc.EXPECT().CreateWithoutStdio("ls", "-f", "{{.Status}}", limaInstanceName).Return(getVMStatusC)
-				getVMStatusC.EXPECT().Output().Return([]byte("Running"), nil)
-				logger.EXPECT().Debugf("Status of virtual machine: %s", "Running")
-				ncsd.EXPECT().LookupEnv("AWS_ACCESS_KEY_ID").Return("", false)
-				ncsd.EXPECT().LookupEnv("AWS_SECRET_ACCESS_KEY").Return("", false)
-				ncsd.EXPECT().LookupEnv("AWS_SESSION_TOKEN").Return("", false)
-				ncsd.EXPECT().LookupEnv("FINCH_DOCKER_COMPAT").Return("1", true)
-				ncsd.EXPECT().LookupEnv("COSIGN_PASSWORD").Return("", false)
-				c := mocks.NewCommand(ctrl)
-				lcc.EXPECT().Create("shell", limaInstanceName, "sudo", "-E", nerdctlCmdName, "run",
-					"--rm", "-v", "volume", "-v", "/tmp:/tmp1:rprivate,rro", "-v", "/tmp:/tmp1/tmp2:rro",
-					"-v", "/tmp:/tmp1/tmp3/tmp4:rshared", "-v", "/tmp:/tmp1/tmp2/tmp3/tmp4:rro", "alpine:latest").Return(c)
-				c.EXPECT().Run()
-			},
-		},
-		{
-			name:    "with multiple nested volumes with full container run command when FINCH_DOCKER_COMPAT is set",
+			name:    "with multiple nested volumes with full container run command",
 			cmdName: "container",
 			args: []string{
 				"run", "--rm", "-v", "/tmp:/tmp1/tmp2:rro", "--volume", "/tmp:/tmp1:rprivate,rro",
@@ -603,12 +557,11 @@ func TestNerdctlCommand_run(t *testing.T) {
 				ncsd.EXPECT().LookupEnv("AWS_ACCESS_KEY_ID").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SECRET_ACCESS_KEY").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SESSION_TOKEN").Return("", false)
-				ncsd.EXPECT().LookupEnv("FINCH_DOCKER_COMPAT").Return("1", true)
 				ncsd.EXPECT().LookupEnv("COSIGN_PASSWORD").Return("", false)
 				c := mocks.NewCommand(ctrl)
 				lcc.EXPECT().Create("shell", limaInstanceName, "sudo", "-E", nerdctlCmdName, "container", "run",
-					"--rm", "-v", "volume", "-v", "/tmp:/tmp1:rprivate,rro", "-v", "/tmp:/tmp1/tmp2:rro",
-					"-v", "/tmp:/tmp1/tmp3/tmp4:rshared", "-v", "/tmp:/tmp1/tmp2/tmp3/tmp4:rro", "alpine:latest").Return(c)
+					"--rm", "-v", "/tmp:/tmp1/tmp2:rro", "--volume", "/tmp:/tmp1:rprivate,rro",
+					"-v=/tmp:/tmp1/tmp2/tmp3/tmp4:rro", "--volume=/tmp:/tmp1/tmp3/tmp4:rshared", "-v", "volume", "alpine:latest").Return(c)
 				c.EXPECT().Run()
 			},
 		},
@@ -632,7 +585,6 @@ func TestNerdctlCommand_run(t *testing.T) {
 				ncsd.EXPECT().LookupEnv("AWS_ACCESS_KEY_ID").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SECRET_ACCESS_KEY").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SESSION_TOKEN").Return("", false)
-				ncsd.EXPECT().LookupEnv("FINCH_DOCKER_COMPAT").Return("", false)
 				ncsd.EXPECT().LookupEnv("COSIGN_PASSWORD").Return("", false)
 				lcc.EXPECT().RunWithReplacingStdout(
 					testStdoutRs, "shell", limaInstanceName, "sudo", "-E", nerdctlCmdName, "pull", "test:tag", "--help").Return(nil)
@@ -658,7 +610,6 @@ func TestNerdctlCommand_run(t *testing.T) {
 				ncsd.EXPECT().LookupEnv("AWS_ACCESS_KEY_ID").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SECRET_ACCESS_KEY").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SESSION_TOKEN").Return("", false)
-				ncsd.EXPECT().LookupEnv("FINCH_DOCKER_COMPAT").Return("", false)
 				ncsd.EXPECT().LookupEnv("COSIGN_PASSWORD").Return("", false)
 				lcc.EXPECT().RunWithReplacingStdout(
 					testStdoutRs, "shell", limaInstanceName, "sudo", "-E", nerdctlCmdName, "pull", "test:tag", "--help").
@@ -685,7 +636,6 @@ func TestNerdctlCommand_run(t *testing.T) {
 				ncsd.EXPECT().LookupEnv("AWS_ACCESS_KEY_ID").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SECRET_ACCESS_KEY").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SESSION_TOKEN").Return("", false)
-				ncsd.EXPECT().LookupEnv("FINCH_DOCKER_COMPAT").Return("", false)
 				ncsd.EXPECT().LookupEnv("COSIGN_PASSWORD").Return("test", true)
 				c := mocks.NewCommand(ctrl)
 				lcc.EXPECT().Create("shell", limaInstanceName, "sudo", "-E", "COSIGN_PASSWORD=test", nerdctlCmdName,
@@ -713,7 +663,6 @@ func TestNerdctlCommand_run(t *testing.T) {
 				ncsd.EXPECT().LookupEnv("AWS_ACCESS_KEY_ID").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SECRET_ACCESS_KEY").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SESSION_TOKEN").Return("", false)
-				ncsd.EXPECT().LookupEnv("FINCH_DOCKER_COMPAT").Return("", false)
 				ncsd.EXPECT().LookupEnv("COSIGN_PASSWORD").Return("test", true)
 				c := mocks.NewCommand(ctrl)
 				lcc.EXPECT().Create("shell", limaInstanceName, "sudo", "-E", "COSIGN_PASSWORD=test", nerdctlCmdName,
@@ -741,7 +690,6 @@ func TestNerdctlCommand_run(t *testing.T) {
 				ncsd.EXPECT().LookupEnv("AWS_ACCESS_KEY_ID").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SECRET_ACCESS_KEY").Return("", false)
 				ncsd.EXPECT().LookupEnv("AWS_SESSION_TOKEN").Return("", false)
-				ncsd.EXPECT().LookupEnv("FINCH_DOCKER_COMPAT").Return("", false)
 				ncsd.EXPECT().LookupEnv("COSIGN_PASSWORD").Return("test", true)
 				c := mocks.NewCommand(ctrl)
 				lcc.EXPECT().Create("shell", limaInstanceName, "sudo", "-E", "COSIGN_PASSWORD=test",


### PR DESCRIPTION
Issue #, if available:

Closes #418 

*Description of changes:*

with release of nerdctl v1.5 we can remove the FINCH_DOCKER_COMPAT environment variable used as a workaround for nested volume mount behavior.

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
