### PR TITLE
fix: use correct URL for rootfs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,8 @@ else ifneq (,$(findstring x86_64,$(ARCH)))
 	# From https://dl.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/
 	FINCH_OS_BASENAME ?= Fedora-Cloud-Base-38-1.6.x86_64-20230918164920.qcow2
 	LIMA_URL ?= https://deps.runfinch.com/x86-64/lima-and-qemu.macos-x86_64.1695247723.tar.gz
-	FINCH_ROOTFS_URL ?= https://deps.runfinch.com/common/x86-64/finch-rootfs-production-amd64-1693001442.tar
+	FINCH_ROOTFS_URL ?= https://deps.runfinch.com/common/x86-64/finch-rootfs-production-amd64-1694791577.tar.gz
 	FINCH_ROOTFS_BASENAME := $(notdir $(FINCH_ROOTFS_URL))
-	FINCH_ROOTFS_BASENAME := $(subst .gz,,$(FINCH_ROOTFS_BASENAME))
 endif
 
 FINCH_OS_HASH := `$(sha) $(OUTDIR)/os/$(FINCH_OS_BASENAME) | cut -d ' ' -f 1`


### PR DESCRIPTION
Issue #, if available:

Mismatch in rootfs between finch and finch-core on respective windev branches - both in the version and in the file referenced. finch-core is correctly providing full .tar.gz extension and latest rootfs.

Evident in jobs:

* https://github.com/runfinch/finch/actions/runs/6386280972/job/17332665289?pr=584
* https://github.com/runfinch/finch/actions/runs/6386379434/job/17332965393?pr=584

*Description of changes:*

*Testing done:*

Validated on windows dev instance. 

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
