### PR TITLE
ci: attempt to reduce flakes and log more info on failure

### DIFF
--- a/e2e/vm/config_test.go
+++ b/e2e/vm/config_test.go
@@ -23,7 +23,10 @@ import (
 	"github.com/runfinch/finch/e2e"
 )
 
-const defaultLimaConfigFilePath = "../../_output/lima/data/_config/override.yaml"
+var (
+	defaultLimaDataDirPath    = filepath.Join("..", "..", "_output/lima/data")
+	defaultLimaConfigFilePath = filepath.Join(defaultLimaDataDirPath, "_config/override.yaml")
+)
 
 func readFile(filePath string) []byte {
 	out, err := os.ReadFile(filepath.Clean(filePath))

--- a/e2e/vm/lifecycle_test.go
+++ b/e2e/vm/lifecycle_test.go
@@ -54,12 +54,8 @@ var testVMLifecycle = func(o *option.Option) {
 				gomega.Expect(command.StdoutStr(o, virtualMachineRootCmd, "status")).To(gomega.Equal("Stopped"))
 			})
 
-			ginkgo.It("should be able to start the virtual machine", ginkgo.FlakeAttempts(3), func() {
-				// TODO: Remove FlakeAttempts
-				// vm start should happen in around 20 seconds if everything is working as expected
-				// sometimes it fails, but the failure timeout is 1 minute. Clamping to 30 seconds and
-				// allowing 3 tries will still be faster than the previous behavior.
-				command.New(o, virtualMachineRootCmd, "start").WithTimeoutInSeconds(30).Run()
+			ginkgo.It("should be able to start the virtual machine", func() {
+				command.New(o, virtualMachineRootCmd, "start").WithTimeoutInSeconds(240).Run()
 				command.Run(o, "images")
 				command.New(o, virtualMachineRootCmd, "stop").WithTimeoutInSeconds(90).Run()
 			})

--- a/e2e/vm/vm_darwin_test.go
+++ b/e2e/vm/vm_darwin_test.go
@@ -50,6 +50,15 @@ func TestVM(t *testing.T) {
 		time.Sleep(1 * time.Second)
 	}, func() {})
 
+	ginkgo.AfterEach(func() {
+		if ginkgo.CurrentSpecReport().Failed() {
+			stderrLogPath := filepath.Join(limaDataDirPath(*e2e.Installed), "finch", "ha.stderr.log")
+			stdoutLogPath := filepath.Join(limaDataDirPath(*e2e.Installed), "finch", "ha.stdout.log")
+			ginkgo.AddReportEntry("ha.stderr.log", string(readFile(stderrLogPath)))
+			ginkgo.AddReportEntry("ha.stdout.log", string(readFile(stdoutLogPath)))
+		}
+	})
+
 	ginkgo.Describe("", func() {
 		testVMLifecycle(o)
 		testAdditionalDisk(o, *e2e.Installed)

--- a/e2e/vm/vm_test.go
+++ b/e2e/vm/vm_test.go
@@ -21,18 +21,21 @@ const (
 	virtualMachineRootCmd = "vm"
 )
 
-var resetVM = func(o *option.Option, installed bool) string {
-	var limaConfigFilePath string
-
-	origFinchCfg := readFile(finchConfigFilePath)
-	limaConfigFilePath = defaultLimaConfigFilePath
+func limaDataDirPath(installed bool) string {
+	limaConfigFilePath := defaultLimaDataDirPath
 	if installed {
 		path, err := exec.LookPath(e2e.InstalledTestSubject)
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		realFinchPath, err := filepath.EvalSymlinks(path)
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-		limaConfigFilePath = filepath.Join(realFinchPath, "..", "..", "lima", "data", "_config", "override.yaml")
+		limaConfigFilePath = filepath.Join(realFinchPath, "..", "..", "lima", "data")
 	}
+	return limaConfigFilePath
+}
+
+var resetVM = func(o *option.Option, installed bool) string {
+	origFinchCfg := readFile(finchConfigFilePath)
+	limaConfigFilePath := filepath.Join(limaDataDirPath(installed), "_config", "override.yaml")
 	origLimaCfg := readFile(limaConfigFilePath)
 
 	command.New(o, virtualMachineRootCmd, "stop", "-f").WithoutCheckingExitCode().WithTimeoutInSeconds(20).Run()


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- remove previously added FlakeAttempts and add back a longer timeout since this test actually can't be re-run straightforwardly
- try to log more data on failure (may have to move it to a different block)

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
