### PR TITLE
fix: Enable `finch support-bundle generate` to execute on Windows whe…

### DIFF
--- a/pkg/support/support.go
+++ b/pkg/support/support.go
@@ -24,6 +24,7 @@ import (
 	"github.com/runfinch/finch/pkg/flog"
 	"github.com/runfinch/finch/pkg/lima/wrapper"
 	fpath "github.com/runfinch/finch/pkg/path"
+	"github.com/runfinch/finch/pkg/system"
 	"github.com/runfinch/finch/pkg/version"
 )
 
@@ -277,11 +278,7 @@ func (bb *bundleBuilder) getPlatformData() (*PlatformData, error) {
 	platform.Os = os
 
 	// populate arch
-	arch, err := bb.getArch()
-	if err != nil {
-		return nil, err
-	}
-	platform.Arch = arch
+	platform.Arch = bb.getArch()
 
 	// populate Finch version
 	platform.Finch = getFinchVersion()
@@ -305,16 +302,8 @@ func (bb *bundleBuilder) getOSVersion() (string, error) {
 	return os, nil
 }
 
-func (bb *bundleBuilder) getArch() (string, error) {
-	cmd := bb.ecc.Create("uname", "-m")
-	out, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-
-	arch := strings.TrimSuffix(string(out), "\n")
-
-	return arch, nil
+func (bb *bundleBuilder) getArch() string {
+	return system.NewStdLib().Arch()
 }
 
 func getFinchVersion() string {

--- a/pkg/support/support_test.go
+++ b/pkg/support/support_test.go
@@ -76,8 +76,6 @@ func TestSupportBundleBuilder_GenerateSupportBundle(t *testing.T) {
 					ecc.EXPECT().Create("sw_vers", "-productVersion").Return(cmd)
 				}
 				cmd.EXPECT().Output().Return([]byte("1.2.3\n"), nil)
-				ecc.EXPECT().Create("uname", "-m").Return(cmd)
-				cmd.EXPECT().Output().Return([]byte("arch\n"), nil)
 
 				config.EXPECT().LogFiles().Return([]string{
 					"log1",
@@ -122,8 +120,6 @@ func TestSupportBundleBuilder_GenerateSupportBundle(t *testing.T) {
 					ecc.EXPECT().Create("sw_vers", "-productVersion").Return(cmd)
 				}
 				cmd.EXPECT().Output().Return([]byte("1.2.3\n"), nil)
-				ecc.EXPECT().Create("uname", "-m").Return(cmd)
-				cmd.EXPECT().Output().Return([]byte("arch\n"), nil)
 
 				config.EXPECT().LogFiles().Return([]string{
 					"log1",
@@ -165,8 +161,6 @@ func TestSupportBundleBuilder_GenerateSupportBundle(t *testing.T) {
 					ecc.EXPECT().Create("sw_vers", "-productVersion").Return(cmd)
 				}
 				cmd.EXPECT().Output().Return([]byte("1.2.3\n"), nil)
-				ecc.EXPECT().Create("uname", "-m").Return(cmd)
-				cmd.EXPECT().Output().Return([]byte("arch\n"), nil)
 
 				config.EXPECT().LogFiles().Return([]string{
 					"log1",
@@ -207,8 +201,6 @@ func TestSupportBundleBuilder_GenerateSupportBundle(t *testing.T) {
 					ecc.EXPECT().Create("sw_vers", "-productVersion").Return(cmd)
 				}
 				cmd.EXPECT().Output().Return([]byte("1.2.3\n"), nil)
-				ecc.EXPECT().Create("uname", "-m").Return(cmd)
-				cmd.EXPECT().Output().Return([]byte("arch\n"), nil)
 
 				config.EXPECT().LogFiles().Return([]string{
 					"log1",
@@ -249,8 +241,6 @@ func TestSupportBundleBuilder_GenerateSupportBundle(t *testing.T) {
 					ecc.EXPECT().Create("sw_vers", "-productVersion").Return(cmd)
 				}
 				cmd.EXPECT().Output().Return([]byte("1.2.3\n"), nil)
-				ecc.EXPECT().Create("uname", "-m").Return(cmd)
-				cmd.EXPECT().Output().Return([]byte("arch\n"), nil)
 
 				config.EXPECT().LogFiles().Return([]string{
 					"log1",
@@ -292,8 +282,6 @@ func TestSupportBundleBuilder_GenerateSupportBundle(t *testing.T) {
 					ecc.EXPECT().Create("sw_vers", "-productVersion").Return(cmd)
 				}
 				cmd.EXPECT().Output().Return([]byte("1.2.3\n"), nil)
-				ecc.EXPECT().Create("uname", "-m").Return(cmd)
-				cmd.EXPECT().Output().Return([]byte("arch\n"), nil)
 
 				config.EXPECT().LogFiles().Return([]string{
 					"log1",


### PR DESCRIPTION
…re the `uname` command does not exist

On Windows environments where the `uname` command is not available, executing `finch support-bundle generate` results in the following error:

```
C:\Users\simpl>"..\..\Program Files\Finch\bin\finch.exe" support-bundle generate
time="2024-06-11T23:21:16+09:00" level=info msg="Generating support bundle..."
time="2024-06-11T23:21:16+09:00" level=fatal msg="exec: \"uname\": executable file not found in %PATH%"
```

This bug has been reported in the following issue:

- https://github.com/runfinch/finch/issues/897

Therefore, this fix enables the execution of
`finch support-bundle generate` even when the `uname` command is not available on Windows.

Issue #, if available: #897

*Description of changes:* The details are described in this commit message.

*Testing done:* Yes



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
