### PR TITLE
ci: Make unsigned MSI has timestamp in its name to easily unique fetch it back

### DIFF
--- a/.github/workflows/build-and-test-msi.yaml
+++ b/.github/workflows/build-and-test-msi.yaml
@@ -93,23 +93,31 @@ jobs:
           $version="${{ needs.get-tag-name.outputs.version }}"
 
           powershell .\msi-builder\BuildFinchMSI.ps1 -Version $version
-          aws s3 cp "./msi-builder/build/Finch-$version.msi" "${{ secrets.WINDOWS_UNSIGNED_BUCKET }}Finch-$version.msi" --acl bucket-owner-full-control --no-progress
+          $timestamp=[math]::truncate((Get-Date (Get-Date).ToUniversalTime() -UFormat "%s"))
+          $unsignedMSI="Finch-$version-$timestamp.msi"
+          Write-Host "Upload unsigned MSI: $unsignedMSI"
+
+          aws s3 cp "./msi-builder/build/Finch-$version.msi" "${{ secrets.WINDOWS_UNSIGNED_BUCKET }}$unsignedMSI" --acl bucket-owner-full-control --no-progress
           New-Item -Path "./msi-builder/build/signed/" -ItemType Directory -Force
 
+          Write-Host "Attemp to download signed MSI"
           $retryCount = 0
           $maxRetries = 20
           $delay = 5
 
           while ($retryCount -lt $maxRetries) {
-              try {
-                Start-Sleep -Seconds $delay
-                $signedMSI = aws s3 ls ${{ secrets.WINDOWS_SIGNED_BUCKET }} | Where-Object { $_ -match "Finch-$version.msi" } | Sort-Object -Descending | Select-Object -First 1 | ForEach-Object { ($_ -split '\s+')[-1] }
-                aws s3 cp "${{ secrets.WINDOWS_SIGNED_BUCKET }}$signedMSI" "./msi-builder/build/signed/Finch-$version.msi"
-                break
-              } catch {
-                $retryCount++
-                Write-Host "Exception: $_"
-                Write-Host "Retry $retryCount/$maxRetries..."
+              Start-Sleep -Seconds $delay
+              $signedMSI = aws s3 ls ${{ secrets.WINDOWS_SIGNED_BUCKET }} 2>&1 | Where-Object { $_ -match "$unsignedMSI" } | Sort-Object -Descending | Select-Object -First 1 | ForEach-Object { ($_ -split '\s+')[-1] }
+              if ($signedMSI -and ($signedMSI -notlike "*An error occurred (404) when calling the HeadObject operation*")) {
+                  try {
+                      aws s3 cp "${{ secrets.WINDOWS_SIGNED_BUCKET }}$signedMSI" "./msi-builder/build/signed/Finch-$version.msi"
+                      break
+                  } catch {
+                      Write-Host "Error during copy: $_"
+                  }
+              } else {
+                  $retryCount++
+                  Write-Host "Unable to find the signed MSI or encountered an error. Retry $retryCount/$maxRetries..."
               }
           }
 

--- a/.github/workflows/build-and-test-msi.yaml
+++ b/.github/workflows/build-and-test-msi.yaml
@@ -39,8 +39,8 @@ jobs:
           if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Version matches format: $version"
           else
-            echo "Version $version doesn't match format. Using default: 0.0.0"
-            version="0.0.0"
+            echo "Version $version doesn't match format. Using test version: 0.0.1"
+            version="0.0.1"
           fi
           echo "version=$version" >> ${GITHUB_OUTPUT}
   

--- a/msi-builder/postinstall.bat
+++ b/msi-builder/postinstall.bat
@@ -6,6 +6,8 @@ if exist "%FilePath%" (
     powershell -Command "$installPath = '%InstallDir%'.Replace('\', '/'); (Get-Content '%FilePath%') -replace '__INSTALLFOLDER__', $installPath | Set-Content '%FilePath%'"
 )
 
+icacls "%InstallDir%\lima\data" /grant Users:(OI)(CI)M
+
 :: Delete files and directories if they exist
 if exist "%InstallDir%\lima\data\finch\" rmdir /s /q "%InstallDir%\lima\data\finch\"
 if exist "%InstallDir%\lima\data\_config\override.yaml" del /f /q "%InstallDir%\lima\data\_config\override.yaml"


### PR DESCRIPTION
*Description of changes:*
When uploading the unsigned to S3, the signer will assign a random postfix to the original MSI.
However, since 0.0.0 is a common test install name, it is hard to uniquely identify the signed MSI since there can be historical ones. Added timestamp in the name so that it can be easily fetched back.

*Testing done:*
Tested with this action run: https://github.com/runfinch/finch/actions/runs/6503614023/job/17664348385


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
