### PR TITLE
fix: parse management commands with proper arguments

### DIFF
--- a/cmd/finch/nerdctl_windows_test.go
+++ b/cmd/finch/nerdctl_windows_test.go
@@ -202,7 +202,7 @@ func TestNerdctlCommand_run(t *testing.T) {
 				ncsd.EXPECT().FilePathToSlash(augmentedPath).Return(wslPath)
 
 				lcc.EXPECT().Create("shell", "--workdir", wslPath, limaInstanceName, "sudo", "-E", nerdctlCmdName, "container", "run",
-					"-e", "ARG1=val1", "--rm", "alpine:latest", "env").Return(c)
+					"--rm", "-e", "ARG1=val1", "alpine:latest", "env").Return(c)
 				c.EXPECT().Run()
 			},
 		},
@@ -239,7 +239,45 @@ func TestNerdctlCommand_run(t *testing.T) {
 				ncsd.EXPECT().FilePathToSlash(augmentedPath).Return(wslPath)
 				// alias substitution run=>container run
 				lcc.EXPECT().Create("shell", "--workdir", wslPath, limaInstanceName, "sudo", "-E", nerdctlCmdName, "container", "run",
-					"-e", "ARG3=val3", "--rm", "alpine:latest", "env").Return(c)
+					"--rm", "-e", "ARG3=val3", "alpine:latest", "env").Return(c)
+				c.EXPECT().Run()
+			},
+		},
+		{
+			name:    "with environment flags parsing and env value exists and with --debug flag",
+			cmdName: "run",
+			fc:      &config.Finch{},
+			args:    []string{"--debug", "--rm", "--env=ARG2", "-eARG3", "alpine:latest", "env"},
+			wantErr: nil,
+			mockSvc: func(
+				_ *testing.T,
+				_ *mocks.CommandCreator,
+				lcc *mocks.LimaCmdCreator,
+				_ *mocks.Command,
+				ncsd *mocks.NerdctlCommandSystemDeps,
+				logger *mocks.Logger,
+				ctrl *gomock.Controller,
+				_ afero.Fs,
+			) {
+				getVMStatusC := mocks.NewCommand(ctrl)
+				lcc.EXPECT().CreateWithoutStdio("ls", "-f", "{{.Status}}", limaInstanceName).Return(getVMStatusC)
+				getVMStatusC.EXPECT().Output().Return([]byte("Running"), nil)
+				logger.EXPECT().SetLevel(flog.Debug)
+				logger.EXPECT().Debugf("Status of virtual machine: %s", "Running")
+				ncsd.EXPECT().LookupEnv("AWS_ACCESS_KEY_ID").Return("", false)
+				ncsd.EXPECT().LookupEnv("AWS_SECRET_ACCESS_KEY").Return("", false)
+				ncsd.EXPECT().LookupEnv("AWS_SESSION_TOKEN").Return("", false)
+				c := mocks.NewCommand(ctrl)
+				ncsd.EXPECT().LookupEnv("ARG2")
+				ncsd.EXPECT().LookupEnv("ARG3").Return("val3", true)
+				ncsd.EXPECT().LookupEnv("COSIGN_PASSWORD").Return("", false)
+				ncsd.EXPECT().GetWd().Return("C:\\workdir", nil)
+				ncsd.EXPECT().FilePathAbs("C:\\workdir").Return("C:\\workdir", nil)
+				ncsd.EXPECT().FilePathJoin(string(filepath.Separator), "mnt", "c", "workdir").Return(augmentedPath)
+				ncsd.EXPECT().FilePathToSlash(augmentedPath).Return(wslPath)
+				// alias substitution run=>container run
+				lcc.EXPECT().Create("shell", "--workdir", wslPath, limaInstanceName, "sudo", "-E", nerdctlCmdName, "container", "run",
+					"--rm", "-e", "ARG3=val3", "alpine:latest", "env").Return(c)
 				c.EXPECT().Run()
 			},
 		},
