### PR TITLE
fix: add force to cni cleanup on boot service

### DIFF
--- a/finch.windows.yaml
+++ b/finch.windows.yaml
@@ -102,7 +102,7 @@ provision:
     sudo systemctl enable --now finch-sync-on-shutdown.service
 
     # Add a new service that cleans up lingering CNI networks on boot
-    printf '[Unit]\nDescription=Delete hanging data on boot\nDefaultDependencies=no\nBefore=basic.target\n\n[Service]\nType=oneshot\nExecStart=/bin/bash -c "sudo rm /var/lib/cni/networks/bridge/**; sudo rm /var/lib/cni/results/bridge-finch-*"\n\n[Install]\nWantedBy=basic.target\n' | sudo tee /usr/local/lib/systemd/system/finch-cleanup-on-boot.service
+    printf '[Unit]\nDescription=Delete hanging data on boot\nDefaultDependencies=no\nBefore=basic.target\n\n[Service]\nType=oneshot\nExecStart=/bin/bash -c "sudo rm -rf /var/lib/cni/networks/bridge/**; sudo rm -rf /var/lib/cni/results/bridge-finch-*"\n\n[Install]\nWantedBy=basic.target\n' | sudo tee /usr/local/lib/systemd/system/finch-cleanup-on-boot.service
     sudo systemctl enable --now finch-cleanup-on-boot.service
 
     sudo systemctl restart containerd.service

--- a/finch.yaml
+++ b/finch.yaml
@@ -212,7 +212,7 @@ provision:
     sudo systemctl enable --now finch-sync-on-shutdown.service
 
     # Add a new service that cleans up lingering CNI networks on boot
-    printf '[Unit]\nDescription=Delete hanging data on boot\nDefaultDependencies=no\nBefore=basic.target\n\n[Service]\nType=oneshot\nExecStart=/bin/bash -c "sudo rm /var/lib/cni/networks/bridge/**; sudo rm /var/lib/cni/results/bridge-finch-*"\n\n[Install]\nWantedBy=basic.target\n' | sudo tee /usr/local/lib/systemd/system/finch-cleanup-on-boot.service
+    printf '[Unit]\nDescription=Delete hanging data on boot\nDefaultDependencies=no\nBefore=basic.target\n\n[Service]\nType=oneshot\nExecStart=/bin/bash -c "sudo rm -rf /var/lib/cni/networks/bridge/**; sudo rm -rf /var/lib/cni/results/bridge-finch-*"\n\n[Install]\nWantedBy=basic.target\n' | sudo tee /usr/local/lib/systemd/system/finch-cleanup-on-boot.service
     sudo systemctl enable --now finch-cleanup-on-boot.service
     
     sudo systemctl restart containerd.service


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
When testing Finch 1.1 I was seeing the new `finch-cleanup-on-boot.service` service fail.

```
PS C:\Program Files\Finch> wsl -d lima-finch 
[systemd]
Failed Units: 2
  auditd.service
  finch-cleanup-on-boot.service
```

Inspecting the service you see:

```
[root@mymachine Finch]# journalctl -u finch-cleanup-on-boot
Feb 01 10:48:26 mymachine systemd[1]: Starting finch-cleanup-on-boot.service - Delete hanging data on boot...
Feb 01 10:48:26 mymachine sudo[938]:     root : PWD=/ ; USER=root ; COMMAND=/usr/bin/rm /var/lib/cni/networks/bridge/**
Feb 01 10:48:26 mymachine sudo[938]: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=0)
Feb 01 10:48:26 mymachine bash[939]: rm: cannot remove '/var/lib/cni/networks/bridge/**': No such file or directory
Feb 01 10:48:26 mymachine sudo[938]: pam_unix(sudo:session): session closed for user root
Feb 01 10:48:26 mymachine sudo[937]:     root : PWD=/ ; USER=root ; COMMAND=/usr/bin/rm /var/lib/cni/results/bridge-finch-*
Feb 01 10:48:26 mymachine sudo[937]: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=0)
Feb 01 10:48:26 mymachine bash[940]: rm: cannot remove '/var/lib/cni/results/bridge-finch-*': No such file or directory
Feb 01 10:48:26 mymachine sudo[937]: pam_unix(sudo:session): session closed for user root
Feb 01 10:48:26 mymachine systemd[1]: finch-cleanup-on-boot.service: Main process exited, code=exited, status=1/FAILURE
Feb 01 10:48:26 mymachine systemd[1]: finch-cleanup-on-boot.service: Failed with result 'exit-code'.
Feb 01 10:48:26 mymachine systemd[1]: Failed to start finch-cleanup-on-boot.service - Delete hanging data on boot.
```

So I have add the `-rf` flags to this command so that even if the files do not exist the systemd service will not fail.


*Testing done:*
I have manually tested this change by adding it to my own `finch.yaml` configuration, then stopping / removing the VM and re-initializing it.


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
