### PR TITLE
ci: add GOOS to golangci-lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,11 @@ jobs:
       - run: make test-unit
   # It's recommended to run golangci-lint in a job separate from other jobs (go test, etc) because different jobs run in parallel.
   go-linter:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+    name: lint
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4

--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,8 @@ gen-code:
 .PHONY: lint
 # To run golangci-lint locally: https://golangci-lint.run/usage/install/#local-installation
 lint:
-	golangci-lint run
+	env GOOS=windows golangci-lint run
+	env GOOS=darwin golangci-lint run
 
 .PHONY: mdlint
 # Install it locally: https://github.com/igorshubovych/markdownlint-cli#installation


### PR DESCRIPTION
Issue #, if available:
Add GOOS to golangci-lint. Currently the golangci-lint runs on ubuntu.
*Description of changes:*
- Change target lint in makefile to run linter for both windows and macOS. 
- Update ci.yaml to lint on macOS and windows github hosted runners.
*Testing done:*
Makefile changes validated. 


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
