### PR TITLE
fix: Clean up all previous finch version installation registries in postinstall and uninstall

### DIFF
--- a/installer-builder/darwin/Resources/uninstall.sh
+++ b/installer-builder/darwin/Resources/uninstall.sh
@@ -27,7 +27,7 @@ echo "[1/3] [DONE] Successfully deleted shortcut links"
 echo "Remove historical pkgutil packages..."
 pkgutil --pkgs | grep '^org\.Finch\.' | while read -r pkg; do
     echo "Forgetting package $pkg"
-    sudo pkgutil --forget "$pkg"
+    sudo pkgutil --forget "$pkg" > /dev/null 2>&1
 done
 
 if [ $? -eq 0 ]

--- a/installer-builder/darwin/Resources/uninstall.sh
+++ b/installer-builder/darwin/Resources/uninstall.sh
@@ -24,7 +24,12 @@ if [ "$$(readlink "/usr/local/bin/finch")" = "/Applications/Finch/bin/finch" ]; 
 echo "[1/3] [DONE] Successfully deleted shortcut links"
 
 #forget from pkgutil
-pkgutil --forget "org.Finch.__VERSION__" > /dev/null 2>&1
+echo "Remove historical pkgutil packages..."
+pkgutil --pkgs | grep '^org\.Finch\.' | while read -r pkg; do
+    echo "Forgetting package $pkg"
+    sudo pkgutil --forget "$pkg"
+done
+
 if [ $? -eq 0 ]
 then
   echo "[2/3] [DONE] Successfully deleted application informations"

--- a/installer-builder/darwin/scripts/postinstall
+++ b/installer-builder/darwin/scripts/postinstall
@@ -25,4 +25,11 @@ sudo rm -rf "/opt/finch/"
 sudo rm -rf "/private/var/run/finch-lima"
 sudo rm -rf "/private/etc/sudoers.d/finch-lima"
 
+# Forget previous pkgutil packages starting with org.Finch except for the current version
+echo "Remove historical pkgutil packages..."
+pkgutil --pkgs | grep '^org\.Finch\.' | grep -v '^org\.Finch\.__VERSION__' | while read -r pkg; do
+    echo "Forgetting package $pkg"
+    sudo pkgutil --forget "$pkg"
+done
+
 echo "Post installation process finished."


### PR DESCRIPTION
Issue #, if available:
https://github.com/runfinch/finch/issues/687
Old finch installation registry remains if uninstall script not explicitly called, the mac will treat a new installation with upgrade info message.

*Description of changes:*
Added a full clean up step in the postinstall script to remove all old registries except the current installed version. Also make the uninstall script not only remove the current but also remove all historical registry record.

*Testing done:*
Tested with cloud build: https://github.com/runfinch/finch/actions/runs/6791189430
Also validated locally with pkg installation:
```
// Before install the fixed pkg, it print all finch registries
% pkgutil --pkgs | grep '^org\.Finch'
org.Finch.v0.8.0
org.Finch.pkg-tool
org.Finch.v0.7.0
org.Finch.v0.6.2
org.Finch.main
org.Finch.0.6.0
org.Finch.0.4.1
org.Finch.0.4.0

// After install the fixed pkg, it only has the current registry
% pkgutil --pkgs | grep '^org\.Finch'
org.Finch.fix-unregistry

// After execute uninstall, all the registries are removed
% pkgutil --pkgs | grep '^org\.Finch'
% // empty
```


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
