### PR TITLE
fix: Reset disks and force remove vm after suite execution

### DIFF
--- a/e2e/vm/vm_darwin_test.go
+++ b/e2e/vm/vm_darwin_test.go
@@ -48,6 +48,7 @@ func TestVM(t *testing.T) {
 		time.Sleep(1 * time.Second)
 		command.New(o, "vm", "remove", "-f").WithoutCheckingExitCode().WithTimeoutInSeconds(20).Run()
 		time.Sleep(1 * time.Second)
+		resetDisks(o, *e2e.Installed)
 	}, func() {})
 
 	ginkgo.AfterEach(func() {

--- a/e2e/vm/vm_windows_test.go
+++ b/e2e/vm/vm_windows_test.go
@@ -36,8 +36,9 @@ func TestVM(t *testing.T) {
 	}, func(_ []byte) {})
 
 	ginkgo.SynchronizedAfterSuite(func() {
-		command.New(o, "vm", "stop").WithTimeoutInSeconds(90).Run()
-		command.New(o, "vm", "remove").WithTimeoutInSeconds(60).Run()
+		command.New(o, "vm", "stop", "-f").WithTimeoutInSeconds(90).Run()
+		command.New(o, "vm", "remove", "-f").WithTimeoutInSeconds(60).Run()
+		resetDisks(o, *e2e.Installed)
 	}, func() {})
 
 	ginkgo.Describe("", func() {


### PR DESCRIPTION
Issue #, if available:

*Description of changes: Force remove vm and clean disks. This gives a chance to recover from builkit failures caused by non-existent uuid files

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
