### PR TITLE
fix: cred helper refactor for windows

### DIFF
--- a/cmd/finch/main_darwin.go
+++ b/cmd/finch/main_darwin.go
@@ -25,6 +25,7 @@ func dependencies(
 	fs afero.Fs,
 	lcc command.LimaCmdCreator,
 	logger flog.Logger,
+	finchRootPath string,
 ) []*dependency.Group {
 	return []*dependency.Group{
 		credhelper.NewDependencyGroup(
@@ -33,7 +34,7 @@ func dependencies(
 			fp,
 			logger,
 			fc,
-			system.NewStdLib().Env("USER"),
+			finchRootPath,
 			system.NewStdLib().Arch(),
 		),
 		vmnet.NewDependencyGroup(ecc, lcc, fs, fp, logger),

--- a/cmd/finch/main_windows.go
+++ b/cmd/finch/main_windows.go
@@ -26,6 +26,7 @@ func dependencies(
 	fs afero.Fs,
 	_ command.LimaCmdCreator,
 	logger flog.Logger,
+	finchDir string,
 ) []*dependency.Group {
 	return []*dependency.Group{
 		credhelper.NewDependencyGroup(
@@ -34,7 +35,7 @@ func dependencies(
 			fp,
 			logger,
 			fc,
-			system.NewStdLib().Env("USER"),
+			finchDir,
 			system.NewStdLib().Arch(),
 		),
 	}

--- a/cmd/finch/virtual_machine.go
+++ b/cmd/finch/virtual_machine.go
@@ -108,7 +108,7 @@ func virtualMachineCommands(
 	return newVirtualMachineCommand(
 		lcc,
 		logger,
-		dependencies(ecc, fc, fp, fs, lcc, logger),
+		dependencies(ecc, fc, fp, fs, lcc, logger, fp.FinchDir(finchRootPath)),
 		config.NewLimaApplier(fc, ecc, fs, fp.LimaOverrideConfigPath(), system.NewStdLib()),
 		config.NewNerdctlApplier(
 			fssh.NewDialer(),

--- a/pkg/dependency/credhelper/cred_helper.go
+++ b/pkg/dependency/credhelper/cred_helper.go
@@ -6,6 +6,7 @@ package credhelper
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/spf13/afero"
 
@@ -28,10 +29,10 @@ func NewDependencyGroup(
 	fp path.Finch,
 	logger flog.Logger,
 	fc *config.Finch,
-	user string,
+	finchDir string,
 	arch string,
 ) *dependency.Group {
-	deps := newDeps(execCmdCreator, fs, fp, logger, fc, user, arch)
+	deps := newDeps(execCmdCreator, fs, fp, logger, fc, finchDir, arch)
 	return dependency.NewGroup(deps, description, errMsg)
 }
 
@@ -49,7 +50,7 @@ func newDeps(
 	fp path.Finch,
 	logger flog.Logger,
 	fc *config.Finch,
-	user string,
+	finchDir string,
 	arch string,
 ) []dependency.Dependency {
 	var deps []dependency.Dependency
@@ -63,8 +64,7 @@ func newDeps(
 		return deps
 	}
 	configs := map[string]helperConfig{}
-	installFolder := fmt.Sprintf("/Users/%s/.finch/cred-helpers/", user)
-	finchPath := fmt.Sprintf("/Users/%s/.finch/", user)
+	installFolder := filepath.Join(finchDir, "cred-helpers")
 
 	const versionEcr = "0.7.0"
 	const hashEcr = "sha256:ff14a4da40d28a2d2d81a12a7c9c36294ddf8e6439780c4ccbc96622991f3714"
@@ -74,13 +74,13 @@ func newDeps(
 	hcEcr := helperConfig{
 		binaryName: "docker-credential-ecr-login", credHelperURL: credHelperURLEcr,
 		hash: hashEcr, installFolder: installFolder,
-		finchPath: finchPath,
+		finchPath: finchDir,
 	}
 	configs["ecr-login"] = hcEcr
 
 	for _, helper := range fc.CredsHelpers {
 		if configs[helper] != (helperConfig{}) {
-			binaries := newCredHelperBinary(fp, fs, execCmdCreator, logger, helper, user, configs[helper])
+			binaries := newCredHelperBinary(fp, fs, execCmdCreator, logger, helper, configs[helper])
 			deps = append(deps, dependency.Dependency(binaries))
 		}
 	}

--- a/pkg/dependency/credhelper/cred_helper_binary.go
+++ b/pkg/dependency/credhelper/cred_helper_binary.go
@@ -34,7 +34,7 @@ type credhelperbin struct {
 var _ dependency.Dependency = (*credhelperbin)(nil)
 
 func newCredHelperBinary(fp path.Finch, fs afero.Fs, cmdCreator command.Creator, l flog.Logger, helper string,
-	user string, hcfg helperConfig,
+	hcfg helperConfig,
 ) *credhelperbin {
 	return &credhelperbin{
 		// TODO: consider replacing fp with only the strings that are used instead of the entire type
@@ -43,7 +43,6 @@ func newCredHelperBinary(fp path.Finch, fs afero.Fs, cmdCreator command.Creator,
 		cmdCreator: cmdCreator,
 		l:          l,
 		helper:     helper,
-		user:       user,
 		hcfg:       hcfg,
 	}
 }

--- a/pkg/dependency/credhelper/cred_helper_binary_test.go
+++ b/pkg/dependency/credhelper/cred_helper_binary_test.go
@@ -26,7 +26,7 @@ const (
 func Test_credHelperConfigName(t *testing.T) {
 	t.Parallel()
 
-	got := newCredHelperBinary("", nil, nil, nil, "", "user",
+	got := newCredHelperBinary("", nil, nil, nil, "",
 		helperConfig{
 			"docker-credential-cred-helper", "", "",
 			"", "",
@@ -37,7 +37,7 @@ func Test_credHelperConfigName(t *testing.T) {
 func Test_fullInstallPath(t *testing.T) {
 	t.Parallel()
 
-	got := newCredHelperBinary("", nil, nil, nil, "", "user",
+	got := newCredHelperBinary("", nil, nil, nil, "",
 		helperConfig{
 			"docker-credential-cred-helper", "", "", "/folder/",
 			"",
@@ -127,7 +127,7 @@ func Test_updateConfigFile(t *testing.T) {
 				"mock_prefix/.finch/",
 			}
 			// hash of an empty file
-			got := updateConfigFile(newCredHelperBinary(mockFinchPath, mFs, nil, l, "ecr-login", "", hc))
+			got := updateConfigFile(newCredHelperBinary(mockFinchPath, mFs, nil, l, "ecr-login", hc))
 
 			assert.Equal(t, tc.want, got)
 			tc.postRunCheck(t, mFs)
@@ -202,7 +202,7 @@ func TestBinaries_Installed(t *testing.T) {
 				"mock_prefix/.finch/",
 			}
 			// hash of an empty file
-			got := newCredHelperBinary(mockFinchPath, mFs, nil, l, "", "", hc).Installed()
+			got := newCredHelperBinary(mockFinchPath, mFs, nil, l, "", hc).Installed()
 
 			assert.Equal(t, tc.want, got)
 		})
@@ -260,7 +260,7 @@ func TestBinaries_Install(t *testing.T) {
 				"mock_prefix/.finch/",
 			}
 			fc := "ecr-login"
-			got := newCredHelperBinary(mockFinchPath, mFs, creator, l, fc, "", hc).Install()
+			got := newCredHelperBinary(mockFinchPath, mFs, creator, l, fc, hc).Install()
 			// fmt.Printf("Error is %s", got.Error())
 			assert.Equal(t, tc.want, got)
 		})
@@ -270,7 +270,7 @@ func TestBinaries_Install(t *testing.T) {
 func TestBinaries_RequiresRoot(t *testing.T) {
 	t.Parallel()
 
-	got := newCredHelperBinary(mockFinchPath, nil, nil, nil, "", "",
+	got := newCredHelperBinary(mockFinchPath, nil, nil, nil, "",
 		helperConfig{}).RequiresRoot()
 	assert.Equal(t, false, got)
 }


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Refactor credhelper and remove hard-coded paths. 
*Testing done:*
Yes, can push to ECR 

```
 cat .\config.json
{"credsStore":"ecr-login"}

PS C:\Users\Administrator> finch build -t test-ecr-from-local .
PS C:\Users\Administrator> finch tag test-ecr-from-local:latest 065363855432.dkr.ecr.us-east-2.amazonaws.com/test-ecr-from-local:latest
PS C:\Users\Administrator> finch tag test-ecr-from-local:latest 065363855432.dkr.ecr.us-east-2.amazonaws.com/test-ecr-from-local:latest^C
PS C:\Users\Administrator> finch push 065363855432.dkr.ecr.us-east-2.amazonaws.com/test-ecr-from-local:latest
INFO[0000] pushing as a reduced-platform image (application/vnd.docker.distribution.manifest.v2+json, sha256:317cda6f2c180388322d9134cf8976aac777a5d6cf1a56161ac22e996a1df051)
manifest-sha256:317cda6f2c180388322d9134cf8976aac777a5d6cf1a56161ac22e996a1df051: done           |++++++++++++++++++++++++++++++++++++++|
config-sha256:1cad2846fc76fdde7217fb06db38fbcdccaed71baccc30a7e8ec70f095ea3d11:   done           |++++++++++++++++++++++++++++++++++++++|
elapsed: 1.1 s                                                                    total:  1.1 Ki (1001.0 B/s)
```


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
