### PR TITLE
ci: MSI e2e test automation and upload MSI to release

### DIFF
--- a/.github/workflows/build-and-test-msi.yaml
+++ b/.github/workflows/build-and-test-msi.yaml
@@ -134,3 +134,90 @@ jobs:
         run: |
           $version="${{ needs.get-tag-name.outputs.version }}"
           aws s3 cp "./msi-builder/build/signed/Finch-$version.msi" "s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-$version.msi" --no-progress
+  
+  msi-e2e-tests:
+    needs:
+      - get-tag-name
+      - windows-msi-build
+    strategy:
+      fail-fast: false
+    runs-on: [self-hosted, windows, amd64, release]
+    timeout-minutes: 180
+    steps:
+      - name: Configure git CRLF settings
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+      - name: Set up Python
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
+        with:
+          python-version: '3.x'
+      - name: Install AWS CLI
+        run: |
+          python -m pip install --upgrade pip
+          pip install awscli
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        with:
+          ref: ${{ needs.get-tag-name.outputs.tag }}
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: recursive
+      - name: Set output variables
+        id: vars
+        run: |
+          $has_creds="${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name }}"
+          echo "has_creds=$has_creds" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+          exit 0 # if $has_creds is false, powershell will exit with code 1 and this step will fail
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.ROLE }}
+          role-session-name: msi-test
+          aws-region: ${{ secrets.REGION }}
+      - name: Remove Finch VM
+        run: |
+          wsl --list --verbose
+          wsl --shutdown
+          wsl --unregister lima-finch
+          wsl --list --verbose
+      - name: Clean up previous files
+        run: |
+          Remove-Item C:\Users\Administrator\.finch -Recurse -ErrorAction Ignore
+          Remove-Item C:\Users\Administrator\AppData\Local\.finch -Recurse -ErrorAction Ignore
+      - name: Uninstall Finch silently
+        run: |
+          $productCode = (Get-WmiObject -Class Win32_Product | Where-Object { $_.Name -like "*Finch*" } | Select-Object -ExpandProperty IdentifyingNumber)
+          if ($productCode) {
+              msiexec /x $productCode /qn
+          } else {
+              Write-Output "Finch not found or it wasn't installed using MSI."
+          }
+      - name: Download MSI from S3
+        run: |
+          $version="${{ needs.get-tag-name.outputs.version }}"
+          aws s3 cp "s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-$version.msi" ./Finch.msi
+      - name: Install MSI silently
+        run: |
+          Start-Process 'Finch.msi' -ArgumentList '/quiet' -Wait
+          echo "C:\Program Files\Finch\bin" >> $env:GITHUB_PATH
+      - name: Run e2e tests
+        run: |
+          # set path to use newer ssh version
+          $newPath = (";C:\Program Files\Git\bin\;" + "C:\Program Files\Git\usr\bin\;" + "$env:Path")
+          $env:Path = $newPath
+          # set networking config option to allow for VM/container -> host communication
+          echo "[experimental]`nnetworkingMode=mirrored`nhostAddressLoopback=true" > C:\Users\Administrator\.wslconfig
+          
+          git status
+          git clean -f -d
+          $env:INSTALLED="true"
+          make test-e2e
+      - name: Uninstall Finch silently
+        if: always()
+        run: |
+          $productCode = (Get-WmiObject -Class Win32_Product | Where-Object { $_.Name -like "*Finch*" } | Select-Object -ExpandProperty IdentifyingNumber)
+          if ($productCode) {
+              msiexec /x $productCode /qn
+          } else {
+              Write-Output "Finch not found or it wasn't installed using MSI."
+          }

--- a/.github/workflows/upload-msi-to-release.yaml
+++ b/.github/workflows/upload-msi-to-release.yaml
@@ -1,0 +1,60 @@
+name: Upload installer
+on:
+  workflow_dispatch: # Trigger this workflow from tag
+  workflow_call:
+    inputs:
+      ref_name:
+        required: true
+        type: string
+
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: write   # This is required for uploading the release assets
+jobs:
+  get-version-tag:
+    name: Get the version, tag and validate the format
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.check-tag.outputs.tag }}
+      version: ${{ steps.check-tag.outputs.version }}
+    steps:
+      - name: Check tag from workflow input and github ref
+        id: check-tag
+        run: |
+          if [ -n "${{ inputs.ref_name }}" ]; then
+            tag=${{ inputs.ref_name }}
+          else
+            tag=${{ github.ref_name }}
+          fi
+          echo "tag=$tag" >> ${GITHUB_OUTPUT}
+
+          version=${tag#v}
+          if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Version matches format: $version"
+          else
+            echo "Error: Version $version doesn't match format."
+            exit 1
+          fi
+          echo "version=$version" >> ${GITHUB_OUTPUT}
+
+  upload-windows-msi:
+    needs: get-version-tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        with:
+          role-to-assume: ${{ secrets.ROLE }}
+          role-session-name: download-installer-session
+          aws-region: ${{ secrets.REGION }}
+      - name: Download installers and dependency source code
+        run: |
+          aws s3 cp s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-${{ get-version-tag.outputs.version }}.msi Finch-${{ get-version-tag.outputs.version }}.msi
+      - name: Upload installers and dependency source code to release
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
+        with:
+          tag_name: ${{ get-version-tag.outputs.tag }}
+          files: |
+            Finch-${{ get-version-tag.outputs.version }}.msi
+      - name: Delete installers and dependency source code
+        run: rm -rf Finch-${{ get-version-tag.outputs.version }}.msi


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
To achieve the one-click release for Windows, added MSI e2e tests and a new action to upload MSI to github release.

*Testing done:*
MSI e2e tests validation done;
Upload MSI to release action can only be validated during the release.


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
