### PR TITLE
ci: Automate signing and upload to installer bucket

### DIFF
--- a/.github/workflows/build-and-test-msi.yaml
+++ b/.github/workflows/build-and-test-msi.yaml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.check-tag.outputs.tag }}
+      version: ${{ steps.check-tag.outputs.version }}
     steps:
       - name: Check tag from workflow input and github ref
         id: check-tag
@@ -33,6 +34,15 @@ jobs:
             tag=${{ github.ref_name }}
           fi
           echo "tag=$tag" >> ${GITHUB_OUTPUT}
+
+          version=${tag#v}
+          if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Version matches format: $version"
+          else
+            echo "Version $version doesn't match format. Using default: 0.0.0"
+            version="0.0.0"
+          fi
+          echo "version=$version" >> ${GITHUB_OUTPUT}
   
   windows-msi-build:
     needs: get-tag-name
@@ -51,27 +61,18 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install awscli
-      - name: Validate aws CLI
-        run: |
-          aws --version
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           ref: ${{ needs.get-tag-name.outputs.tag }}
           fetch-depth: 0
           persist-credentials: false
           submodules: recursive
-      - name: Set output variables
-        id: vars
-        run: |
-          $has_creds="${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name }}"
-          echo "has_creds=$has_creds" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-          exit 0 # if $has_creds is false, powershell will exit with code 1 and this step will fail
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
-          role-to-assume: ${{ secrets.ROLE }}
+          role-to-assume: ${{ secrets.WINDOWS_ROLE }}
           role-session-name: windows-msi
-          aws-region: ${{ secrets.REGION }}
+          aws-region: ${{ secrets.WINDOWS_REGION }}
       - name: Remove Finch VM
         run: |
           wsl --list --verbose
@@ -87,18 +88,41 @@ jobs:
       - name: Build project
         run: |
           make FINCH_ROOTFS_LOCATION_ROOT=/__INSTALLFOLDER__
-      - name: generate msi
+      - name: generate and download signed msi
         run: |
-          $version="${{ needs.get-tag-name.outputs.tag }}"
-          $version=$version.TrimStart("v")
-
-          if ($version -match '^[0-9]+\.[0-9]+\.[0-9]+$') {
-            Write-Host "Version matches format: $version"
-          }
-          else {
-            Write-Host "Version $version doesn't match format. Using default: 0.0.0"
-            $version="0.0.0"
-          }
+          $version="${{ needs.get-tag-name.outputs.version }}"
 
           powershell .\msi-builder\BuildFinchMSI.ps1 -Version $version
-          aws s3 cp "./msi-builder/build/Finch-$version.msi" "s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-$version.msi" --no-progress
+          aws s3 cp "./msi-builder/build/Finch-$version.msi" "${{ secrets.WINDOWS_UNSIGNED_BUCKET }}Finch-$version.msi" --acl bucket-owner-full-control --no-progress
+          New-Item -Path "./msi-builder/build/signed/" -ItemType Directory -Force
+
+          $retryCount = 0
+          $maxRetries = 20
+          $delay = 5
+
+          while ($retryCount -lt $maxRetries) {
+              try {
+                Start-Sleep -Seconds $delay
+                $signedMSI = aws s3 ls ${{ secrets.WINDOWS_SIGNED_BUCKET }} | Where-Object { $_ -match "Finch-$version.msi" } | Sort-Object -Descending | Select-Object -First 1 | ForEach-Object { ($_ -split '\s+')[-1] }
+                aws s3 cp "${{ secrets.WINDOWS_SIGNED_BUCKET }}$signedMSI" "./msi-builder/build/signed/Finch-$version.msi"
+                break
+              } catch {
+                $retryCount++
+                Write-Host "Exception: $_"
+                Write-Host "Retry $retryCount/$maxRetries..."
+              }
+          }
+
+          if ($retryCount -eq $maxRetries) {
+              throw "Failed after $maxRetries attempts."
+          }
+      - name: configure aws credentials for upload signed MSI to installer bucket
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        with:
+          role-to-assume: ${{ secrets.ROLE }}
+          role-session-name: windows-msi
+          aws-region: ${{ secrets.REGION }}
+      - name: upload signed MSI to S3
+        run: |
+          $version="${{ needs.get-tag-name.outputs.version }}"
+          aws s3 cp "./msi-builder/build/signed/Finch-$version.msi" "s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-$version.msi" --no-progress


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Make the MSI upload to unsigned bucket and download it to the final installer bucket automatically

*Testing done:*
Tested the action: https://github.com/runfinch/finch/actions/runs/6501071851/job/17657687196


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
