### PR TITLE
ci: update release script to embed Info.plists

### DIFF
--- a/.github/workflows/build-pkg.yaml
+++ b/.github/workflows/build-pkg.yaml
@@ -49,7 +49,7 @@ jobs:
           cache: true
       - name: Build for macOS ${{ inputs.version }} (${{ inputs.output_arch }})
         run: |
-          brew install lz4 automake autoconf libtool yq
+          brew install lz4 automake autoconf libtool yq llvm
           git status
           git clean -f -d
           make clean

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ CORE_VDE_PREFIX ?= $(OUTDIR)/dependencies/vde/opt/finch
 LICENSEDIR := $(OUTDIR)/license-files
 VERSION := $(shell git describe --match 'v[0-9]*' --dirty='.modified' --always --tags)
 GITCOMMIT := $(shell git rev-parse HEAD)$(shell test -z "$(git status --porcelain)" || echo .m)
-LDFLAGS := "-X $(PACKAGE)/pkg/version.Version=$(VERSION) -X $(PACKAGE)/pkg/version.GitCommit=$(GITCOMMIT)"
+LDFLAGS = "-w -X $(PACKAGE)/pkg/version.Version=$(VERSION) -X $(PACKAGE)/pkg/version.GitCommit=$(GITCOMMIT)"
 MIN_MACOS_VERSION ?= 11.0
 
 GOOS ?= $(shell $(GO) env GOOS)

--- a/installer-builder/tools/build-macos-pkg.sh
+++ b/installer-builder/tools/build-macos-pkg.sh
@@ -44,6 +44,8 @@ buildPkgInstaller() {
     mkdir -p $INSTALLER_FULL_PATH/unsigned/package/artifact
 
     #build pkg
+    # this identifier doens't match what's in the Info.plist for Finch, but changing it now
+    # would break upgrades
     pkgbuild --identifier org.Finch."${VERSION}" \
     --version "$VERSION" \
     --scripts $INSTALLER_FULL_PATH/darwin/scripts \

--- a/installer-builder/tools/extract-executables.sh
+++ b/installer-builder/tools/extract-executables.sh
@@ -57,9 +57,15 @@ extractExecutables() {
             newname=${relativepath//\//__}
 
             #copy executable to destination folder
-            cp -a "$1/$file" ./installer-builder/output/executables/unsigned/package/artifact/EXECUTABLES_TO_SIGN/"$newname"
-            codesign --remove-signature ./installer-builder/output/executables/unsigned/package/artifact/EXECUTABLES_TO_SIGN/"$newname"
-
+            newpath="./installer-builder/output/executables/unsigned/package/artifact/EXECUTABLES_TO_SIGN/$newname"
+            cp -a "$1/$file" "$newpath"
+            codesign --remove-signature "$newpath"
+            "$(brew --prefix)"/opt/llvm/bin/llvm-objcopy \
+                --keep-undefined \
+                --add-section \
+                __TEXT,__info_plist=./installer-builder/darwin/Info.plist \
+                "$newpath" \
+                "$newpath"
             #qemu needs specific entitlement, handle it separately
             if [[ $file == "qemu-system-x86_64" || $file == "qemu-system-aarch64" ]];
             then


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Embed Info.plists into all of the executables that we vend. Requires stripping debug information from the go executable (see [this issue](https://github.com/golang/go/issues/62577)).

*Testing done:*
Tested manually


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
