### PR TITLE
ci: Update msi name to include the branch/tag name instead of the version

### DIFF
--- a/.github/workflows/build-and-test-msi.yaml
+++ b/.github/workflows/build-and-test-msi.yaml
@@ -91,10 +91,10 @@ jobs:
       - name: generate and download signed msi
         run: |
           $version="${{ needs.get-tag-name.outputs.version }}"
-
+          $tag="${{ needs.get-tag-name.outputs.tag }}"
           powershell .\msi-builder\BuildFinchMSI.ps1 -Version $version
           $timestamp=[math]::truncate((Get-Date (Get-Date).ToUniversalTime() -UFormat "%s"))
-          $unsignedMSI="Finch-$version-$timestamp.msi"
+          $unsignedMSI="Finch-$tag-$timestamp.msi"
           Write-Host "Upload unsigned MSI: $unsignedMSI"
 
           aws s3 cp "./msi-builder/build/Finch-$version.msi" "${{ secrets.WINDOWS_UNSIGNED_BUCKET }}$unsignedMSI" --acl bucket-owner-full-control --no-progress
@@ -110,7 +110,7 @@ jobs:
               $signedMSI = aws s3 ls ${{ secrets.WINDOWS_SIGNED_BUCKET }} 2>&1 | Where-Object { $_ -match "$unsignedMSI" } | Sort-Object -Descending | Select-Object -First 1 | ForEach-Object { ($_ -split '\s+')[-1] }
               if ($signedMSI -and ($signedMSI -notlike "*An error occurred (404) when calling the HeadObject operation*")) {
                   try {
-                      aws s3 cp "${{ secrets.WINDOWS_SIGNED_BUCKET }}$signedMSI" "./msi-builder/build/signed/Finch-$version.msi"
+                      aws s3 cp "${{ secrets.WINDOWS_SIGNED_BUCKET }}$signedMSI" "./msi-builder/build/signed/Finch-$tag.msi"
                       break
                   } catch {
                       Write-Host "Error during copy: $_"
@@ -132,8 +132,8 @@ jobs:
           aws-region: ${{ secrets.REGION }}
       - name: upload signed MSI to S3
         run: |
-          $version="${{ needs.get-tag-name.outputs.version }}"
-          aws s3 cp "./msi-builder/build/signed/Finch-$version.msi" "s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-$version.msi" --no-progress
+          $tag="${{ needs.get-tag-name.outputs.tag }}"
+          aws s3 cp "./msi-builder/build/signed/Finch-$tag.msi" "s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-$tag.msi" --no-progress
   
   msi-e2e-tests:
     needs:
@@ -194,8 +194,8 @@ jobs:
           }
       - name: Download MSI from S3
         run: |
-          $version="${{ needs.get-tag-name.outputs.version }}"
-          aws s3 cp "s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-$version.msi" ./Finch.msi
+          $tag="${{ needs.get-tag-name.outputs.tag }}"
+          aws s3 cp "s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-$tag.msi" ./Finch.msi
       - name: Install MSI silently
         run: |
           Start-Process 'Finch.msi' -ArgumentList '/quiet' -Wait

--- a/.github/workflows/upload-msi-to-release.yaml
+++ b/.github/workflows/upload-msi-to-release.yaml
@@ -49,12 +49,12 @@ jobs:
           aws-region: ${{ secrets.REGION }}
       - name: Download installers and dependency source code
         run: |
-          aws s3 cp s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-${{ get-version-tag.outputs.version }}.msi Finch-${{ get-version-tag.outputs.version }}.msi
+          aws s3 cp s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-${{ get-version-tag.outputs.tag }}.msi Finch-${{ get-version-tag.outputs.tag }}.msi
       - name: Upload installers and dependency source code to release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
         with:
           tag_name: ${{ get-version-tag.outputs.tag }}
           files: |
-            Finch-${{ get-version-tag.outputs.version }}.msi
+            Finch-${{ get-version-tag.outputs.tag }}.msi
       - name: Delete installers and dependency source code
-        run: rm -rf Finch-${{ get-version-tag.outputs.version }}.msi
+        run: rm -rf Finch-${{ get-version-tag.outputs.tag }}.msi


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Make the MSI file have the branch/tag reduce the confusion about the build source.
The actual version will remain 0.0.1

*Test done:*
Validated with this action run: https://github.com/runfinch/finch/actions/runs/6513549300

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
