### PR TITLE
ci: move from manifest to config file

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -9,5 +9,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: google-github-actions/release-please-action@v4
-        with:
-          release-type: go

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,27 +1,3 @@
 {
-    ".": {
-        "package-name": "finch",
-        "changelog-sections": [
-            {
-                "type": "feat",
-                "section": "Features",
-                "hidden": false
-            },
-            {
-                "type": "fix",
-                "section": "Bug Fixes",
-                "hidden": false
-            },
-            {
-                "type": "exp",
-                "section": "Experimental",
-                "hidden": false
-            },
-            {
-                "type": "build",
-                "section": "Build System or External Dependencies",
-                "hidden": false
-            }
-        ]
-    }
+    ".": "1.0.1"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,64 @@
+{
+    "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+    "release-type": "go",
+    "changelog-sections": [
+        {
+            "type": "build",
+            "section": "Build System or External Dependencies",
+            "hidden": false
+        },
+        {
+            "type": "exp",
+            "section": "Experimental",
+            "hidden": false
+        },
+        {
+            "type": "feat",
+            "section": "Features",
+            "hidden": false
+        },
+        {
+            "type": "fix",
+            "section": "Bug Fixes",
+            "hidden": false
+        },
+        {
+            "type": "revert",
+            "section": "Reverts",
+            "hidden": false
+        },
+        {
+            "type": "chore",
+            "section": "Miscellaneous Chores",
+            "hidden": true
+        },
+        {
+            "type": "docs",
+            "section": "Documentation",
+            "hidden": true
+        },
+        {
+            "type": "refactor",
+            "section": "Code Refactoring",
+            "hidden": true
+        },
+        {
+            "type": "test",
+            "section": "Tests",
+            "hidden": true
+        },
+        {
+            "type": "build",
+            "section": "Build System",
+            "hidden": true
+        },
+        {
+            "type": "ci",
+            "section": "Continuous Integration",
+            "hidden": true
+        }
+    ],
+    "packages": {
+        ".": {}
+    }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -48,11 +48,6 @@
             "hidden": true
         },
         {
-            "type": "build",
-            "section": "Build System",
-            "hidden": true
-        },
-        {
             "type": "ci",
             "section": "Continuous Integration",
             "hidden": true


### PR DESCRIPTION
Issue #, if available: release-please action not triggering as expected, see [errors](https://github.com/runfinch/finch/actions/runs/7292396775/job/20104474662) and previous PR (https://github.com/runfinch/finch/pull/738)

*Description of changes:*
- I re-read the release-please-action [documentation](https://github.com/google-github-actions/release-please-action?tab=readme-ov-file#advanced-release-configuration), and I think I put the config in the wrong file in my previous PR.
- Followed the instructions [here](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md) to create a manifest release since that seems to be what release-please requires when using a config file on v4
- Moved release-type to the config file instead of the yaml directly because the action [seems to branch](https://github.com/google-github-actions/release-please-action/blob/cc61a07e2da466bebbc19b3a7dd01d6aecb20d1e/src/index.ts#L83) its behavior depending on if that's present or not
 
*Testing done:*
- Tested on my fork, but its hard to replicate the upstream perfectly


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