@@ -278,7 +316,47 @@ func TestNerdctlCommand_run(t *testing.T) {
 				ncsd.EXPECT().FilePathJoin(string(filepath.Separator), "mnt", "c", "workdir").Return(augmentedPath)
 				ncsd.EXPECT().FilePathToSlash(augmentedPath).Return(wslPath)
 				lcc.EXPECT().Create("shell", "--workdir", wslPath, limaInstanceName,
-					"sudo", "-E", nerdctlCmdName, "container", "run", "-e", "ARG1=val1", "--rm", "alpine:latest", "env").Return(c)
+					"sudo", "-E", nerdctlCmdName, "container", "run", "--rm", "-e", "ARG1=val1", "alpine:latest", "env").Return(c)
+				c.EXPECT().Run()
+			},
+		},
+		{
+			name:    "with --env-file flag replacement and with --debug flag",
+			cmdName: "run",
+			fc:      &config.Finch{},
+			args:    []string{"--debug", "--rm", "--env-file=" + envFilePath, "alpine:latest", "env"},
+			wantErr: nil,
+			mockSvc: func(
+				t *testing.T,
+				_ *mocks.CommandCreator,
+				lcc *mocks.LimaCmdCreator,
+				_ *mocks.Command,
+				ncsd *mocks.NerdctlCommandSystemDeps,
+				logger *mocks.Logger,
+				ctrl *gomock.Controller,
+				fs afero.Fs,
+			) {
+				envFileStr := "# a comment\nARG1=val1\n  ARG2\n\n  # a 2nd comment\nNOTSETARG\n  "
+				require.NoError(t, afero.WriteFile(fs, envFilePath, []byte(envFileStr), 0o600))
+
+				getVMStatusC := mocks.NewCommand(ctrl)
+				lcc.EXPECT().CreateWithoutStdio("ls", "-f", "{{.Status}}", limaInstanceName).Return(getVMStatusC)
+				getVMStatusC.EXPECT().Output().Return([]byte("Running"), nil)
+				logger.EXPECT().SetLevel(flog.Debug)
+				logger.EXPECT().Debugf("Status of virtual machine: %s", "Running")
+				ncsd.EXPECT().LookupEnv("AWS_ACCESS_KEY_ID").Return("", false)
+				ncsd.EXPECT().LookupEnv("AWS_SECRET_ACCESS_KEY").Return("", false)
+				ncsd.EXPECT().LookupEnv("AWS_SESSION_TOKEN").Return("", false)
+				c := mocks.NewCommand(ctrl)
+				ncsd.EXPECT().LookupEnv("ARG2")
+				ncsd.EXPECT().LookupEnv("NOTSETARG")
+				ncsd.EXPECT().LookupEnv("COSIGN_PASSWORD").Return("", false)
+				ncsd.EXPECT().GetWd().Return("C:\\workdir", nil)
+				ncsd.EXPECT().FilePathAbs("C:\\workdir").Return("C:\\workdir", nil)
+				ncsd.EXPECT().FilePathJoin(string(filepath.Separator), "mnt", "c", "workdir").Return(augmentedPath)
+				ncsd.EXPECT().FilePathToSlash(augmentedPath).Return(wslPath)
+				lcc.EXPECT().Create("shell", "--workdir", wslPath, limaInstanceName,
+					"sudo", "-E", nerdctlCmdName, "container", "run", "--rm", "-e", "ARG1=val1", "alpine:latest", "env").Return(c)
 				c.EXPECT().Run()
 			},
 		},
@@ -317,7 +395,7 @@ func TestNerdctlCommand_run(t *testing.T) {
 				ncsd.EXPECT().FilePathJoin(string(filepath.Separator), "mnt", "c", "workdir").Return(augmentedPath)
 				ncsd.EXPECT().FilePathToSlash(augmentedPath).Return(wslPath)
 				lcc.EXPECT().Create("shell", "--workdir", wslPath, limaInstanceName,
-					"sudo", "-E", nerdctlCmdName, "container", "run", "-e", "ARG2=val2", "--rm", "alpine:latest", "env").Return(c)
+					"sudo", "-E", nerdctlCmdName, "container", "run", "--rm", "-e", "ARG2=val2", "alpine:latest", "env").Return(c)
 				c.EXPECT().Run()
 			},
 		},


### PR DESCRIPTION
Issue #, if available: https://github.com/runfinch/finch/issues/827

Description of changes:
Addresses https://github.com/runfinch/finch/issues/827 by adding all environment variables at the location of first occurrence of the environment flag

Testing done:
Changes tested locally to ensure that the issue is fixed.

$ ./_output/bin/finch container run --debug -it --rm --env="E=v" busybox env
DEBU[0000] Creating limactl command: ARGUMENTS: [shell finch sudo -E nerdctl container run -e E=v -it --rm busybox env], LIMA_HOME: /Users/mharwani/work/runfinch/finch/_output/lima/data 
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
E=v
TERM=xterm
HOME=/root
*Testing done:*



- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
