### PR TITLE
fix: Fix to remove the virtual machine storage in deps/finch-core/dow…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,6 +327,7 @@ clean:
 	-sudo rm -rf "/private/etc/sudoers.d/finch-lima"
 	-@rm -rf $(OUTDIR) 2>/dev/null || true
 	-@rm -rf ./deps/finch-core/_output || true
+	-@rm -rf ./deps/finch-core/downloads/os/$(FINCH_OS_BASENAME) || true
 	-@rm ./*.tar.gz 2>/dev/null || true
 	-@rm ./*.qcow2 2>/dev/null || true
 	-@rm ./test-coverage.* 2>/dev/null || true


### PR DESCRIPTION
…nloads/os by make clean

Issue #, if available: #537

*Description of changes:*

In finch, when booting a virtual machine using Lima, it is necessary to download the virtual machine storage in QCOW2 format.

The QCOW2 virtual machine storage thus downloaded and located in deps/finch-core/downloads/os is not deleted when make clean is run in the home directory as currently implemented.

This file may be larger than 500 MB in size and is reported in issue/#537 such that it is expected to be deleted when make clean is run.

Therefore, this fix will remove the QCOW2 format downloaded files in deps/finch-core/downloads/os when make clean is run in the home directory.

*Testing done:* yes

- [x] I've reviewed the guidance in CONTRIBUTING.md

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---------

