### PR TITLE
ci: make tests more reliable by splitting and bumping common-tests

### DIFF
--- a/.github/workflows/build-and-test-msi.yaml
+++ b/.github/workflows/build-and-test-msi.yaml
@@ -217,18 +217,40 @@ jobs:
         run: |
           Start-Process 'Finch.msi' -ArgumentList '/quiet' -Wait
           echo "C:\Program Files\Finch\bin" >> $env:GITHUB_PATH
-      - name: Run e2e tests
+      - name: Run VM e2e tests
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+        with:
+          timeout_minutes: 180
+          max_attempts: 3
+          command: |
+            # set path to use newer ssh version
+            $newPath = (";C:\Program Files\Git\bin\;" + "C:\Program Files\Git\usr\bin\;" + "$env:Path")
+            $env:Path = $newPath
+            
+            git status
+            git clean -f -d
+            $env:INSTALLED="true"
+            make test-e2e-vm
+      - name: Remove Finch VM
         run: |
-          # set path to use newer ssh version
-          $newPath = (";C:\Program Files\Git\bin\;" + "C:\Program Files\Git\usr\bin\;" + "$env:Path")
-          $env:Path = $newPath
-          # set networking config option to allow for VM/container -> host communication
-          echo "[experimental]`nnetworkingMode=mirrored`nhostAddressLoopback=true" > C:\Users\Administrator\.wslconfig
-          
-          git status
-          git clean -f -d
-          $env:INSTALLED="true"
-          make test-e2e
+          wsl --list --verbose
+          wsl --shutdown
+          timeout 10
+          wsl --unregister lima-finch
+          wsl --list --verbose    
+      - name: Run container e2e tests
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+        with:
+          timeout_minutes: 180
+          max_attempts: 3
+          command: |
+            # set path to use newer ssh version
+            $newPath = (";C:\Program Files\Git\bin\;" + "C:\Program Files\Git\usr\bin\;" + "$env:Path")
+            $env:Path = $newPath
+            
+            git status
+            git clean -f -d
+            make test-e2e-container
       - name: Uninstall Finch silently
         if: ${{ always() }}
         run: |

--- a/.github/workflows/build-and-test-pkg.yaml
+++ b/.github/workflows/build-and-test-pkg.yaml
@@ -216,7 +216,17 @@ jobs:
           command: |
             git status
             git clean -f -d
-            INSTALLED=true make test-e2e
+            INSTALLED=true make test-e2e-vm
+            make test-e2e-container
+      - name: Run e2e tests
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+        with:
+          timeout_minutes: 180
+          max_attempts: 3
+          command: |
+            git status
+            git clean -f -d
+            make test-e2e-container    
       - name: Silently uninstall
         run: echo 'y' | sudo bash /Applications/Finch/uninstall.sh
       - name: Delete installer
@@ -317,7 +327,7 @@ jobs:
           sudo rm -rf ./_output
           echo 'y' | sudo bash /Applications/Finch/uninstall.sh
           sudo installer -pkg Finch-${{ needs.get-tag-name.outputs.tag }}-x86_64.pkg -target /
-      - name: Run e2e tests
+      - name: Run VM e2e tests
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
         with:
           timeout_minutes: 180
@@ -325,7 +335,17 @@ jobs:
           command: |
             git status
             git clean -f -d
-            INSTALLED=true make test-e2e
+            INSTALLED=true make test-e2e-vm
+            make test-e2e-container
+      - name: Run VM e2e tests
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+        with:
+          timeout_minutes: 180
+          max_attempts: 3
+          command: |
+            git status
+            git clean -f -d
+            make test-e2e-container
       - name: Silently uninstall
         run: echo 'y' | sudo bash /Applications/Finch/uninstall.sh
       - name: Delete installer

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/onsi/gomega v1.31.1
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/sftp v1.13.6
-	github.com/runfinch/common-tests v0.7.12
+	github.com/runfinch/common-tests v0.7.13
 	github.com/shirou/gopsutil/v3 v3.23.12
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/afero v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -151,8 +151,8 @@ github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:Om
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
-github.com/runfinch/common-tests v0.7.12 h1:i/uUDP5zVRCNZmdGI22vxYq/qKtKcgsRwc5+CMkkhLo=
-github.com/runfinch/common-tests v0.7.12/go.mod h1:VKrdDQrhWnjsry6WMLj0eipL9lWYFODOKGbe9Df5D7k=
+github.com/runfinch/common-tests v0.7.13 h1:zYb029hy3SoWAhMktFtX+918/IQbQt7F77FRRKIoXT0=
+github.com/runfinch/common-tests v0.7.13/go.mod h1:4JVWZRyjSQ5+X9DRP4tg/Uvxi80AK8pOoe0qrBDi4y4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- split release tests
  - we've seen increased pass rate after similar changes on the regular e2e test side
- Also added retries, since this is an async workflow that we don't care how long it takes
- bump common-tests
  - there's a fix for a common e2e test failure in the new version. was waiting for dependabot but it hasn't hit yet, so just bundled it with this

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
