### PR TITLE
fix: Fix to allow users to configure disk size for finch space

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ vmType: "qemu"
 # Only available when using vmType "vz" on Apple Silicon running macOS 13+.
 # If true, also sets vmType to "vz".
 rosetta: false
+# finchDiskSize: the amount of disk size allocated for finch space in the virtual machine. (optional)
+# Only takes effect when a new VM is launched (only on vm init).
+finchDiskSize: 50GB
 ```
 
 ### FAQ

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,6 +55,9 @@ type Finch struct {
 	// Has no effect on systems where Rosetta 2 is not available (Intel/AMD64 macs, or macOS < 13.0).
 	// This setting will only be applied on vm init.
 	Rosetta *bool `yaml:"rosetta,omitempty"`
+	// FinchDiskSize: the amount of disk size allocated for finch space in the virtual machine.
+	// This setting will only be applied on vm init.
+	FinchDiskSize *string `yaml:"finchDiskSize,omitempty"`
 }
 
 // Nerdctl is a copy from github.com/containerd/nerdctl/cmd/nerdctl/main.go

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -22,6 +22,10 @@ import (
 const (
 	// diskName must always be consistent with the value under additionalDisks in finch.yaml.
 	diskName = "finch"
+)
+
+var (
+	// the amount of disk size allocated for finch space in the virtual machine.
 	diskSize = "50G"
 )
 
@@ -191,6 +195,9 @@ func (m *userDataDiskManager) convertToRaw(diskPath string) error {
 }
 
 func (m *userDataDiskManager) createLimaDisk() error {
+	if m.config.FinchDiskSize != nil {
+		diskSize = *m.config.FinchDiskSize
+	}
 	cmd := m.lcc.CreateWithoutStdio("disk", "create", diskName, "--size", diskSize, "--format", "raw")
 	if logs, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to create disk, debug logs:\n%s", logs)


### PR DESCRIPTION
In the current implementation, the disk space allocated for finch is hard-coded with a fixed value of 50G. Therefore, when users pull large docker images and use more than 50G of the allocated finch space, "no space left on device" error may occur.

As mentioned above, the disk size available for finch is fixed at 50GB and cannot be set by users. To work around this setting, they need to rewrite the hard-coded parts and use their own build of finch, but this is very time-consuming.

Alternatively, they can use the following method to change the disk size.

- https://github.com/runfinch/finch/issues/275#issuecomment-1577010453

Thus, although there is some workarounds to adjust the disk size for finch, users will be able to use finch more flexibly if they are able to specify the disk size that finch can use at the time of vm init.

Therefore, this fix improves usability by allowing users to run "finch vm init" and flexibly set the size of the disk created for finch based on the finchDiskSize in ~/.finch/finch.yaml.

Note that for finch at present, the size of finchDiskSize becomes the disk size of the finch area only when the vm is initialized ("finch vm init").

Issue #, if available: No

*Description of changes:* Detail are described in this commit message.

*Testing done:* Yes



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
