### PR TITLE
ci: update shellcheck to v0.10.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,12 +95,11 @@ jobs:
   shellcheck:
     name: ShellCheck
     runs-on: ubuntu-latest
+    container: koalaman/shellcheck-alpine:v0.10.0
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
-        with:
-          version: v0.9.0
+        run: shellcheck ./**/*.sh
         continue-on-error: true
   go-mod-tidy-check:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -269,8 +269,8 @@ download-licenses:
 	curl https://raw.githubusercontent.com/golangci/golangci-lint-action/master/LICENSE --output "$(LICENSEDIR)/github.com/golangci/golangci-lint-action/LICENSE"
 	mkdir -p "$(LICENSEDIR)/github.com/avto-dev/markdown-lint"
 	curl https://raw.githubusercontent.com/avto-dev/markdown-lint/master/LICENSE --output "$(LICENSEDIR)/github.com/avto-dev/markdown-lint/LICENSE"
-	mkdir -p "$(LICENSEDIR)"/github.com/ludeeus/action-shellcheck"
-	curl https://raw.githubusercontent.com/ludeeus/action-shellcheck/blob/2.0.0/LICENSE --output "$(LICENSEDIR)/github.com/ludeeus/action-shellcheck/LICENSE"
+	mkdir -p "$(LICENSEDIR)"/github.com/koalaman/shellcheck/LICENSE"
+	curl https://raw.githubusercontent.com/koalaman/shellcheck/blob/v0.10.0/LICENSE --output "$(LICENSEDIR)/github.com/koalaman/shellcheck/LICENSE"
 
     ### dependencies in ci.yaml - end ###
 


### PR DESCRIPTION
Issue #, if available:
N/A

*Description of changes:*
This change updates CI to run shellcheck via container instead of a third-party GitHub Action package. It also updates the version ran to v0.10.0 (latest).

*Testing done:*
CI is successful

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
