### PR TITLE
ci: remove macOS 11 release runners

### DIFF
--- a/.github/workflows/build-and-test-pkg.yaml
+++ b/.github/workflows/build-and-test-pkg.yaml
@@ -58,10 +58,7 @@ jobs:
           git clean -f -d
           make clean
           make download-licenses 
-          CGO_CFLAGS="-mmacosx-version-min=11.0" \
-            CGO_LDFLAGS="-mmacosx-version-min=11.0" \
-            FINCH_OS_IMAGE_LOCATION_ROOT=/Applications/Finch \
-            make
+          make
         shell: zsh {0}
 
       - name: configure aws credentials
@@ -99,10 +96,7 @@ jobs:
           git clean -f -d
           make clean
           make download-licenses 
-          CGO_CFLAGS="-mmacosx-version-min=11.0" \
-            CGO_LDFLAGS="-mmacosx-version-min=11.0" \
-            FINCH_OS_IMAGE_LOCATION_ROOT=/Applications/Finch \
-            make
+          make
         shell: zsh {0}
 
       - name: configure aws credentials

--- a/.github/workflows/build-and-test-pkg.yaml
+++ b/.github/workflows/build-and-test-pkg.yaml
@@ -38,7 +38,7 @@ jobs:
   
   macos-aarch64-pkg-build:
     needs: get-tag-name
-    runs-on: [self-hosted, macos, arm64, 11, release]
+    runs-on: [self-hosted, macos, arm64, 14, release]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
@@ -58,7 +58,10 @@ jobs:
           git clean -f -d
           make clean
           make download-licenses 
-          make FINCH_OS_IMAGE_LOCATION_ROOT=/Applications/Finch
+          CGO_CFLAGS="-mmacosx-version-min=11.0" \
+            CGO_LDFLAGS="-mmacosx-version-min=11.0" \
+            FINCH_OS_IMAGE_LOCATION_ROOT=/Applications/Finch \
+            make
         shell: zsh {0}
 
       - name: configure aws credentials
@@ -75,7 +78,7 @@ jobs:
 
   macos-x86-64-pkg-build:
     needs: get-tag-name
-    runs-on: [self-hosted, macos, amd64, 11, release]
+    runs-on: [self-hosted, macos, amd64, 14, release]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
@@ -96,7 +99,10 @@ jobs:
           git clean -f -d
           make clean
           make download-licenses 
-          make FINCH_OS_IMAGE_LOCATION_ROOT=/Applications/Finch
+          CGO_CFLAGS="-mmacosx-version-min=11.0" \
+            CGO_LDFLAGS="-mmacosx-version-min=11.0" \
+            FINCH_OS_IMAGE_LOCATION_ROOT=/Applications/Finch \
+            make
         shell: zsh {0}
 
       - name: configure aws credentials

--- a/.github/workflows/build-and-test-pkg.yaml
+++ b/.github/workflows/build-and-test-pkg.yaml
@@ -58,7 +58,7 @@ jobs:
           git clean -f -d
           make clean
           make download-licenses 
-          make
+          make FINCH_OS_IMAGE_LOCATION_ROOT=/Applications/Finch
         shell: zsh {0}
 
       - name: configure aws credentials
@@ -96,7 +96,7 @@ jobs:
           git clean -f -d
           make clean
           make download-licenses 
-          make
+          make FINCH_OS_IMAGE_LOCATION_ROOT=/Applications/Finch
         shell: zsh {0}
 
       - name: configure aws credentials

--- a/.github/workflows/upload-build-to-S3.yaml
+++ b/.github/workflows/upload-build-to-S3.yaml
@@ -30,10 +30,7 @@ jobs:
           brew install lz4 automake autoconf libtool yq
           make clean
           make download-licenses 
-          CGO_CFLAGS="-mmacosx-version-min=11.0" \
-            CGO_LDFLAGS="-mmacosx-version-min=11.0" \
-            FINCH_OS_IMAGE_LOCATION_ROOT=/Applications/Finch \
-            make
+          make
           tar -zcvf finch.${GITHUB_REF_NAME}.aarch64.tar.gz _output
         shell: zsh {0}
 
@@ -62,10 +59,7 @@ jobs:
           brew install lz4 automake autoconf libtool yq
           make clean
           make download-licenses 
-          CGO_CFLAGS="-mmacosx-version-min=11.0" \
-            CGO_LDFLAGS="-mmacosx-version-min=11.0" \
-            FINCH_OS_IMAGE_LOCATION_ROOT=/Applications/Finch \
-            make
+          make
           tar -zcvf finch.${GITHUB_REF_NAME}.x86_64.tar.gz _output
         shell: zsh {0}
 

--- a/.github/workflows/upload-build-to-S3.yaml
+++ b/.github/workflows/upload-build-to-S3.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   macos-aarch64-build:
-    runs-on: [self-hosted, macos, arm64, 11, release]
+    runs-on: [self-hosted, macos, arm64, 14, release]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
@@ -30,7 +30,10 @@ jobs:
           brew install lz4 automake autoconf libtool yq
           make clean
           make download-licenses 
