### PR TITLE
fix(windows-installer): add new cleanup script on install

### DIFF
--- a/msi-builder/BuildFinchMSI.ps1
+++ b/msi-builder/BuildFinchMSI.ps1
@@ -60,6 +60,7 @@ Write-Host "Files copied successfully."
 Write-Host "4. Copy extra scripts, license and icon..."
 Copy-Item -Path (Join-Path -Path $scriptDirectory -ChildPath "postinstall.bat") -Destination (Join-Path -Path $scriptDirectory -ChildPath "build\Finch")
 Copy-Item -Path (Join-Path -Path $scriptDirectory -ChildPath "uninstall.bat") -Destination (Join-Path -Path $scriptDirectory -ChildPath "build\Finch")
+Copy-Item -Path (Join-Path -Path $scriptDirectory -ChildPath "removevm.bat") -Destination (Join-Path -Path $scriptDirectory -ChildPath "build\Finch")
 Copy-Item -Path (Join-Path -Path $scriptDirectory -ChildPath "finch.ico") -Destination (Join-Path -Path $scriptDirectory -ChildPath "build\Finch")
 Copy-Item -Path (Join-Path -Path $scriptDirectory -ChildPath "LICENSE.rtf") -Destination (Join-Path -Path $scriptDirectory -ChildPath "build\Finch")
 Write-Host "Files copied successfully."

--- a/msi-builder/FinchMSITemplate.wxs
+++ b/msi-builder/FinchMSITemplate.wxs
@@ -21,6 +21,7 @@
             <File Id="config_yaml" Source="__SOURCE__\config.yaml" />
             <File Id="finch_ico" Source="__SOURCE__\finch.ico" />
             <File Id="LICENSE_rtf" Source="__SOURCE__\LICENSE.rtf" />
+            <File Id="removevm_bat" Source="__SOURCE__\removevm.bat" />
             <File Id="postinstall_bat" Source="__SOURCE__\postinstall.bat" />
             <File Id="uninstall_bat" Source="__SOURCE__\uninstall.bat" />
           </Component>
@@ -102,9 +103,11 @@
     </ComponentGroup>
     <CustomAction Id="RunPostInstallScript" FileKey="postinstall_bat" ExeCommand="&quot;[INSTALLFOLDER]&quot;" Return="check" Execute="deferred" Impersonate="no" />
     <CustomAction Id="RunUninstallScript" FileKey="uninstall_bat" ExeCommand="&quot;[INSTALLFOLDER]&quot;" Execute="deferred" Return="ignore" Impersonate="yes" />
+    <CustomAction Id="RunVMCleanupScript" FileKey="removevm_bat" ExeCommand="&quot;[INSTALLFOLDER]&quot;" Execute="deferred" Return="ignore" Impersonate="yes" />
     <InstallExecuteSequence>
       <RemoveExistingProducts After="InstallInitialize" />
-      <Custom Action="RunPostInstallScript" After="InstallFiles">NOT Installed</Custom>
+      <Custom Action="RunVMCleanupScript" After="InstallFiles">NOT Installed</Custom>
+      <Custom Action="RunPostInstallScript" After="RunVMCleanupScript">NOT Installed</Custom>
       <Custom Action="RunUninstallScript" After="InstallInitialize">REMOVE="ALL"</Custom> 
     </InstallExecuteSequence>
     <Property Id="WIXUI_INSTALLDIR" Value="ProgramFiles64Folder" />

--- a/msi-builder/removevm.bat
+++ b/msi-builder/removevm.bat
@@ -1,0 +1,10 @@
+@echo off
+SET InstallDir=%~1
+
+:: Stop and remove any running instance
+finch.exe vm stop -f ^ & 
+finch.exe vm remove -f ^ & 
+
+:: Just in case
+wsl --terminate lima-finch ^ & 
+wsl --unregister lima-finch


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Add new script that runs upon installation to cleanup any dangling Finch VM
  - This is needed because earlier versions of Finch's Windows installer don't clean up properly on uninstall / reinstall
  - Even with this change, user's will be prompted to stop limactl on reinstall if Finch is running. Regardless of which action they choose, the install script will cleanup any dangling VMs.

*Testing done:*
- Tested locally


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
