### PR TITLE
fix: add finch attach command

### DIFF
--- a/cmd/finch/nerdctl.go
+++ b/cmd/finch/nerdctl.go
@@ -473,4 +473,5 @@ var nerdctlCmds = map[string]string{
 	"update":    "Update configuration of one or more containers",
 	"volume":    "Manage volumes",
 	"wait":      "Block until one or more containers stop, then print their exit codes",
+	"attach":    "Attach stdin, stdout, and stderr to a running container",
 }


### PR DESCRIPTION
The finch attach command cannot be executed at the top level. Therefore, when the finch attach -h command is executed, the following error occurs.

  ```
  > finch attach -h
  FATA[0000] unknown command "attach" for "finch"
  ```

Also, this bug has been reported in issue/747 below, and it is hoped that finch attach will be executed.

- https://github.com/runfinch/finch/issues/747

Meanwhile, with the nerdctl command, it is possible to execute the nerdctl attach command.

Therefore, in this commit, we will make corrections so that the finch attach command can be executed.

Issue #, if available: #747

*Description of changes:* Details are described in commit message.

*Testing done:* No



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
