### PR TITLE
docs: Update a link for the struct link with a full list of configura…

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The installer will install Finch and its dependencies in its own area of your sy
 
 Finch has a simple and extensible configuration. A configuration file at `${HOME}/.finch/finch.yaml` will be generated on first run. Currently, this config file has options for system resource limits for the underlying virtual machine. These default limits are generated dynamically based on the resources available on the host system, but can be changed by manually editing the config file.
 
-For a full list of configuration options, check [the struct here](pkg/config/config.go#L30).
+For a full list of configuration options, check [the struct here](pkg/config/config.go#L34).
 
 An example `finch.yaml` looks like this:
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The installer will install Finch and its dependencies in its own area of your sy
 
 Finch has a simple and extensible configuration. A configuration file at `${HOME}/.finch/finch.yaml` will be generated on first run. Currently, this config file has options for system resource limits for the underlying virtual machine. These default limits are generated dynamically based on the resources available on the host system, but can be changed by manually editing the config file.
 
-For a full list of configuration options, check [the struct here](pkg/config/config.go#L34).
+For a full list of configuration options, check [the struct here](https://github.com/runfinch/finch/blob/main/pkg/config/config.go#L34).
 
 An example `finch.yaml` looks like this:
 


### PR DESCRIPTION
…tion options for ${HOME}/.finch/finch.yaml

At this time, the following "the struct here" link in README.md was not updated.

  ```
  For a full list of configuration options, check the struct here.
  ```

Therefore, this commit fixes the "the struct here" link to link the updated struct code.

Issue #, if available: N/A

*Description of changes:* Detail are described in the commit message.

*Testing done:* N/A



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
