### PR TITLE
ci: fix taskkill error

### DIFF
--- a/.github/workflows/build-and-test-msi.yaml
+++ b/.github/workflows/build-and-test-msi.yaml
@@ -78,7 +78,7 @@ jobs:
       - name: Remove Finch VM
         run: |
           $ErrorActionPreference = 'Ignore'
-          taskkill /f /im wslservice.exe
+          taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
           wsl --list --verbose
           wsl --shutdown
           wsl --unregister lima-finch
@@ -144,7 +144,7 @@ jobs:
         run: |
           # We want these cleanup commands to always run, ignore errors so the step completes.
           $ErrorActionPreference = 'Ignore'
-          taskkill /f /im wslservice.exe
+          taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
           wsl --list --verbose
           wsl --shutdown
           wsl --unregister lima-finch
@@ -271,7 +271,7 @@ jobs:
         run: |
           # We want these cleanup commands to always run, ignore errors so the step completes.
           $ErrorActionPreference = 'Ignore'
-          taskkill /f /im wslservice.exe
+          taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
           wsl --list --verbose
           wsl --shutdown
           wsl --unregister lima-finch

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -271,7 +271,7 @@ jobs:
         run: |
           # We want these cleanup commands to always run, ignore errors so the step completes.
           $ErrorActionPreference = 'Ignore'
-          taskkill /f /im wslservice.exe
+          taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
           wsl --list --verbose
           wsl --shutdown
           wsl --unregister lima-finch


### PR DESCRIPTION
Issue #, if available:
https://github.com/runfinch/finch/actions/runs/8659666232/job/23746037924

*Description of changes:*
Previously, if the process didn't exist, the `taskkill` command would fail, which would cause the entire workflow step to fail. This is because although `$ErrorActionPreference = 'Ignore'` is set, it doesn't actually work for sessions, only individual commands

*Testing done:*
- Tested the output of `$LASTEXITCODE` after running the commands manually, got 0


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
