### PR TITLE
feat: supports adding files inside the VM to support bundles

### DIFF
--- a/cmd/finch/main.go
+++ b/cmd/finch/main.go
@@ -96,6 +96,7 @@ var newApp = func(logger flog.Logger, fp path.Finch, fs afero.Fs, fc *config.Fin
 		support.NewBundleConfig(fp, system.NewStdLib().Env("HOME")),
 		fp,
 		ecc,
+		lcc,
 		wrapper.NewLimaWrapper(),
 	)
 

--- a/cmd/finch/support_bundle.go
+++ b/cmd/finch/support_bundle.go
@@ -35,7 +35,8 @@ func newSupportBundleGenerateCommand(logger flog.Logger, builder support.BundleB
 	}
 
 	supportBundleGenerateCommand.Flags().StringArray("include", []string{},
-		"additional files to include in the support bundle, specified by absolute or relative path")
+		//nolint:lll // usage string
+		`additional files to include in the support bundle, specified by absolute or relative path. to include a file from the VM, prefix the file path with "vm:"`)
 	supportBundleGenerateCommand.Flags().StringArray("exclude", []string{},
 		//nolint:lll // usage string
 		"files to exclude from the support bundle. if you specify a base name, all files matching that base name will be excluded. if you specify an absolute or relative path, only exact matches will be excluded")

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -26,6 +26,8 @@ type Command interface {
 	SetStderr(io.Writer)
 
 	Run() error
+	Start() error
+	Wait() error
 	Output() ([]byte, error)
 	CombinedOutput() ([]byte, error)
 }

--- a/pkg/mocks/command_command.go
+++ b/pkg/mocks/command_command.go
@@ -128,3 +128,31 @@ func (mr *CommandMockRecorder) SetStdout(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStdout", reflect.TypeOf((*Command)(nil).SetStdout), arg0)
 }
+
+// Start mocks base method.
+func (m *Command) Start() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Start")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Start indicates an expected call of Start.
+func (mr *CommandMockRecorder) Start() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*Command)(nil).Start))
+}
+
+// Wait mocks base method.
+func (m *Command) Wait() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Wait")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Wait indicates an expected call of Wait.
+func (mr *CommandMockRecorder) Wait() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Wait", reflect.TypeOf((*Command)(nil).Wait))
+}


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*

Allows users to add files from inside their finch VM to a support bundle. The file can be specified in a config or in a command line flag with `vm:/path/to/file/in/vm`

*Testing done:*

```
make test-unit
```

manual testing


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
