### PR TITLE
ci: auto update binary dependencies

### DIFF
--- a/.github/workflows/sync-submodules-and-deps.yaml
+++ b/.github/workflows/sync-submodules-and-deps.yaml
@@ -46,6 +46,34 @@ jobs:
         run: |
           ./deps/finch-core/bin/update-rootfs.sh -d ${{ secrets.DEPENDENCY_BUCKET_NAME }}
 
+      - name: Check for latest SOCI version
+        id: soci-version-check
+        uses: pozetroninc/github-action-get-latest-release@d1dafdb6e338bdab109e6afce581a01858680dfb
+        with:
+          owner: awslabs
+          repo: soci-snapshotter
+          excludes: "prerelease, draft"
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update SOCI snapshotter
+        run: |
+          VERSION=$(echo ${{ steps.soci-version-check.outputs.release }} | tr -d 'v')
+          sed -E -i.bak "s/[0-9]+\.[0-9]+\.[0-9]+/$VERSION/"  ./pkg/config/lima_config_applier.go
+
+      - name: Check for latest ECR credential helper version
+        id: ecr-credential-helper-version-check
+        uses: pozetroninc/github-action-get-latest-release@d1dafdb6e338bdab109e6afce581a01858680dfb
+        with:
+          owner: awslabs
+          repo:  amazon-ecr-credential-helper
+          excludes: "prerelease, draft"
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update ECR credential helper
+        run: |
+          VERSION=$(echo ${{ steps.ecr-credential-helper-version-check.outputs.release }} | tr -d 'v')
+          sed -E -i.bak "s/[0-9]+\.[0-9]+\.[0-9]+/$VERSION/" ./pkg/dependency/cred_helper.go
+
       - name: Create PR
         uses: peter-evans/create-pull-request@v5
         with:

--- a/pkg/dependency/credhelper/cred_helper.go
+++ b/pkg/dependency/credhelper/cred_helper.go
@@ -19,6 +19,8 @@ import (
 const (
 	description = "Installing Credential Helper"
 	errMsg      = "Failed to finish installing credential helper"
+	versionEcr  = "0.7.0"
+	hashEcr     = "sha256:ff14a4da40d28a2d2d81a12a7c9c36294ddf8e6439780c4ccbc96622991f3714"
 )
 
 // NewDependencyGroup returns a dependency group that contains all the dependencies required to make credhelper work.
@@ -66,8 +68,6 @@ func newDeps(
 	installFolder := fmt.Sprintf("/Users/%s/.finch/cred-helpers/", user)
 	finchPath := fmt.Sprintf("/Users/%s/.finch/", user)
 
-	const versionEcr = "0.7.0"
-	const hashEcr = "sha256:ff14a4da40d28a2d2d81a12a7c9c36294ddf8e6439780c4ccbc96622991f3714"
 	credHelperURLEcr := fmt.Sprintf("https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com"+
 		"/%s/linux-%s/docker-credential-ecr-login", versionEcr, arch)
 


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*

This PR adds automation to support upgrading SOCI and ECR Cred helper dependencies to their latest versions. Finch hardcodes the SHA of the ECR Credential Helper binary for the arm64 architecture to be used in checking for if it has been `Installed()`. However, this logic likely needs to be reworked as Finch supports both x86_64 and ARM architectures. Checking for previously installed ECR cred helper can be done in a separate PR.

Issue opened to track ECR cred helper hash refactor: #663

This PR makes use of the [Get Latest Release](https://github.com/marketplace/actions/get-latest-release?version=v0.7.0) action

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
