### PR TITLE
fix: Remove unnecessary error handling

### DIFF
--- a/pkg/config/lima_config_applier.go
+++ b/pkg/config/lima_config_applier.go
@@ -142,10 +142,6 @@ func (lca *limaConfigApplier) ConfigureDefaultLimaYaml() error {
 		return fmt.Errorf("failed to write to the lima config file: %w", err)
 	}
 
-	if err != nil {
-		return fmt.Errorf("unable to apply override config: %w", err)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Inside the ConfigureDefaultLimaYaml() function, there is a process to write to the config file as follows:

    ```
    if err := afero.WriteFile(lca.fs, lca.limaDefaultConfigPath, limaCfgBytes, 0o600); err != nil {
    	return fmt.Errorf("failed to write to the lima config file: %w", err)
    }

    if err != nil {
    	return fmt.Errorf("unable to apply override config: %w", err)
    }
    ```

The current implementation has two error checks to determine if the file can be written.

The err object in the second part is guaranteed to be nil due to the previous if statement.

Therefore, this fix removes the unnecessary second error check.

Issue #, if available: N/A

*Description of changes:* The details are described in this commit message.

*Testing done:* N/A



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
