### PR TITLE
fix: Change the default behavoir for deleting .finch folder to false when uninstall

### DIFF
--- a/installer-builder/darwin/Resources/uninstall.sh
+++ b/installer-builder/darwin/Resources/uninstall.sh
@@ -49,7 +49,7 @@ fi
 #clean up ~/.finch directory
 while true; do
   read -r -p "Delete ~/.finch containing persistent user data [Y/n]? " answer
-  if [[ $answer == "y" || $answer == "Y" || $answer == "" ]]
+  if [[ $answer == "y" || $answer == "Y" ]]
   then
     [ -d ~/.finch ] && rm -rf ~/.finch
     if [ $? -eq 0 ]
@@ -59,7 +59,7 @@ while true; do
         echo "[4/4] [ERROR] Could not delete ~/.finch" >&2
     fi
     break
-  elif [[ $answer == "n" || $answer == "N" ]]
+  elif [[ $answer == "n" || $answer == "N" || $answer == "" ]]
   then
     echo "[4/4] Deletion of ~/.finch was aborted."
     break


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
To make homebrew keep the .finch folder when uninstall, change the uninstall script default option to not deleting the .finch folder

*Testing done:*
Tested locally by modifying the script after homebrew installation


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
