### PR TITLE
fix: update run test windows

### DIFF
--- a/e2e/container/container_test.go
+++ b/e2e/container/container_test.go
@@ -43,7 +43,7 @@ func TestContainer(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			// wsl2 cgroup v2 is mounted at /sys/fs/cgroup/unified,
 			// containerd expects it at /sys/fs/cgroup based on https://github.com/containerd/cgroups/blob/cc78c6c1e32dc5bde018d92999910fdace3cfa27/utils.go#L36
-			tests.Run(&tests.RunOption{BaseOpt: o, CGMode: tests.Unavailable, DefaultHostGatewayIP: "192.168.5.2"})
+			tests.Run(&tests.RunOption{BaseOpt: o, CGMode: tests.Hybrid, DefaultHostGatewayIP: "192.168.5.2"})
 
 		} else {
 			tests.Run(&tests.RunOption{BaseOpt: o, CGMode: tests.Unified, DefaultHostGatewayIP: "192.168.5.2"})

--- a/e2e/container/container_test.go
+++ b/e2e/container/container_test.go
@@ -5,6 +5,7 @@
 package container
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -39,7 +40,14 @@ func TestContainer(t *testing.T) {
 		tests.Pull(o)
 		tests.Rm(o)
 		tests.Rmi(o)
-		tests.Run(&tests.RunOption{BaseOpt: o, CGMode: tests.Unified, DefaultHostGatewayIP: "192.168.5.2"})
+		if runtime.GOOS == "windows" {
+			// wsl2 cgroup v2 is mounted at /sys/fs/cgroup/unified,
+			// containerd expects it at /sys/fs/cgroup based on https://github.com/containerd/cgroups/blob/cc78c6c1e32dc5bde018d92999910fdace3cfa27/utils.go#L36
+			tests.Run(&tests.RunOption{BaseOpt: o, CGMode: tests.Unavailable, DefaultHostGatewayIP: "192.168.5.2"})
+
+		} else {
+			tests.Run(&tests.RunOption{BaseOpt: o, CGMode: tests.Unified, DefaultHostGatewayIP: "192.168.5.2"})
+		}
 		tests.Start(o)
 		tests.Stop(o)
 		tests.Cp(o)


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Update run tests related to cgroup v2 resource flag tests for windows.

In wsl2 cgroup v2 is mounted at /sys/fs/cgroup/unified but containerd expects it to be mounted at /sys/fs/cgroup https://github.com/containerd/cgroups/blob/cc78c6c1e32dc5bde018d92999910fdace3cfa27/utils.go#L36. 

Enabling cgroup v2 requires extra tweaks in wsl 2 based on https://stackoverflow.com/questions/73021599/how-to-enable-cgroup-v2-in-wsl2
*Testing done:*
Yes. 


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
