### PR TITLE
fix(windows-installer): uninstall script behavior

### DIFF
--- a/msi-builder/FinchMSITemplate.wxs
+++ b/msi-builder/FinchMSITemplate.wxs
@@ -99,7 +99,7 @@
       <ComponentRef Id="Component_Roofts" />
     </ComponentGroup>
     <CustomAction Id="RunPostInstallScript" FileKey="postinstall_bat" ExeCommand="&quot;[INSTALLFOLDER]&quot;" Return="check" Execute="deferred" Impersonate="no" />
-    <CustomAction Id="RunUninstallScript" FileKey="uninstall_bat" ExeCommand="&quot;[INSTALLFOLDER]&quot;" Execute="deferred" Return="ignore" Impersonate="no" />
+    <CustomAction Id="RunUninstallScript" FileKey="uninstall_bat" ExeCommand="&quot;[INSTALLFOLDER]&quot;" Execute="deferred" Return="ignore" Impersonate="yes" />
     <InstallExecuteSequence>
       <RemoveExistingProducts After="InstallInitialize" />
       <Custom Action="RunPostInstallScript" After="InstallFiles">NOT Installed</Custom>

--- a/msi-builder/uninstall.bat
+++ b/msi-builder/uninstall.bat
@@ -2,11 +2,11 @@
 SET InstallDir=%~1
 
 :: Stop and remove any running instance
-finch.exe vm stop -f
-finch.exe vm remove -f
+finch.exe vm stop -f ^ & 
+finch.exe vm remove -f ^ & 
 
 :: Just in case
-wsl --terminate lima-finch
+wsl --terminate lima-finch ^ & 
 wsl --unregister lima-finch
 
 :: Delete files and directories if they exist


### PR DESCRIPTION
Issue #, if available:
- After my recent changes to the uninstall script (which were aimed at making sure Lima was not running and the WSL2 instance was stopped), I tested the new installer, and it still had weird behavior. I noticed that the script would exit immediately if the Lima stop command failed, so I added the `&` separators. After that, I noticed that the WSL commands would fail immediately. This was because the commands were being executed as a Local install user, instead of the target user. Changing `Impersonate` to `yes` should resolve that issue ([docs](https://wixtoolset.org/docs/v3/xsd/wix/customaction/)).

_Description of changes:_
- Ensure that all commands execute by separating them with & instead of letting failures stop the script
- Ensure script runs in the user's context by setting `Impersonate` to `yes`

*Testing done:*
- Local testing


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
