### PR TITLE
fix: soci being reset on vm stop/start

### DIFF
--- a/pkg/config/lima_config_applier.go
+++ b/pkg/config/lima_config_applier.go
@@ -23,17 +23,14 @@ const (
 	sociFileNameFormat                       = "soci-snapshotter-%s-linux-%s.tar.gz"
 	sociDownloadURLFormat                    = "https://github.com/awslabs/soci-snapshotter/releases/download/v%s/%s"
 	sociServiceDownloadURLFormat             = "https://raw.githubusercontent.com/awslabs/soci-snapshotter/v%s/soci-snapshotter.service"
-	sociInstallationScriptFormat             = `%s
+	//nolint:lll // command string
+	sociInstallationScriptFormat = `%s
 if [ ! -f /usr/local/bin/soci ]; then
 	# download soci
 	set -e
 	curl --retry 2 --retry-max-time 120 -OL "%s"
 	# move to usr/local/bin
 	tar -C /usr/local/bin -xvf %s soci soci-snapshotter-grpc
-	# changing containerd config
-	echo "    [proxy_plugins.soci]
-	type = \"snapshot\"
-	address = \"/run/soci-snapshotter-grpc/soci-snapshotter-grpc.sock\" " >> /etc/containerd/config.toml
 
 	# install as a systemd service
 	curl --retry 2 --retry-max-time 120 -OL "%s"
@@ -43,6 +40,11 @@ if [ ! -f /usr/local/bin/soci ]; then
 	systemctl daemon-reload
 	sudo systemctl add-requires soci-snapshotter.service containerd.service
 	systemctl enable --now soci-snapshotter
+fi
+
+# changing containerd config, this seems to get reset on every VM stop/start
+if ! grep -q soci /etc/containerd/config.toml; then
+	printf '    [proxy_plugins.soci]\n      type = "snapshot"\n      address = "/run/soci-snapshotter-grpc/soci-snapshotter-grpc.sock"\n' >> /etc/containerd/config.toml
 fi
 
 sudo systemctl restart containerd.service


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Not sure why, but containerd's config file gets reset every time we relaunch the VM, so I just separate the "download" and "configure" logic to keep the script idempotent
- TODO: Move this all into a separate "config_applier", similar to the `nerdctl_config_applier` so that there can be more logic around the "already installed" checks

*Testing done:*
- Local testing, an e2e test for this is a nice TODO though


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
