### PR TITLE
ci: disable secrets for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,11 +141,11 @@ jobs:
       - name: Set output variables
         id: vars
         run: |
-          has_creds=${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name }}
+          has_creds=${{ (github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name) && github.actor != 'dependabot[bot]' }}
           echo "has_creds=$has_creds" >> $GITHUB_OUTPUT
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
-        if: steps.vars.outputs.has_creds == true
+        if: ${{ steps.vars.outputs.has_creds == true }}
         with:
           role-to-assume: ${{ secrets.ROLE }}
           role-session-name: credhelper-test
@@ -202,7 +202,7 @@ jobs:
       - name: Set output variables
         id: vars
         run: |
-          $has_creds="${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name }}"
+          $has_creds="${{ (github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name) && github.actor != 'dependabot[bot]'}}"
           echo "has_creds=$has_creds" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
           exit 0 # if $has_creds is false, powershell will exit with code 1 and this step will fail
       - name: configure aws credentials


### PR DESCRIPTION
Issue #, if available: https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544

*Description of changes:*
We've seen several tests fail lately, mainly on Windows, for the reason that the `aws-actions/configure-aws-credentials` action is failing [like so](https://github.com/runfinch/finch/actions/runs/7477790251/job/20351287299):
```
Run aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a
  with:
    role-session-name: credhelper-test
    audience: sts.amazonaws.com
  env:
    has_creds: true
Error: Input required and not supplied: aws-region
```

The role-to-assume and aws-region aren't even passed into the action as inputs. Since this seems to only happen on Windows and on dependabot PRs, it leads me to believe that this is the root cause: https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544. The issue describes how/why dependabot PRs are have secrets disabled in depth, which lines up with the errors we're seeing.

The reason this only occurred for Windows e2e test runs is because the condition that was set for macOS always evaluated to false, due to a syntax error (which should also be fixed by this PR).

*Testing done:*
- It's pretty hard to test this since I'm not dependabot, but we'll know as soon as this PR is merged and the dependabot PRs are rebased.


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
