### PR TITLE
test: add strict version checks for packages

### DIFF
--- a/.github/workflows/sync-submodules-and-deps.yaml
+++ b/.github/workflows/sync-submodules-and-deps.yaml
@@ -52,3 +52,26 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           signoff: true
           title: 'build(deps): Bump submodules and dependencies'
+          body: >
+            Bump for Finch's dependencies.
+
+            Currently, this updates values based on artifacts defined in the finch-core repository,
+            such as: operating system images, and the version of Lima (and it's dependencies),
+            which are bundled as `lima-and-qemu.macos-*.*.tar.gz` archives.
+
+            Since updating the Lima version may also update the default version of the `nerdctl-full`
+            archive (which contains nerdctl, containerd, buildkit, etc.), this may require a manual
+            update to
+            [`e2e/vm/version_test.go`](https://github.com/runfinch/finch/tree/create-pull-request/patch/e2e/vm/version_test.go).
+
+            To do so, checkout this PR branch locally, add a new commit to the branch,
+            and push back to the branch:
+
+              ```bash
+              git fetch --all
+              git switch create-pull-request/patch
+              # make changes
+              git add e2e/vm/version_test.go
+              git commit -s "update dependency versions in version test"
+              git push
+              ```

--- a/e2e/vm/version_test.go
+++ b/e2e/vm/version_test.go
@@ -4,8 +4,9 @@
 package vm
 
 import (
-	"fmt"
+	"bytes"
 	"strings"
+	"text/template"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -15,31 +16,61 @@ import (
 	"github.com/runfinch/finch/pkg/version"
 )
 
+const (
+	nerdctlVersion    = "v1.7.3"
+	buildKitVersion   = "v0.12.5"
+	containerdVersion = "v1.7.13"
+	runcVersion       = "1.1.12"
+)
+
+type Versions struct {
+	FinchVersion      string
+	FinchCommit       string
+	NerdctlVersion    string
+	BuildKitVersion   string
+	ContainerdVersion string
+	RuncVersion       string
+}
+
+var versions = Versions{
+	FinchVersion:      strings.ReplaceAll(version.Version, ".", "\\."),
+	FinchCommit:       strings.ReplaceAll(version.GitCommit, ".", "\\."),
+	NerdctlVersion:    strings.ReplaceAll(nerdctlVersion, ".", "\\."),
+	BuildKitVersion:   strings.ReplaceAll(buildKitVersion, ".", "\\."),
+	ContainerdVersion: strings.ReplaceAll(containerdVersion, ".", "\\."),
+	RuncVersion:       strings.ReplaceAll(runcVersion, ".", "\\."),
+}
+
 // Checks finch version.
 var testVersion = func(o *option.Option) {
 	ginkgo.Describe("Check finch version", func() {
 		ginkgo.It("Should print finch version information", func() {
-			// StdoutStr is not used because it trims both leading and trailing spaces,
-			// while we want an exact match here.
-			gomega.Expect(string(command.Stdout(o, "version"))).Should(gomega.MatchRegexp(fmt.Sprintf(`Client:
- Version:	%s
+			tmpl, err := template.New("versionTemplate").Parse(`Client:
+ Version:	{{ .FinchVersion }}
  OS\/Arch:	[A-Za-z0-9]+\/[A-Za-z0-9]+
- GitCommit:	%s
+ GitCommit:	{{ .FinchCommit }}
  nerdctl:
-  Version:	v[0-9]+\.[0-9]+\.[0-9]+
+  Version:	{{ .NerdctlVersion }}
   GitCommit:	[a-z0-9]{40}
  buildctl:
-  Version:	v[0-9]+\.[0-9]+\.[0-9]+
+  Version:	{{ .BuildKitVersion }}
   GitCommit:	[a-z0-9]{40}
 
 Server:
  containerd:
-  Version:	v[0-9]+\.[0-9]+\.[0-9]+
+  Version:	{{ .ContainerdVersion }}
   GitCommit:	[a-z0-9]{40}
  runc:
-  Version:	[0-9]+\.[0-9]+\.[0-9]+
+  Version:	{{ .RuncVersion }}
   GitCommit:	v[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+-g[a-z0-9]{8})?
-`, strings.ReplaceAll(version.Version, ".", "\\."), version.GitCommit)))
+`)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			var versionMatcher bytes.Buffer
+			err = tmpl.Execute(&versionMatcher, versions)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			// command.StdoutStr is not used because it trims both leading and trailing spaces,
+			// while we want an exact match here.
+			gomega.Expect(string(command.Stdout(o, "version"))).Should(gomega.MatchRegexp(versionMatcher.String()))
 		})
 	})
 }


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Adds strict version checks for nerdctl, containerd, buildkit, and runc
- Refactors to use templates, since fmt strings were getting unwieldy
- Updates documentation on automated PR explaining how to manually update PR to fix version mismatches
- Future work: also automate this change as part of the `.github/workflows/sync-submodules-and-deps.yaml` workflow

*Testing done:*
- Tested locally


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
