### PR TITLE
fix: enables bridge-nf-call-iptables by default

### DIFF
--- a/finch.yaml
+++ b/finch.yaml
@@ -143,6 +143,15 @@ provision:
 - mode: boot
   script: |
     modprobe virtiofs
+- mode: boot
+  script: |
+    modprobe br_netfilter
+    cat <<EOF > /etc/sysctl.d/99-finch.conf
+    net.bridge.bridge-nf-call-iptables = 1
+    net.bridge.bridge-nf-call-ip6tables = 1
+    net.ipv4.ip_forward = 1
+    EOF
+    sysctl --system
 # # `user` is executed without the root privilege
 - mode: user
   script: |


### PR DESCRIPTION
Issue #, if available: https://github.com/runfinch/finch/issues/538

*Description of changes:*

Enables `net.bridge.bridge-nf-call-iptables` by default in `sysctl`. This will [send packets in a bridge network to iptables for processing](https://wiki.libvirt.org/Net.bridge.bridge-nf-call_and_sysctl.conf.html).

This will also fix the warning on `finch info`:
```
WARNING: bridge-nf-call-iptables is disabled
WARNING: bridge-nf-call-ip6tables is disabled
```

*Testing done:*

1. `finch info`
1. Inspected `/etc/sysctl.d/99-lima.conf` to ensure all of the expected fields are there
1. Reproduced https://github.com/runfinch/finch/issues/538 against my local Finch, and it succeeded.

**To discuss:** is it worth creating a new sysctl config file instead of appending to `/etc/sysctl.d/99-lima.conf`?

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
