### PR TITLE
fix: Fix to delete ~/.finch when uninstalling finch

### DIFF
--- a/installer-builder/darwin/Resources/uninstall.sh
+++ b/installer-builder/darwin/Resources/uninstall.sh
@@ -21,7 +21,7 @@ sudo pkill '^limactl'
 
 if [ "$(readlink '/usr/local/bin/finch')" = "/Applications/Finch/bin/finch" ]; then sudo rm /usr/local/bin/finch; fi
 
-echo "[1/3] [DONE] Successfully deleted shortcut links"
+echo "[1/4] [DONE] Successfully deleted shortcut links"
 
 #forget from pkgutil
 echo "Remove historical pkgutil packages..."
@@ -32,18 +32,27 @@ done
 
 if [ $? -eq 0 ]
 then
-  echo "[2/3] [DONE] Successfully deleted application informations"
+  echo "[2/4] [DONE] Successfully deleted application informations"
 else
-  echo "[2/3] [ERROR] Could not delete application informations" >&2
+  echo "[2/4] [ERROR] Could not delete application informations" >&2
 fi
 
 #remove application source distribution
 [ -e "/Applications/Finch" ] && rm -rf /Applications/Finch && rm -rf /opt/finch && rm -rf /private/var/run/finch-lima && rm -rf /private/etc/sudoers.d/finch-lima
 if [ $? -eq 0 ]
 then
-  echo "[3/3] [DONE] Successfully deleted application"
+  echo "[3/4] [DONE] Successfully deleted application"
 else
-  echo "[3/3] [ERROR] Could not delete application" >&2
+  echo "[3/4] [ERROR] Could not delete application" >&2
+fi
+
+#clean up ~/.finch directory
+[ -d ~/.finch ] && rm -rf ~/.finch
+if [ $? -eq 0 ]
+then
+  echo "[4/4] [DONE] Successfully deleted ~/.finch"
+else
+  echo "[4/4] [ERROR] Could not delete ~/.finch" >&2
 fi
 
 echo "Application uninstall process finished"

--- a/installer-builder/darwin/Resources/uninstall.sh
+++ b/installer-builder/darwin/Resources/uninstall.sh
@@ -47,13 +47,26 @@ else
 fi
 
 #clean up ~/.finch directory
-[ -d ~/.finch ] && rm -rf ~/.finch
-if [ $? -eq 0 ]
-then
-  echo "[4/4] [DONE] Successfully deleted ~/.finch"
-else
-  echo "[4/4] [ERROR] Could not delete ~/.finch" >&2
-fi
+while true; do
+  read -r -p "Delete ~/.finch containing persistent user data [Y/n]? " answer
+  if [[ $answer == "y" || $answer == "Y" || $answer == "" ]]
+  then
+    [ -d ~/.finch ] && rm -rf ~/.finch
+    if [ $? -eq 0 ]
+    then
+        echo "[4/4] [DONE] Successfully deleted ~/.finch"
+    else
+        echo "[4/4] [ERROR] Could not delete ~/.finch" >&2
+    fi
+    break
+  elif [[ $answer == "n" || $answer == "N" ]]
+  then
+    echo "[4/4] Deletion of ~/.finch was aborted."
+    break
+  else
+    echo "Please answer with 'y' or 'n'"
+  fi
+done
 
 echo "Application uninstall process finished"
 exit 0


### PR DESCRIPTION
In the current implementation, uninstalling finch does not delete the ~/.finch directory.

This directory may hold several GB of container data disks, which can consume a lot of space and be left unremoved.

This issue has also been reported in issue/#457 and needs to be fixed.

Therefore, this fix will ensure that when finch is uninstalled, ~/.finch is also deleted to free up disk space for finch.

Issue #, if available: issue/#457

*Description of changes:* Details are described in commit messages.

*Testing done:* Yes



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
