### PR TITLE
ci: release-homebrew workflow updated to remove the --force option in…

### DIFF
--- a/.github/workflows/release-homebrew.yaml
+++ b/.github/workflows/release-homebrew.yaml
@@ -87,7 +87,7 @@ jobs:
           export HOMEBREW_NO_INSTALL_FROM_API=1
           cd $(brew --repo homebrew/cask)
           echo "Update the local Finch cask with version $FINCH_VERSION"
-          brew bump-cask-pr --write-only -f --version=$FINCH_VERSION finch
+          brew bump-cask-pr --write-only --version=$FINCH_VERSION finch
         shell: zsh {0}
       - name: Silently install
         run: |
@@ -208,7 +208,7 @@ jobs:
           export HOMEBREW_NO_INSTALL_FROM_API=1
           cd $(brew --repo homebrew/cask)
           echo "Update the local Finch cask with version $FINCH_VERSION"
-          brew bump-cask-pr --write-only -f --version=$FINCH_VERSION finch
+          brew bump-cask-pr --write-only --version=$FINCH_VERSION finch
         shell: zsh {0}
       - name: Silently install
         run: |


### PR DESCRIPTION
… PR bump

Issue #, if available:

*Description of changes:*
The latest release of Homebrew does not allow forcing multiple PRs (https://github.com/Homebrew/brew/pull/16664). This causes the `release-homebrew` workflow to fail as it uses the `--force` option in `bump-cask-pr` command which is disabled as of brew version 4.2.9. This PR removes the `--force` flag to fix the workflow step.

Recent Homebrew workflow failure: https://github.com/runfinch/finch/actions/runs/7997204281/job/21841199683

*Testing done:*



- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
