### PR TITLE
fix: Mount /var/folders to finch vm

### DIFF
--- a/finch.yaml
+++ b/finch.yaml
@@ -76,6 +76,11 @@ mounts:
   # 🟢 Builtin default: false
   # 🔵 This file: true (only for "/tmp/lima")
   writable: true
+- location: "/var/folders"
+  writable: true
+# Because readlink /var => private/var
+- location: "/private/var/folders"
+  writable: true
 
 # Lima disks to attach to the instance. The disks will be accessible from inside the
 # instance, labeled by name. (e.g. if the disk is named "data", it will be labeled


### PR DESCRIPTION
Issue #, if available:
https://github.com/runfinch/finch/issues/297

*Description of changes:*
Mount /var/folders into finch vm automatically to improve compatibility with docker. 

Docker mount directories
<img width="567" alt="image" src="https://github.com/runfinch/finch/assets/69735799/61e561f9-6ac7-4610-9a88-aa044794ce00">


*Testing done:*
Yes


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
