### PR TITLE
docs(contributing): add note to fetch all tags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,12 @@ If the repo is already cloned, but the submodules are not pulled yet, the follow
 git submodule update --init --recursive
 ```
 
+If you are building on Windows from a fork of finch, you may need to fetch upstream tags in order to build:
+
+```shell
+git fetch <upstream finch remote name> --tags
+```
+
 After cloning the repo, run the following command to make subsequent `git pull` to also update submodules to the versions specified in the upstream branch.
 
 ```shell


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*

upstream dependency go-winres uses `git tag` to embed versioning in Windows binary. However, if the repo from which finch is being built has no tags, build will fail. Add note on how to fetch upstream finch tags.

See https://github.com/tc-hib/go-winres/pull/16

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
