### PR TITLE
fix: msi release tests cleanup

### DIFF
--- a/.github/workflows/build-and-test-msi.yaml
+++ b/.github/workflows/build-and-test-msi.yaml
@@ -235,8 +235,9 @@ jobs:
         run: |
           wsl --list --verbose
           wsl --shutdown
-          timeout 10
+          Start-Sleep -s 10
           wsl --unregister lima-finch
+          Remove-Item C:\Users\Administrator\AppData\Local\.finch -Recurse
           wsl --list --verbose    
       - name: Run container e2e tests
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Replace `timeout` with `Start-Sleep` (timeout wasn't working)
- Also cleanup the persistent data volume

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
