### PR TITLE
ci: match job name to branch protection rule

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -45,14 +45,21 @@ jobs:
           git secrets --scan-history
 
   gen-code-no-diff:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - run: echo "Skipping CI for docs & contrib files"
   unit-tests:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - run: echo "Skipping CI for docs & contrib files"
   go-linter:
+    name: lint
     runs-on: ubuntu-latest
     steps:
       - run: echo "Skipping CI for docs & contrib files"


### PR DESCRIPTION
Issue #, if available:
#986 is currently blocked on merge due to required CI job checks not matching the expected naming in the branch protection ruleset. The `go-linter` job was renamed in #649 to `lint` and `unit-test` and `gen-code-no-diff` were expanded for the Windows platform.

*Description of changes:*
This change updates the docs CI job to match the expected job names in the branch protection ruleset.

*Testing done:*
Manually verified the branch protection ruleset name matches.

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
