### PR TITLE
[ci]: Fix clean up step for signed artifact

### DIFF
--- a/installer-builder/tools/artifact-helper.sh
+++ b/installer-builder/tools/artifact-helper.sh
@@ -38,7 +38,7 @@ downloadSignedExecutables() {
     fi
 
     tar xzvf "./installer-builder/output/executables/signed/finch-executables-${1//_/-}.zip" -C ./installer-builder/output/executables/signed
-    aws s3 "rm s3://${2}-${1//_/-}/pre-signed/package.tar.gz"
+    aws s3 rm "s3://${2}-${1//_/-}/pre-signed/package.tar.gz"
 }
 
 #$1: arch: {x86_64, aarch64}


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Fix the error in pkg build in aws: "error: argument subcommand: Invalid choice" introduced in https://github.com/runfinch/finch/pull/458/files#diff-0134cf9698393331b869104a3488e7a44bd4c112dbb3b6a10b0acbb7b26f886aR41

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
