### PR TITLE
feat: add handling for nerdctl commands and options

### DIFF
--- a/cmd/finch/nerdctl_darwin.go
+++ b/cmd/finch/nerdctl_darwin.go
@@ -16,3 +16,5 @@ func handleVolume(systemDeps NerdctlCommandSystemDeps, v string) (string, error)
 var aliasMap = map[string]string{}
 
 var argHandlerMap = map[string]map[string]argHandler{}
+
+var commandHanderMap = map[string]commandHandler{}

--- a/cmd/finch/nerdctl_darwin_test.go
+++ b/cmd/finch/nerdctl_darwin_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/runfinch/finch/pkg/flog"
 
-	"github.com/runfinch/finch/pkg/command"
 	"github.com/runfinch/finch/pkg/mocks"
 )
 

--- a/cmd/finch/nerdctl_windows.go
+++ b/cmd/finch/nerdctl_windows.go
@@ -26,24 +26,24 @@ func convertToWSLPath(systemDeps NerdctlCommandSystemDeps, winPath string) (stri
 }
 
 // substitues wsl path for the provided option in place for nerdctl args
-func handleFilePath(systemDeps NerdctlCommandSystemDeps, args []string, index int) error {
-	var prefix = args[index]
+func handleFilePath(systemDeps NerdctlCommandSystemDeps, nerdctlCmdArgs []string, index int) error {
+	var prefix = nerdctlCmdArgs[index]
 
 	// If --filename="<filepath> then we need to cut <filepath> and convert that to wsl path
-	if strings.Contains(args[index], "=") {
+	if strings.Contains(nerdctlCmdArgs[index], "=") {
 		before, after, _ := strings.Cut(prefix, "=")
 		wslPath, err := convertToWSLPath(systemDeps, after)
 		if err != nil {
 			return err
 		}
-		args[index] = fmt.Sprintf("%s=%s", before, wslPath)
+		nerdctlCmdArgs[index] = fmt.Sprintf("%s=%s", before, wslPath)
 	} else {
-		if (index + 1) < len(args) {
-			wslPath, err := convertToWSLPath(systemDeps, args[index+1])
+		if (index + 1) < len(nerdctlCmdArgs) {
+			wslPath, err := convertToWSLPath(systemDeps, nerdctlCmdArgs[index+1])
 			if err != nil {
 				return err
 			}
-			args[index+1] = wslPath
+			nerdctlCmdArgs[index+1] = wslPath
 		} else {
 			return fmt.Errorf("invalid positional parameter for %s", prefix)
 		}
@@ -52,16 +52,16 @@ func handleFilePath(systemDeps NerdctlCommandSystemDeps, args []string, index in
 }
 
 // hanldes -v/--volumes option. For anonymous volumes and named volumes this is no-op. For bind mounts path is converted to wsl path.
-func handleVolume(systemDeps NerdctlCommandSystemDeps, args []string, index int) error {
-	var prefix = args[index]
+func handleVolume(systemDeps NerdctlCommandSystemDeps, nerdctlCmdArgs []string, index int) error {
+	var prefix = nerdctlCmdArgs[index]
 	var v = ""
 	var found = false
 	var before = ""
-	if strings.Contains(args[index], "=") {
+	if strings.Contains(nerdctlCmdArgs[index], "=") {
 		before, v, found = strings.Cut(prefix, "=")
 	} else {
-		if (index + 1) < len(args) {
-			v = args[index+1]
+		if (index + 1) < len(nerdctlCmdArgs) {
+			v = nerdctlCmdArgs[index+1]
 		} else {
 			return fmt.Errorf("invalid positional parameter for %s", prefix)
 		}
@@ -99,24 +99,24 @@ func handleVolume(systemDeps NerdctlCommandSystemDeps, args []string, index int)
 	}
 
 	if found {
-		args[index] = fmt.Sprintf("%s=%s:%s%s", before, wslHostPath, containerPath, readWrite)
+		nerdctlCmdArgs[index] = fmt.Sprintf("%s=%s:%s%s", before, wslHostPath, containerPath, readWrite)
 	} else {
-		args[index+1] = fmt.Sprintf("%s:%s%s", wslHostPath, containerPath, readWrite)
+		nerdctlCmdArgs[index+1] = fmt.Sprintf("%s:%s%s", wslHostPath, containerPath, readWrite)
 	}
 	return nil
 }
 
 // translates source path of the bind mount to wslpath for --mount option
-func handleBindMounts(systemDeps NerdctlCommandSystemDeps, args []string, index int) error {
-	var prefix = args[index]
+func handleBindMounts(systemDeps NerdctlCommandSystemDeps, nerdctlCmdArgs []string, index int) error {
+	var prefix = nerdctlCmdArgs[index]
 	var v = ""
 	var found = false
 	var before = ""
-	if strings.Contains(args[index], "=") {
+	if strings.Contains(nerdctlCmdArgs[index], "=") {
 		before, v, found = strings.Cut(prefix, "=")
 	} else {
-		if (index + 1) < len(args) {
-			v = args[index+1]
+		if (index + 1) < len(nerdctlCmdArgs) {
+			v = nerdctlCmdArgs[index+1]
 		} else {
 			return fmt.Errorf("invalid positional parameter for %s", prefix)
 		}
@@ -164,25 +164,25 @@ func handleBindMounts(systemDeps NerdctlCommandSystemDeps, args []string, index 
 		s = s + "," + strings.Join(ro, ",")
 	}
 	if found {
-		args[index] = fmt.Sprintf("%s=%s", before, s)
+		nerdctlCmdArgs[index] = fmt.Sprintf("%s=%s", before, s)
 	} else {
-		args[index+1] = s
+		nerdctlCmdArgs[index+1] = s
 	}
 
 	return nil
 }
 
 // handles --output/-o for build command
-func handleOutputOption(systemDeps NerdctlCommandSystemDeps, args []string, index int) error {
-	var prefix = args[index]
+func handleOutputOption(systemDeps NerdctlCommandSystemDeps, nerdctlCmdArgs []string, index int) error {
+	var prefix = nerdctlCmdArgs[index]
 	var v = ""
 	var found = false
 	var before = ""
-	if strings.Contains(args[index], "=") {
+	if strings.Contains(nerdctlCmdArgs[index], "=") {
 		before, v, found = strings.Cut(prefix, "=")
 	} else {
-		if (index + 1) < len(args) {
-			v = args[index+1]
+		if (index + 1) < len(nerdctlCmdArgs) {
+			v = nerdctlCmdArgs[index+1]
 		} else {
 			return fmt.Errorf("invalid positional parameter for %s", prefix)
 		}
@@ -209,25 +209,25 @@ func handleOutputOption(systemDeps NerdctlCommandSystemDeps, args []string, inde
 	s := mapToString(m)
 
 	if found {
-		args[index] = fmt.Sprintf("%s=%s", before, s)
+		nerdctlCmdArgs[index] = fmt.Sprintf("%s=%s", before, s)
 	} else {
-		args[index+1] = s
+		nerdctlCmdArgs[index+1] = s
 	}
 
 	return nil
 }
 
 // handles --secret option for build command.
-func handleSecretOption(systemDeps NerdctlCommandSystemDeps, args []string, index int) error {
-	var prefix = args[index]
+func handleSecretOption(systemDeps NerdctlCommandSystemDeps, nerdctlCmdArgs []string, index int) error {
+	var prefix = nerdctlCmdArgs[index]
 	var v = ""
 	var found = false
 	var before = ""
-	if strings.Contains(args[index], "=") {
+	if strings.Contains(nerdctlCmdArgs[index], "=") {
 		before, v, found = strings.Cut(prefix, "=")
 	} else {
-		if (index + 1) < len(args) {
-			v = args[index+1]
+		if (index + 1) < len(nerdctlCmdArgs) {
+			v = nerdctlCmdArgs[index+1]
 		} else {
 			return fmt.Errorf("invalid positional parameter for %s", prefix)
 		}
@@ -253,17 +253,17 @@ func handleSecretOption(systemDeps NerdctlCommandSystemDeps, args []string, inde
 	s := mapToString(m)
 
 	if found {
-		args[index] = fmt.Sprintf("%s=%s", before, s)
+		nerdctlCmdArgs[index] = fmt.Sprintf("%s=%s", before, s)
 	} else {
-		args[index+1] = s
+		nerdctlCmdArgs[index+1] = s
 	}
 
 	return nil
 }
 
 // cp command handler, takes command arguments and converts hostpath to wsl path in place. It ignores all other arguments
-func cpHandler(systemDeps NerdctlCommandSystemDeps, cmdArgs []string) error {
-	for i, arg := range cmdArgs {
+func cpHandler(systemDeps NerdctlCommandSystemDeps, nerdctlCmdArgs []string) error {
+	for i, arg := range nerdctlCmdArgs {
 		// -L and --follow-symlink don't have to be processed
 		if strings.HasPrefix(arg, "-") || arg == "cp" {
 			continue
@@ -279,29 +279,29 @@ func cpHandler(systemDeps NerdctlCommandSystemDeps, cmdArgs []string) error {
 			if err != nil {
 				return err
 			}
-			cmdArgs[i] = wslPath
+			nerdctlCmdArgs[i] = wslPath
 		}
 	}
 	return nil
 }
 
 // this is the handler for image build command. It translates build context to wsl path.
-func imageBuildHandler(systemDeps NerdctlCommandSystemDeps, cmdArgs []string) error {
+func imageBuildHandler(systemDeps NerdctlCommandSystemDeps, nerdctlCmdArgs []string) error {
 	var err error
-	argLen := len(cmdArgs) - 1
+	argLen := len(nerdctlCmdArgs) - 1
 	// -h/--help don't have buildcontext, just return
-	for _, a := range cmdArgs {
+	for _, a := range nerdctlCmdArgs {
 		if a == "--help" || a == "-h" {
 			return nil
 		}
 	}
-	if cmdArgs[argLen] != "--debug" {
-		cmdArgs[argLen], err = convertToWSLPath(systemDeps, cmdArgs[argLen])
+	if nerdctlCmdArgs[argLen] != "--debug" {
+		nerdctlCmdArgs[argLen], err = convertToWSLPath(systemDeps, nerdctlCmdArgs[argLen])
 		if err != nil {
 			return err
 		}
 	} else {
-		cmdArgs[argLen-1], err = convertToWSLPath(systemDeps, cmdArgs[argLen-1])
+		nerdctlCmdArgs[argLen-1], err = convertToWSLPath(systemDeps, nerdctlCmdArgs[argLen-1])
 		if err != nil {
 			return err
 		}

--- a/cmd/finch/nerdctl_windows.go
+++ b/cmd/finch/nerdctl_windows.go
@@ -10,10 +10,7 @@ import (
 )
 
 func convertToWSLPath(systemDeps NerdctlCommandSystemDeps, winPath string) (string, error) {
-	var path = filepath.Clean(winPath)
-	var err error
-
-	path, err = systemDeps.FilePathAbs(winPath)
+	path, err := systemDeps.FilePathAbs(filepath.Clean(winPath))
 	if err != nil {
 		return "", err
 	}
@@ -28,6 +25,7 @@ func convertToWSLPath(systemDeps NerdctlCommandSystemDeps, winPath string) (stri
 	return path, nil
 }
 
+// substitues wsl path for the provided option in place for nerdctl args
 func handleFilePath(systemDeps NerdctlCommandSystemDeps, args []string, index int) error {
 	var prefix = args[index]
 
@@ -47,12 +45,13 @@ func handleFilePath(systemDeps NerdctlCommandSystemDeps, args []string, index in
 			}
 			args[index+1] = wslPath
 		} else {
-			fmt.Errorf("invalid positional parameter for %s", prefix)
+			return fmt.Errorf("invalid positional parameter for %s", prefix)
 		}
 	}
 	return nil
 }
 
+// hanldes -v/--volumes option. For anonymous volumes and named volumes this is no-op. For bind mounts path is converted to wsl path.
 func handleVolume(systemDeps NerdctlCommandSystemDeps, args []string, index int) error {
 	var prefix = args[index]
 	var v = ""
@@ -64,7 +63,7 @@ func handleVolume(systemDeps NerdctlCommandSystemDeps, args []string, index int)
 		if (index + 1) < len(args) {
 			v = args[index+1]
 		} else {
-			fmt.Errorf("invalid positional parameter for %s", prefix)
+			return fmt.Errorf("invalid positional parameter for %s", prefix)
 		}
 	}
 	cleanArg := v
@@ -107,21 +106,257 @@ func handleVolume(systemDeps NerdctlCommandSystemDeps, args []string, index int)
 	return nil
 }
 
+// translates source path of the bind mount to wslpath for --mount option
+func handleBindMounts(systemDeps NerdctlCommandSystemDeps, args []string, index int) error {
+	var prefix = args[index]
+	var v = ""
+	var found = false
+	var before = ""
+	if strings.Contains(args[index], "=") {
+		before, v, found = strings.Cut(prefix, "=")
+	} else {
+		if (index + 1) < len(args) {
+			v = args[index+1]
+		} else {
+			return fmt.Errorf("invalid positional parameter for %s", prefix)
+		}
+	}
+
+	// https://docs.docker.com/storage/bind-mounts/#choose-the--v-or---mount-flag  order does not matter, so convert to a map
+	entries := strings.Split(v, ",")
+	m := make(map[string]string)
+	ro := []string{}
+	for _, e := range entries {
+		parts := strings.Split(e, "=")
+		// eg --mount type=bind,source="$(pwd)"/target,target=/app,readonly
+		if len(parts) < 2 {
+			ro = append(ro, parts...)
+		} else {
+			m[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+		}
+	}
+	// Check if type is bind mount, else return
+	if m["type"] != "bind" {
+		return nil
+	}
+	var k string
+	path, ok := m["src"]
+	if !ok {
+		path, ok = m["source"]
+		k = "source"
+	} else {
+		k = "src"
+	}
+	// If there is no src or source or not a windows path, do nothing, let nerdctl handle error
+	if !ok || !strings.Contains(path, `\`) {
+		return nil
+	}
+	wslPath, err := convertToWSLPath(systemDeps, path)
+	if err != nil {
+		return err
+	}
+	m[k] = wslPath
+
+	// Convert to string representation
+	s := mapToString(m)
+	// append read-only key if present
+	if len(ro) > 0 {
+		s = s + "," + strings.Join(ro, ",")
+	}
+	if found {
+		args[index] = fmt.Sprintf("%s=%s", before, s)
+	} else {
+		args[index+1] = s
+	}
+
+	return nil
+}
+
+// handles --output/-o for build command
+func handleOutputOption(systemDeps NerdctlCommandSystemDeps, args []string, index int) error {
+	var prefix = args[index]
+	var v = ""
+	var found = false
+	var before = ""
+	if strings.Contains(args[index], "=") {
+		before, v, found = strings.Cut(prefix, "=")
+	} else {
+		if (index + 1) < len(args) {
+			v = args[index+1]
+		} else {
+			return fmt.Errorf("invalid positional parameter for %s", prefix)
+		}
+	}
+
+	// https://docs.docker.com/engine/reference/commandline/build/ order does not matter, so convert to a map
+	entries := strings.Split(v, ",")
+	m := make(map[string]string)
+	for _, e := range entries {
+		parts := strings.Split(e, "=")
+		m[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+	}
+	dest, ok := m["dest"]
+	if !ok {
+		return nil
+	}
+	wslPath, err := convertToWSLPath(systemDeps, dest)
+	if err != nil {
+		return err
+	}
+	m["dest"] = wslPath
+
+	// Convert to string representation
+	s := mapToString(m)
+
+	if found {
+		args[index] = fmt.Sprintf("%s=%s", before, s)
+	} else {
+		args[index+1] = s
+	}
+
+	return nil
+}
+
+// handles --secret option for build command.
+func handleSecretOption(systemDeps NerdctlCommandSystemDeps, args []string, index int) error {
+	var prefix = args[index]
+	var v = ""
+	var found = false
+	var before = ""
+	if strings.Contains(args[index], "=") {
+		before, v, found = strings.Cut(prefix, "=")
+	} else {
+		if (index + 1) < len(args) {
+			v = args[index+1]
+		} else {
+			return fmt.Errorf("invalid positional parameter for %s", prefix)
+		}
+	}
+
+	entries := strings.Split(v, ",")
+	m := make(map[string]string)
+	for _, e := range entries {
+		parts := strings.Split(e, "=")
+		m[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+	}
+	sp, ok := m["src"]
+	if !ok {
+		return nil
+	}
+	wslPath, err := convertToWSLPath(systemDeps, sp)
+	if err != nil {
+		return err
+	}
+	m["src"] = wslPath
+
+	// Convert to string representation
+	s := mapToString(m)
+
+	if found {
+		args[index] = fmt.Sprintf("%s=%s", before, s)
+	} else {
+		args[index+1] = s
+	}
+
+	return nil
+}
+
+// cp command handler, takes command arguments and converts hostpath to wsl path in place. It ignores all other arguments
+func cpHandler(systemDeps NerdctlCommandSystemDeps, cmdArgs []string) error {
+	for i, arg := range cmdArgs {
+		// -L and --follow-symlink don't have to be processed
+		if strings.HasPrefix(arg, "-") || arg == "cp" {
+			continue
+		} else {
+			// If argument contains container path, then continue
+			colon := strings.Index(arg, ":")
+
+			// this is a container path
+			if colon > 1 {
+				continue
+			}
+			wslPath, err := convertToWSLPath(systemDeps, arg)
+			if err != nil {
+				return err
+			}
+			cmdArgs[i] = wslPath
+		}
+	}
+	return nil
+}
+
+// this is the handler for image build command. It translates build context to wsl path.
+func imageBuildHandler(systemDeps NerdctlCommandSystemDeps, cmdArgs []string) error {
+	var err error
+	argLen := len(cmdArgs) - 1
+	// -h/--help don't have buildcontext, just return
+	for _, a := range cmdArgs {
+		if a == "--help" || a == "-h" {
+			return nil
+		}
+	}
+	if cmdArgs[argLen] != "--debug" {
+		cmdArgs[argLen], err = convertToWSLPath(systemDeps, cmdArgs[argLen])
+		if err != nil {
+			return err
+		}
+	} else {
+		cmdArgs[argLen-1], err = convertToWSLPath(systemDeps, cmdArgs[argLen-1])
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 var aliasMap = map[string]string{
 	"build": "image build",
+	"save":  "image save",
+	"load":  "image load",
 	"cp":    "container cp",
 	"run":   "container run",
 }
 
 var argHandlerMap = map[string]map[string]argHandler{
 	"image build": {
-		"-f":     handleFilePath,
-		"--file": handleFilePath,
+		"-f":        handleFilePath,
+		"--file":    handleFilePath,
+		"--iidfile": handleFilePath,
+		"-o":        handleOutputOption,
+		"--output":  handleOutputOption,
+		"--secret":  handleSecretOption,
+	},
+	"image save": {
+		"-o":       handleFilePath,
+		"--output": handleFilePath,
+	},
+	"image load": {
+		"-i":      handleFilePath,
+		"--input": handleFilePath,
 	},
 	"container run": {
 		"--label-file": handleFilePath,
 		"--cosign-key": handleFilePath,
+		"--cidfile":    handleFilePath,
 		"-v":           handleVolume,
 		"--volume":     handleVolume,
+		"--mount":      handleBindMounts,
 	},
+	"compose": {
+		"--file": handleFilePath,
+	},
+}
+
+var commandHandlerMap = map[string]commandHandler{
+	"container cp": cpHandler,
+	"image build":  imageBuildHandler,
+}
+
+func mapToString(m map[string]string) string {
+	var parts []string
+	for k, v := range m {
+		part := fmt.Sprintf("%s=%s", k, v)
+		parts = append(parts, part)
+	}
+	return strings.Join(parts, ",")
 }

--- a/pkg/command/lima_test.go
+++ b/pkg/command/lima_test.go
@@ -312,6 +312,7 @@ func TestLimaCmdCreator_RunWithReplacingStdout(t *testing.T) {
 			stdout, err := os.ReadFile(stdoutFilepath)
 			require.NoError(t, err)
 			assert.Equal(t, tc.outOut, string(stdout))
+			assert.NoError(t, stdoutFile.Close())
 			assert.NoError(t, os.Remove(stdoutFilepath))
 		})
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,8 +30,8 @@ type AdditionalDirectory struct {
 
 // Finch represents the configuration file for Finch CLI.
 type Finch struct {
-	CPUs   *int    `yaml:"cpus"`
-	Memory *string `yaml:"memory"`
+	CPUs   *int    `yaml:"cpus,omitempty"`
+	Memory *string `yaml:"memory,omitempty"`
 	// Snapshotters: the snapshotters that will be installed and configured automatically on vm init or on vm start.
 	// Values: `soci` for SOCI snapshotter; `overlayfs` for default overlay snapshotter.
 	Snapshotters []string `yaml:"snapshotters,omitempty"`

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -4,11 +4,6 @@
 package config
 
 import (
-	"math"
-
-	"github.com/docker/go-units"
-	"github.com/xorcare/pointer"
-
 	"github.com/runfinch/finch/pkg/fmemory"
 )
 
@@ -29,26 +24,4 @@ func applyDefaults(cfg *Finch, deps LoadSystemDeps, mem fmemory.Memory) *Finch {
 	rosettaDefault(cfg)
 
 	return cfg
-}
-
-func memoryDefault(cfg *Finch, mem fmemory.Memory) {
-	if cfg.Memory == nil {
-		defaultMemory := math.Round(float64(mem.TotalMemory()) * 0.25)
-		if defaultMemory >= fallbackMemory {
-			cfg.Memory = pointer.String(units.BytesSize(defaultMemory))
-		} else {
-			cfg.Memory = pointer.String(units.BytesSize(fallbackMemory))
-		}
-	}
-}
-
-func cpuDefault(cfg *Finch, deps LoadSystemDeps) {
-	if cfg.CPUs == nil {
-		defaultCPUs := int(math.Round(float64(deps.NumCPU()) * 0.25))
-		if defaultCPUs >= fallbackCPUs {
-			cfg.CPUs = pointer.Int(defaultCPUs)
-		} else {
-			cfg.CPUs = pointer.Int(fallbackCPUs)
-		}
-	}
 }

--- a/pkg/config/defaults_darwin.go
+++ b/pkg/config/defaults_darwin.go
@@ -19,3 +19,25 @@ func rosettaDefault(cfg *Finch) {
 		cfg.Rosetta = pointer.Bool(false)
 	}
 }
+
+func memoryDefault(cfg *Finch, mem fmemory.Memory) {
+	if cfg.Memory == nil {
+		defaultMemory := math.Round(float64(mem.TotalMemory()) * 0.25)
+		if defaultMemory >= fallbackMemory {
+			cfg.Memory = pointer.String(units.BytesSize(defaultMemory))
+		} else {
+			cfg.Memory = pointer.String(units.BytesSize(fallbackMemory))
+		}
+	}
+}
+
+func cpuDefault(cfg *Finch, deps LoadSystemDeps) {
+	if cfg.CPUs == nil {
+		defaultCPUs := int(math.Round(float64(deps.NumCPU()) * 0.25))
+		if defaultCPUs >= fallbackCPUs {
+			cfg.CPUs = pointer.Int(defaultCPUs)
+		} else {
+			cfg.CPUs = pointer.Int(fallbackCPUs)
+		}
+	}
+}

--- a/pkg/config/defaults_test.go
+++ b/pkg/config/defaults_test.go
@@ -102,13 +102,8 @@ func Test_applyDefaults(t *testing.T) {
 			name: "happy path",
 			cfg:  &Finch{},
 			mockSvc: func(deps *mocks.LoadSystemDeps, mem *mocks.Memory) {
-				deps.EXPECT().NumCPU().Return(8)
-				// 12,884,901,888 == 12GiB
-				mem.EXPECT().TotalMemory().Return(uint64(12_884_901_888))
 			},
 			want: &Finch{
-				CPUs:   pointer.Int(2),
-				Memory: pointer.String("3GiB"),
 				VMType: pointer.String("wsl2"),
 			},
 		},
@@ -118,14 +113,9 @@ func Test_applyDefaults(t *testing.T) {
 				VMType: pointer.String("wsl"),
 			},
 			mockSvc: func(deps *mocks.LoadSystemDeps, mem *mocks.Memory) {
-				deps.EXPECT().NumCPU().Return(8)
-				// 12,884,901,888 == 12GiB
-				mem.EXPECT().TotalMemory().Return(uint64(12_884_901_888))
 
 			},
 			want: &Finch{
-				CPUs:   pointer.Int(2),
-				Memory: pointer.String("3GiB"),
 				VMType: pointer.String("wsl"),
 			},
 		},

--- a/pkg/config/defaults_windows.go
+++ b/pkg/config/defaults_windows.go
@@ -5,7 +5,10 @@
 
 package config
 
-import "github.com/xorcare/pointer"
+import (
+	"github.com/runfinch/finch/pkg/fmemory"
+	"github.com/xorcare/pointer"
+)
 
 // Does not matter if Rosetta is set, no-op
 func rosettaDefault(cfg *Finch) {
@@ -15,4 +18,12 @@ func vmDefault(cfg *Finch) {
 	if cfg.VMType == nil {
 		cfg.VMType = pointer.String("wsl2")
 	}
+}
+
+// no-op , not configurable in wsl
+func memoryDefault(cfg *Finch, mem fmemory.Memory) {
+}
+
+// no-op , not configurable in wsl
+func cpuDefault(cfg *Finch, deps LoadSystemDeps) {
 }

--- a/pkg/config/validate_darwin.go
+++ b/pkg/config/validate_darwin.go
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build darwin
+
 package config
 
 import (

--- a/pkg/config/validate_darwin_test.go
+++ b/pkg/config/validate_darwin_test.go
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build darwin
+
 package config
 
 import (

--- a/pkg/config/validate_windows.go
+++ b/pkg/config/validate_windows.go
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package config
+
+import (
+	"github.com/runfinch/finch/pkg/flog"
+	"github.com/runfinch/finch/pkg/fmemory"
+)
+
+func validate(cfg *Finch, log flog.Logger, systemDeps LoadSystemDeps, mem fmemory.Memory) error {
+	return nil
+}


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- introduces aliases for nerdctl commands. Eg `nerdctl run` is equivalent to `nerdctl container run`. cli commands are restructured based on https://www.docker.com/blog/whats-new-in-docker-1-13/ , `nerdctl container run` is the recommended way of using the cli. This also helps in handling options for commands and avoids duplication for having to handle the same options for equivalent commands such as `run` and `container run`. 
- introduces command handlers. command handlers are functions that handle arguments of a specific command. For example `cpHandler`, handles `nerdctl cp` command. It has a one to one mapping with nerdctl commands that need command handling. 
- introduces argHandlers, which handle particular options in nerdctl commands. These are not tied to a specific command. For instance `handleFilePath` function can handle `-f/--file` option in `nerdctl build`. It can also handle `--label-file` in `nerdctl run` command. The mapping is defined by `argHandlerMap`. 


*Testing done:*
Yes, unit tests added for cmdhandler and argHandlers. all container e2e tests and passed.

----- 
#### Notes 
There were several options considered for translating windows filepaths to wsl filepaths for nerdctl commands. 

* add logic [handleEnv](https://github.com/runfinch/finch/blob/main/cmd/finch/nerdctl.go#L229) function to handle options. This approach had several disadvantages
    *  options require different handling depending on the command. For instance -f/--file option in build command has different semantics to -f in rm command. 
    *  Not extensible if new options are added to nerdctl command.
* search and replace. match every argument in a nerdctl to a windows filepath. If a match is found then replace it with it's equivalent wsl filepath. This approach also has a couple of problems. 

    * There is no perfect regex to match windows paths in nerdctl commands. Windows paths can have spaces and can also be relative paths and when used in conjunction with nerdctl commands there is ambiguity. Eg nerdctl cp C:\\Test USER conname:<containerpath>. Do we match C:\\Test USER or C:\\Test USER conname since both are valid windows paths. 
    * Matching every argument adds to the  computation cost of parsing nerdctl commands.
    
Therefore the choice was made to have a mapping between commands and options with the path translation logic which can guarantee correctness in handling nerdctl arguments(if implemented correctly :) ) and is extensible.

For macOS, the handers are no-op. We can refactor [handling logic ](https://github.com/runfinch/finch/blob/main/cmd/finch/nerdctl.go#L229) in a later PR. 

-------
  
- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