-          make FINCH_OS_IMAGE_LOCATION_ROOT=/Applications/Finch
+          CGO_CFLAGS="-mmacosx-version-min=11.0" \
+            CGO_LDFLAGS="-mmacosx-version-min=11.0" \
+            FINCH_OS_IMAGE_LOCATION_ROOT=/Applications/Finch \
+            make
           tar -zcvf finch.${GITHUB_REF_NAME}.aarch64.tar.gz _output
         shell: zsh {0}
 
@@ -42,7 +45,7 @@ jobs:
           if-no-files-found: error
 
   macos-x86_64-build:
-    runs-on: [self-hosted, macos, amd64, 11, release]
+    runs-on: [self-hosted, macos, amd64, 14, release]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
@@ -59,7 +62,10 @@ jobs:
           brew install lz4 automake autoconf libtool yq
           make clean
           make download-licenses 
-          make FINCH_OS_IMAGE_LOCATION_ROOT=/Applications/Finch
+          CGO_CFLAGS="-mmacosx-version-min=11.0" \
+            CGO_LDFLAGS="-mmacosx-version-min=11.0" \
+            FINCH_OS_IMAGE_LOCATION_ROOT=/Applications/Finch \
+            make
           tar -zcvf finch.${GITHUB_REF_NAME}.x86_64.tar.gz _output
         shell: zsh {0}
 

--- a/.github/workflows/upload-build-to-S3.yaml
+++ b/.github/workflows/upload-build-to-S3.yaml
@@ -30,7 +30,7 @@ jobs:
           brew install lz4 automake autoconf libtool yq
           make clean
           make download-licenses 
-          make
+          make FINCH_OS_IMAGE_LOCATION_ROOT=/Applications/Finch
           tar -zcvf finch.${GITHUB_REF_NAME}.aarch64.tar.gz _output
         shell: zsh {0}
 
@@ -59,7 +59,7 @@ jobs:
           brew install lz4 automake autoconf libtool yq
           make clean
           make download-licenses 
-          make
+          make FINCH_OS_IMAGE_LOCATION_ROOT=/Applications/Finch
           tar -zcvf finch.${GITHUB_REF_NAME}.x86_64.tar.gz _output
         shell: zsh {0}
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ LICENSEDIR := $(OUTDIR)/license-files
 VERSION := $(shell git describe --match 'v[0-9]*' --dirty='.modified' --always --tags)
 GITCOMMIT := $(shell git rev-parse HEAD)$(shell test -z "$(git status --porcelain)" || echo .m)
 LDFLAGS := "-X $(PACKAGE)/pkg/version.Version=$(VERSION) -X $(PACKAGE)/pkg/version.GitCommit=$(GITCOMMIT)"
+MIN_MACOS_VERSION ?= 11.0
 
 GOOS ?= $(shell $(GO) env GOOS)
 ifeq ($(GOOS),windows)
@@ -203,6 +204,8 @@ uninstall: uninstall.finch
 .PHONY: finch
 ifeq ($(GOOS),windows)
 finch: finch-windows finch-general
+else ifeq ($(GOOS),darwin)
+finch: finch-macos
 else
 finch: finch-unix
 endif
@@ -210,6 +213,10 @@ endif
 finch-windows:
 	GOBIN=$(GOBIN) go install github.com/tc-hib/go-winres
 	$(GO) generate cmd/finch/main_windows.go
+
+finch-macos: export CGO_CFLAGS := -mmacosx-version-min=$(MIN_MACOS_VERSION)
+finch-macos: export CGO_LDFLAGS := -mmacosx-version-min=$(MIN_MACOS_VERSION)
+finch-macos: finch-unix
 
 finch-unix: finch-general
 


### PR DESCRIPTION
Issue #, if available:
- https://github.com/runfinch/finch/actions/runs/9092946617/job/24990820049#step:4:172
    - Builds are failing when running on older versions of macOS due to the new dependency on yq, which we install via brew. It is possible to install this dependency through other means (curling / chmoding / moving), but this seems like a better long-term solution.

*Description of changes:*
- Removes the need to build finch on macOS 11. This was previously done so that our binaries would be compatible with older versions of macOS. However, we can get around this by using the `CGO` flags that are in this diff, entirely removing the need to build on older macOS versions. In the future, these hosts can be completely dropped from the CI as well, as macOS 11 is no longer one of the 2 most recent versions of macOS.
- Going forward, it may be possible to use something like [crazy-max/xgo](https://github.com/crazy-max/xgo?tab=readme-ov-file) or [crazy-max/goxx](https://github.com/crazy-max/goxx?tab=readme-ov-file), with the [osxcross toolchain](https://github.com/crazy-max/goxx?tab=readme-ov-file#macosx-cross-toolchain) to containerize builds of Finch, making them more reproducible and removing the need for macOS build/release hosts entirely.

*Testing done:*
- Verified finch binaries built on macOS 14 run properly on macOS 11 hosts
- Since this isn't obvious, this is how you can at least test that the compiler used the flags:
    ```shell
    otool -l ./_output/bin/finch | grep minos
        minos 11.0
    ```


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
