### PR TITLE
chore: update Amazon ECR credential helper to v0.8.0

### DIFF
--- a/pkg/dependency/credhelper/cred_helper.go
+++ b/pkg/dependency/credhelper/cred_helper.go
@@ -66,9 +66,9 @@ func newDeps(
 	configs := map[string]helperConfig{}
 	installFolder := filepath.Join(finchDir, "cred-helpers")
 
-	const versionEcr = "0.7.0"
-	const hashARM64 = "sha256:ff14a4da40d28a2d2d81a12a7c9c36294ddf8e6439780c4ccbc96622991f3714"
-	const hashAMD64 = "sha256:c978912da7f54eb3bccf4a3f990c91cc758e1494a8af7a60f3faf77271b565db"
+	const versionEcr = "0.8.0"
+	const hashARM64 = "sha256:d62badea3153688ec5c24f440df9fb84ff4b02c624dff9288967267e7445daa1"
+	const hashAMD64 = "sha256:dcc7ae9915b5d8fa2d9e2b18fc30bab5bfbbce5b82401c7644e6ab97973ac35c"
 	credHelperURLEcr := fmt.Sprintf("https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com"+
 		"/%s/linux-%s/docker-credential-ecr-login", versionEcr, arch)
 


### PR DESCRIPTION
Issue #, if available:
N/A

*Description of changes:*
This change updates the Amazon ECR credential helper to v0.8.0

full diff: https://github.com/awslabs/amazon-ecr-credential-helper/compare/v0.7.1...v0.8.0

*Testing done:*

Validated 0.8.0 is installed in local finch build.

```
macedonv@localhost:~/finch$ LIMA_HOME=/Users/macedonv/finch/_output/lima/data/ /Users/macedonv/finch/_output/lima/bin/limactl shell finch
[macedonv@lima-finch finch]$ docker-credential-ecr-login version
docker-credential-ecr-login (github.com/awslabs/amazon-ecr-credential-helper/ecr-login) 0.8.0
[macedonv@lima-finch finch]$ 
```

Pulled image use credential helper as authorizer.
```
macedonv@localhost:~/finch$ ./_output/bin/finch run -it <redacted>.dkr.ecr.us-west-2.amazonaws.com/hello-world
<redacted>.dkr.ecr.us-west-2.amazonaws.com/hello-world:latest:                  resolved       |++++++++++++++++++++++++++++++++++++++| 
manifest-sha256:35393f104f0b077ee6ba7cf86afeae1663e03de19e05d59c748ae82cf928cba0: done           |++++++++++++++++++++++++++++++++++++++| 
config-sha256:efcdebc4572d389f890c8ccfc19622fe2f5f660bec6eb7be979380e54de1dae0:   done           |++++++++++++++++++++++++++++++++++++++| 
layer-sha256:31e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3:    exists         |++++++++++++++++++++++++++++++++++++++| 
elapsed: 3.5 s                                                                    total:  1.6 Ki (461.0 B/s)                                       
Hello world
macedonv@localhost:~/finch$ 
```

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
