### PR TITLE
docs: Add docs for finch vm settings command

### DIFF
--- a/docs/cmd/finch_vm_settings.md
+++ b/docs/cmd/finch_vm_settings.md
@@ -1,0 +1,15 @@
+# finch vm settings
+
+Configure the virtual machine instance
+
+```text
+  finch vm settings [flags]
+```
+
+## Options
+
+```text
+      --cpus int        the amount of vCPU to dedicate to the virtual machine (restart the vm when applying this change.)
+  -h, --help            help for settings
+      --memory string   the amount of memory to dedicate to the virtual machine (restart the vm when applying this change.)
+```


### PR DESCRIPTION
In my previous pull request, we added the functionality to change the number of CPUs and memory size allocated to VMs.

  - https://github.com/runfinch/finch/pull/887

However, at that time, we did not add documentations for the finch vm settings command.

Therefore, in this fix, we will add documentations for the finch vm settings command.

Issue #, if available: N/A

*Description of changes:* Details are described in this commit message.

*Testing done:* N/A



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
