### PR TITLE
fix: wsl custom ip mapping

### DIFF
--- a/cmd/finch/main.go
+++ b/cmd/finch/main.go
@@ -113,7 +113,7 @@ var newApp = func(
 	)
 
 	// append nerdctl commands
-	allCommands := initializeNerdctlCommands(lcc, logger, fs)
+	allCommands := initializeNerdctlCommands(ecc, lcc, logger, fs)
 	// append finch specific commands
 	allCommands = append(allCommands,
 		newVersionCommand(lcc, logger, stdOut),
@@ -126,8 +126,8 @@ var newApp = func(
 	return rootCmd
 }
 
-func initializeNerdctlCommands(lcc command.LimaCmdCreator, logger flog.Logger, fs afero.Fs) []*cobra.Command {
-	nerdctlCommandCreator := newNerdctlCommandCreator(lcc, system.NewStdLib(), logger, fs)
+func initializeNerdctlCommands(ecc command.Creator, lcc command.LimaCmdCreator, logger flog.Logger, fs afero.Fs) []*cobra.Command {
+	nerdctlCommandCreator := newNerdctlCommandCreator(ecc, lcc, system.NewStdLib(), logger, fs)
 	var allNerdctlCommands []*cobra.Command
 	for cmdName, cmdDescription := range nerdctlCmds {
 		allNerdctlCommands = append(allNerdctlCommands, nerdctlCommandCreator.create(cmdName, cmdDescription))

--- a/cmd/finch/nerdctl_darwin.go
+++ b/cmd/finch/nerdctl_darwin.go
@@ -11,6 +11,7 @@ import (
 
 	dockerops "github.com/docker/docker/opts"
 	"github.com/lima-vm/lima/pkg/networks"
+
 	"github.com/runfinch/finch/pkg/command"
 	"github.com/runfinch/finch/pkg/flog"
 )
@@ -21,14 +22,13 @@ var argHandlerMap = map[string]map[string]argHandler{}
 
 var commandHandlerMap = map[string]commandHandler{}
 
-func resolveIP(host string, logger flog.Logger, ecc command.Creator) string {
+func resolveIP(host string, logger flog.Logger, ecc command.Creator) (string, error) {
 	parts := strings.SplitN(host, ":", 2)
 	// If the IP Address is a string called "host-gateway", replace this value with the IP address that can be used to
 	// access host from the containers.
 	// TODO: make the host gateway ip configurable.
 	var resolvedIP string
 	if parts[1] == dockerops.HostGatewayName {
-
 		resolvedIP = networks.SlirpGateway
 
 		logger.Debugf(`Resolving special IP "host-gateway" to %q for host %q`, resolvedIP, parts[0])

--- a/cmd/finch/nerdctl_darwin.go
+++ b/cmd/finch/nerdctl_darwin.go
@@ -5,8 +5,34 @@
 
 package main
 
+import (
+	"fmt"
+	"strings"
+
+	dockerops "github.com/docker/docker/opts"
+	"github.com/lima-vm/lima/pkg/networks"
+	"github.com/runfinch/finch/pkg/command"
+	"github.com/runfinch/finch/pkg/flog"
+)
+
 var aliasMap = map[string]string{}
 
 var argHandlerMap = map[string]map[string]argHandler{}
 
 var commandHandlerMap = map[string]commandHandler{}
+
+func resolveIP(host string, logger flog.Logger, ecc command.Creator) string {
+	parts := strings.SplitN(host, ":", 2)
+	// If the IP Address is a string called "host-gateway", replace this value with the IP address that can be used to
+	// access host from the containers.
+	// TODO: make the host gateway ip configurable.
+	var resolvedIP string
+	if parts[1] == dockerops.HostGatewayName {
+
+		resolvedIP = networks.SlirpGateway
+
+		logger.Debugf(`Resolving special IP "host-gateway" to %q for host %q`, resolvedIP, parts[0])
+		return fmt.Sprintf("%s:%s", parts[0], resolvedIP), nil
+	}
+	return host, nil
+}

--- a/cmd/finch/nerdctl_darwin_test.go
+++ b/cmd/finch/nerdctl_darwin_test.go
@@ -284,6 +284,7 @@ func TestNerdctlCommand_run(t *testing.T) {
 			wantErr: nil,
 			mockSvc: func(
 				t *testing.T,
+				ecc *mocks.CommandCreator,
 				lcc *mocks.LimaCmdCreator,
 				ncsd *mocks.NerdctlCommandSystemDeps,
 				logger *mocks.Logger,

--- a/cmd/finch/nerdctl_darwin_test.go
+++ b/cmd/finch/nerdctl_darwin_test.go
@@ -65,7 +65,7 @@ func TestNerdctlCommand_runAdaptor(t *testing.T) {
 			logger := mocks.NewLogger(ctrl)
 			tc.mockSvc(lcc, logger, ctrl, ncsd)
 
-			assert.NoError(t, newNerdctlCommand(lcc, ncsd, logger, nil).runAdapter(tc.cmd, tc.args))
+			assert.NoError(t, newNerdctlCommand(nil, lcc, ncsd, logger, nil).runAdapter(tc.cmd, tc.args))
 		})
 	}
 }
@@ -284,7 +284,6 @@ func TestNerdctlCommand_run(t *testing.T) {
 			wantErr: nil,
 			mockSvc: func(
 				t *testing.T,
-				ecc *mocks.CommandCreator,
 				lcc *mocks.LimaCmdCreator,
 				ncsd *mocks.NerdctlCommandSystemDeps,
 				logger *mocks.Logger,
@@ -623,7 +622,7 @@ func TestNerdctlCommand_run(t *testing.T) {
 			logger := mocks.NewLogger(ctrl)
 			fs := afero.NewMemMapFs()
 			tc.mockSvc(t, lcc, ncsd, logger, ctrl, fs)
-			assert.Equal(t, tc.wantErr, newNerdctlCommand(lcc, ncsd, logger, fs).run(tc.cmdName, tc.args))
+			assert.Equal(t, tc.wantErr, newNerdctlCommand(nil, lcc, ncsd, logger, fs).run(tc.cmdName, tc.args))
 		})
 	}
 }

--- a/cmd/finch/nerdctl_windows.go
+++ b/cmd/finch/nerdctl_windows.go
@@ -6,7 +6,13 @@ package main
 import (
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"strings"
+
+	dockerops "github.com/docker/docker/opts"
+
+	"github.com/runfinch/finch/pkg/command"
+	"github.com/runfinch/finch/pkg/flog"
 )
 
 func convertToWSLPath(systemDeps NerdctlCommandSystemDeps, winPath string) (string, error) {
@@ -358,4 +364,34 @@ func mapToString(m map[string]string) string {
 		parts = append(parts, part)
 	}
 	return strings.Join(parts, ",")
+}
+
+func resolveIP(host string, logger flog.Logger, ecc command.Creator) (string, error) {
+	parts := strings.SplitN(host, ":", 2)
+	// If the IP Address is a string called "host-gateway", replace this value with the IP address that can be used to
+	// access host from the containers.
+	var resolvedIP string
+	if parts[1] == dockerops.HostGatewayName {
+		// get ip address for adapter vEthernet (WSL) to reach host from wsl
+		// https://learn.microsoft.com/en-us/windows/wsl/networking#accessing-windows-networking-apps-from-linux-host-ip
+		out, err := ecc.Create("cmd", "/C", "netsh", "interface", "ipv4", "show", "addresses", "vEthernet (WSL)").Output()
+		if err != nil {
+			return "", err
+		}
+		resolvedIP = extractIPAddress(string(out))
+
+		logger.Debugf(`Resolving special IP "host-gateway" to %q for host %q`, resolvedIP, parts[0])
+		return fmt.Sprintf("%s:%s", parts[0], resolvedIP), nil
+	}
+	return host, nil
+}
+
+func extractIPAddress(data string) string {
+	re := regexp.MustCompile(`IP Address:\s+(\d+\.\d+\.\d+\.\d+)`)
+	match := re.FindStringSubmatch(data)
+
+	if match != nil {
+		return match[1]
+	}
+	return ""
 }

--- a/e2e/container/container_test.go
+++ b/e2e/container/container_test.go
@@ -5,6 +5,8 @@
 package container
 
 import (
+	"os/exec"
+	"regexp"
 	"runtime"
 	"testing"
 
@@ -41,10 +43,15 @@ func TestContainer(t *testing.T) {
 		tests.Rm(o)
 		tests.Rmi(o)
 		if runtime.GOOS == "windows" {
+			// get ip address for adapter vEthernet (WSL)
+			n, err := exec.Command("cmd", "/C", "netsh", "interface", "ipv4", "show",
+				"addresses", "vEthernet (WSL)").Output()
+			gomega.Expect(err).Should(gomega.BeNil())
+			hostIP := extractIPAddress(string(n))
 			// wsl2 cgroup v2 is mounted at /sys/fs/cgroup/unified,
 			// containerd expects it at /sys/fs/cgroup based on
 			// https://github.com/containerd/cgroups/blob/cc78c6c1e32dc5bde018d92999910fdace3cfa27/utils.go#L36
-			tests.Run(&tests.RunOption{BaseOpt: o, CGMode: tests.Hybrid, DefaultHostGatewayIP: "192.168.5.2"})
+			tests.Run(&tests.RunOption{BaseOpt: o, CGMode: tests.Hybrid, DefaultHostGatewayIP: hostIP})
 		} else {
 			tests.Run(&tests.RunOption{BaseOpt: o, CGMode: tests.Unified, DefaultHostGatewayIP: "192.168.5.2"})
 		}
@@ -92,4 +99,14 @@ func TestContainer(t *testing.T) {
 
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, description)
+}
+
+func extractIPAddress(data string) string {
+	re := regexp.MustCompile(`IP Address:\s+(\d+\.\d+\.\d+\.\d+)`)
+	match := re.FindStringSubmatch(data)
+
+	if match != nil {
+		return match[1]
+	}
+	return ""
 }

--- a/pkg/config/lima_config_applier.go
+++ b/pkg/config/lima_config_applier.go
@@ -105,7 +105,8 @@ func (lca *limaConfigApplier) Apply(isInit bool) error {
 
 	// Unmarshall with custom unmarshaler for Disk:
 	// https://github.com/lima-vm/lima/blob/v0.17.2/pkg/limayaml/load.go#L16
-	if err := goyaml.UnmarshalWithOptions(b, &limaCfg, goyaml.DisallowDuplicateKey(), goyaml.CustomUnmarshaler[limayaml.Disk](unmarshalDisk)); err != nil {
+	if err := goyaml.UnmarshalWithOptions(b, &limaCfg, goyaml.DisallowDuplicateKey(),
+		goyaml.CustomUnmarshaler[limayaml.Disk](unmarshalDisk)); err != nil {
 		return fmt.Errorf("failed to unmarshal the lima config file: %w", err)
 	}
 


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- resolve `host-gateway` ip address of "vEthernet (WSL) interface used for connecting from wsl to host.
- this change allows accessing networking apps on windows hosts from finch vm. 
*Testing done:*
- Unit tests
- e2e test with [host-gateway](https://github.com/runfinch/common-tests/blob/main/tests/run.go#L336)


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
