### PR TITLE
fix(windows-installer): ignore FilesInUse/Restart dialogue

### DIFF
--- a/msi-builder/FinchMSITemplate.wxs
+++ b/msi-builder/FinchMSITemplate.wxs
@@ -12,6 +12,8 @@
     <Feature Id="ProductFeature" Title="Finch" Level="1">
       <ComponentGroupRef Id="FinchComponents" />
     </Feature>
+    <!-- Disable FilesInUse/Restart dialogue -->
+    <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" />
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="ProgramFiles64Folder">
         <Directory Id="INSTALLFOLDER" Name="Finch">


### PR DESCRIPTION
Issue #, if available:
- When upgrading Finch, if the VM is still running, an important looking screen mentioning "Files in use" will pop up, and prompt the user to have Finch try to delete these files, or ignore them. The default behavior of these options doesn't actually do anything in our case. Luckily, stopping Finch's VM and making sure its removed (which is done in the uninstall script) should take care of this for us instead. This change just removes the extra unnecessary step for users since it may be confusing.

*Description of changes:*
- Suppress the "Files in use" dialogue since it's confusing and not useful

*Testing done:*
- Simulated upgrades and uninstalls on my test machine



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
