### PR TITLE
fix: fix file perm

### DIFF
--- a/benchmark/suite.go
+++ b/benchmark/suite.go
@@ -99,7 +99,7 @@ func (suite *Suite) BenchmarkImageBuild(b *testing.B) {
 	dockerFilePath := filepath.Join(tempDir, "Dockerfile")
 	err = os.WriteFile(dockerFilePath, []byte(fmt.Sprintf(`FROM %s
 			CMD ["echo", "finch-test-dummy-output"]
-			`, alpineImage)), 0o644)
+			`, alpineImage)), 0o600)
 	assert.NoError(b, err)
 	buildContext := filepath.Dir(dockerFilePath)
 	defer os.RemoveAll(buildContext) //nolint:errcheck // testing only

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -99,7 +99,7 @@ func writeConfig(cfg *Finch, fs afero.Fs, path string) error {
 		return fmt.Errorf("failed to write to marshal config: %w", err)
 	}
 
-	if err := afero.WriteFile(fs, path, cfgBuf, 0o755); err != nil {
+	if err := afero.WriteFile(fs, path, cfgBuf, 0o600); err != nil {
 		return fmt.Errorf("failed to write to config file: %w", err)
 	}
 
@@ -113,7 +113,7 @@ func ensureConfigDir(fs afero.Fs, path string, log flog.Logger) error {
 	}
 	if !dirExists {
 		log.Infof("%q directory doesn't exist, attempting to create it", path)
-		if err := fs.Mkdir(path, 0o755); err != nil {
+		if err := fs.Mkdir(path, 0o700); err != nil {
 			return fmt.Errorf("failed to create config directory: %w", err)
 		}
 	}

--- a/pkg/config/lima_config_applier.go
+++ b/pkg/config/lima_config_applier.go
@@ -87,7 +87,7 @@ func (lca *limaConfigApplier) Apply(isInit bool) error {
 	if cfgExists, err := afero.Exists(lca.fs, lca.limaConfigPath); err != nil {
 		return fmt.Errorf("error checking if file at path %s exists, error: %w", lca.limaConfigPath, err)
 	} else if !cfgExists {
-		if err := afero.WriteFile(lca.fs, lca.limaConfigPath, []byte(""), 0o644); err != nil {
+		if err := afero.WriteFile(lca.fs, lca.limaConfigPath, []byte(""), 0o600); err != nil {
 			return fmt.Errorf("failed to create the an empty lima config file: %w", err)
 		}
 	}
@@ -156,7 +156,7 @@ func (lca *limaConfigApplier) Apply(isInit bool) error {
 		return fmt.Errorf("failed to marshal the lima config file: %w", err)
 	}
 
-	if err := afero.WriteFile(lca.fs, lca.limaConfigPath, limaCfgBytes, 0o644); err != nil {
+	if err := afero.WriteFile(lca.fs, lca.limaConfigPath, limaCfgBytes, 0o600); err != nil {
 		return fmt.Errorf("failed to write to the lima config file: %w", err)
 	}
 

--- a/pkg/config/nerdctl_config_applier.go
+++ b/pkg/config/nerdctl_config_applier.go
@@ -60,7 +60,7 @@ func NewNerdctlApplier(
 func addLineToBashrc(fs afero.Fs, profileFilePath string, profStr string, cmd string) (string, error) {
 	if !strings.Contains(profStr, cmd) {
 		profBufWithCmd := fmt.Sprintf("%s\n%s", profStr, cmd)
-		if err := afero.WriteFile(fs, profileFilePath, []byte(profBufWithCmd), 0o644); err != nil {
+		if err := afero.WriteFile(fs, profileFilePath, []byte(profBufWithCmd), 0o600); err != nil {
 			return "", fmt.Errorf("failed to write to profile file: %w", err)
 		}
 		return profBufWithCmd, nil
@@ -132,12 +132,12 @@ func updateNerdctlConfig(fs afero.Fs, homeDir string, rootless bool) error {
 		cfgPath = nerdctlRootfulCfgPath
 	}
 
-	if err := fs.MkdirAll(path.Dir(cfgPath), 0o755); err != nil {
+	if err := fs.MkdirAll(path.Dir(cfgPath), 0o700); err != nil {
 		return fmt.Errorf("failed to create config dir (dir(filepath)) %s: %w", cfgPath, err)
 	}
 
 	if _, err := fs.Stat(cfgPath); errors.Is(err, afero.ErrFileNotFound) {
-		if err := afero.WriteFile(fs, cfgPath, []byte{}, 0o644); err != nil {
+		if err := afero.WriteFile(fs, cfgPath, []byte{}, 0o600); err != nil {
 			return fmt.Errorf("failed to create %q with afero.WriteFile: %w", cfgPath, err)
 		}
 	}
@@ -159,7 +159,7 @@ func updateNerdctlConfig(fs afero.Fs, homeDir string, rootless bool) error {
 		return fmt.Errorf("failed to marshal config file %q: %w", cfgPath, err)
 	}
 
-	if err := afero.WriteFile(fs, cfgPath, updatedCfg, 0o644); err != nil {
+	if err := afero.WriteFile(fs, cfgPath, updatedCfg, 0o600); err != nil {
 		return fmt.Errorf("failed to write to config file %q: %w", cfgPath, err)
 	}
 

--- a/pkg/dependency/credhelper/cred_helper_binary.go
+++ b/pkg/dependency/credhelper/cred_helper_binary.go
@@ -86,7 +86,7 @@ func updateConfigFile(bin *credhelperbin) error {
 
 		defer fileRead.Close() //nolint:errcheck // closing the file
 		if strings.Compare(credsStore, binCfgName) != 0 {
-			file, err := bin.fs.OpenFile(cfgPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o755)
+			file, err := bin.fs.OpenFile(cfgPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 			if err != nil {
 				return err
 			}
@@ -181,7 +181,7 @@ func (bin *credhelperbin) Install() error {
 		return fmt.Errorf("error installing binary %s, err: %w", bin.hcfg.binaryName, err)
 	}
 
-	err = bin.fs.Chmod(bin.fullInstallPath(), 0o755)
+	err = bin.fs.Chmod(bin.fullInstallPath(), 0o700)
 	if err != nil {
 		return err
 	}

--- a/pkg/disk/disk_unix.go
+++ b/pkg/disk/disk_unix.go
@@ -170,7 +170,7 @@ func (m *userDataDiskManager) attachPersistentDiskToLimaDisk() error {
 		disksDir := path.Dir(m.finch.UserDataDiskPath(m.rootDir))
 		_, err := m.fs.Stat(disksDir)
 		if errors.Is(err, fs.ErrNotExist) {
-			if err := m.fs.MkdirAll(disksDir, 0o755); err != nil {
+			if err := m.fs.MkdirAll(disksDir, 0o700); err != nil {
 				return fmt.Errorf("could not create persistent disk directory: %w", err)
 			}
 		}

--- a/pkg/disk/disk_windows.go
+++ b/pkg/disk/disk_windows.go
@@ -30,7 +30,7 @@ func (m *userDataDiskManager) EnsureUserDataDisk() error {
 	m.logger.Debugf("disksDir: %s", disksDir)
 
 	if _, err := m.fs.Stat(disksDir); errors.Is(err, fs.ErrNotExist) {
-		if err := m.fs.MkdirAll(disksDir, 0o755); err != nil {
+		if err := m.fs.MkdirAll(disksDir, 0o700); err != nil {
 			return fmt.Errorf("could not create persistent disk directory: %w", err)
 		}
 	}


### PR DESCRIPTION
Issue #, if available:
Mitigate excessive permissions on files and directory creation. 
*Description of changes:*
- sets restrictive permissions on files to 0o600 and 0o700 for creating directories.
*Testing done:*
Yes, unit tests and sanity checks. 

```
 grep -RE '[0-9]o[0-9]{3}' --include='*.go' --exclude='*_test.go'
./benchmark/suite.go:                   `, alpineImage)), 0o600)
./deps/finch-core/src/lima/pkg/yqutil/yqutil.go:        err = os.WriteFile(tmpYAMLPath, content, 0o600)
./deps/finch-core/src/lima/pkg/editutil/editutil.go:            0o600); err != nil {
./pkg/config/config.go: if err := afero.WriteFile(fs, path, cfgBuf, 0o600); err != nil {
./pkg/config/config.go:         if err := fs.Mkdir(path, 0o700); err != nil {
./pkg/config/nerdctl_config_applier.go:         if err := afero.WriteFile(fs, profileFilePath, []byte(profBufWithCmd), 0o600); err != nil {
./pkg/config/nerdctl_config_applier.go: if err := fs.MkdirAll(path.Dir(cfgPath), 0o700); err != nil {
./pkg/config/nerdctl_config_applier.go:         if err := afero.WriteFile(fs, cfgPath, []byte{}, 0o600); err != nil {
./pkg/config/nerdctl_config_applier.go: if err := afero.WriteFile(fs, cfgPath, updatedCfg, 0o600); err != nil {
./pkg/config/lima_config_applier.go:            if err := afero.WriteFile(lca.fs, lca.limaConfigPath, []byte(""), 0o600); err != nil {
./pkg/config/lima_config_applier.go:    if err := afero.WriteFile(lca.fs, lca.limaConfigPath, limaCfgBytes, 0o600); err != nil {
./pkg/dependency/vmnet/update_override_lima_config_unix.go:     f, err := overConf.fs.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
./pkg/dependency/credhelper/cred_helper_binary.go:                      file, err := bin.fs.OpenFile(cfgPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
./pkg/dependency/credhelper/cred_helper_binary.go:      err = bin.fs.Chmod(bin.fullInstallPath(), 0o700)
./pkg/disk/disk_unix.go:                        if err := m.fs.MkdirAll(disksDir, 0o700); err != nil {
./pkg/disk/disk_windows.go:             if err := m.fs.MkdirAll(disksDir, 0o700); err != nil {
./pkg/disk/disk_windows.go:             if err := m.fs.MkdirAll(disksDir, 0o700); err != nil {

```



- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
