### PR TITLE
fix: stop Finch on uninstall

### DIFF
--- a/msi-builder/uninstall.bat
+++ b/msi-builder/uninstall.bat
@@ -1,5 +1,13 @@
 @echo off
 SET InstallDir=%~1
 
+:: Stop and remove any running instance
+finch.exe vm stop -f
+finch.exe vm remove -f
+
+:: Just in case
+wsl --terminate lima-finch
+wsl --unregister lima-finch
+
 :: Delete files and directories if they exist
 if exist "%InstallDir%\lima\" rmdir /s /q "%InstallDir%\lima\"


### PR DESCRIPTION
Issue #, if available: Fixes #794

*Description of changes:*
- The uninstall script runs on upgrade, and this makes the uninstall script stop/remove Finch's VM

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
