### PR TITLE
fix: use LimaUser method instead of host user name

### DIFF
--- a/cmd/finch/main.go
+++ b/cmd/finch/main.go
@@ -90,6 +90,7 @@ var newApp = func(logger flog.Logger, fp path.Finch, fs afero.Fs, fc *config.Fin
 		fp.QEMUBinDir(),
 		system.NewStdLib(),
 	)
+	lima := wrapper.NewLimaWrapper()
 	supportBundleBuilder := support.NewBundleBuilder(
 		logger,
 		fs,
@@ -97,7 +98,7 @@ var newApp = func(logger flog.Logger, fp path.Finch, fs afero.Fs, fc *config.Fin
 		fp,
 		ecc,
 		lcc,
-		wrapper.NewLimaWrapper(),
+		lima,
 	)
 
 	// append nerdctl commands
@@ -105,7 +106,7 @@ var newApp = func(logger flog.Logger, fp path.Finch, fs afero.Fs, fc *config.Fin
 	// append finch specific commands
 	allCommands = append(allCommands,
 		newVersionCommand(lcc, logger, stdOut),
-		virtualMachineCommands(logger, fp, lcc, ecc, fs, fc),
+		virtualMachineCommands(logger, fp, lcc, ecc, fs, fc, lima),
 		newSupportBundleCommand(logger, supportBundleBuilder, lcc),
 		newGenDocsCommand(rootCmd, logger, fs, system.NewStdLib()),
 	)
@@ -122,6 +123,7 @@ func virtualMachineCommands(
 	ecc *command.ExecCmdCreator,
 	fs afero.Fs,
 	fc *config.Finch,
+	lima wrapper.LimaWrapper,
 ) *cobra.Command {
 	optionalDepGroups := []*dependency.Group{
 		vmnet.NewDependencyGroup(ecc, lcc, fs, fp, logger),
@@ -133,7 +135,7 @@ func virtualMachineCommands(
 		logger,
 		optionalDepGroups,
 		config.NewLimaApplier(fc, ecc, fs, fp.LimaOverrideConfigPath(), system.NewStdLib()),
-		config.NewNerdctlApplier(fssh.NewDialer(), fs, fp.LimaSSHPrivateKeyPath(), system.NewStdLib().Env("USER")),
+		config.NewNerdctlApplier(fssh.NewDialer(), fs, fp.LimaSSHPrivateKeyPath(), lima),
 		fp,
 		fs,
 		disk.NewUserDataDiskManager(lcc, ecc, &afero.OsFs{}, fp, system.NewStdLib().Env("HOME"), fc),

--- a/pkg/config/nerdctl_config_applier_test.go
+++ b/pkg/config/nerdctl_config_applier_test.go
@@ -199,7 +199,6 @@ func TestNerdctlConfigApplier_Apply(t *testing.T) {
 	testCases := []struct {
 		name       string
 		path       string
-		hostUser   string
 		remoteAddr string
 		mockSvc    func(t *testing.T, fs afero.Fs, d *mocks.Dialer)
 		want       error
@@ -208,7 +207,6 @@ func TestNerdctlConfigApplier_Apply(t *testing.T) {
 			name:       "private key path doesn't exist",
 			path:       "/private-key",
 			remoteAddr: "",
-			hostUser:   "mock-host-user",
 			mockSvc: func(t *testing.T, fs afero.Fs, d *mocks.Dialer) {
 			},
 			want: fmt.Errorf(
@@ -241,9 +239,10 @@ func TestNerdctlConfigApplier_Apply(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			fs := afero.NewMemMapFs()
 			d := mocks.NewDialer(ctrl)
+			lima := mocks.NewMockLimaWrapper(ctrl)
 
 			tc.mockSvc(t, fs, d)
-			got := NewNerdctlApplier(d, fs, tc.path, tc.hostUser).Apply(tc.remoteAddr)
+			got := NewNerdctlApplier(d, fs, tc.path, lima).Apply(tc.remoteAddr)
 
 			assert.Equal(t, tc.want, got)
 		})


### PR DESCRIPTION
Issue #, if available: #399

*Description of changes:*
In `nerdctl_config_applier.go`, editing `.bashrc` uses a file path based on the host's username. However, if the host's username contains `.` or `@`, lima uses `lima` as the username instead of the host's username. Therefore, if the host's user name contains `.` or `@`, editing `.bashrc` fails.
This PR fixes this so that you can get the actual username from `LimaWrapper.LimaUser()`.


*Testing done:* yes


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
