### PR TITLE
ci(release): fix release build generation

### DIFF
--- a/Makefile.darwin
+++ b/Makefile.darwin
@@ -12,8 +12,11 @@ FINCH_OS_BASENAME=$(AARCH64_ARTIFACT)
 FINCH_OS_DIGEST=$(AARCH64_512_DIGEST)
 endif
 
-FINCH_IMAGE_LOCATION:=$(OS_OUTDIR)/$(FINCH_OS_BASENAME)
-FINCH_IMAGE_DIGEST:="sha512:$(FINCH_OS_DIGEST)"
+# This variable is used to generate release builds, where the OS iamge path should be overwritten
+# to /Applications/Finch/...
+FINCH_OS_IMAGE_LOCATION_ROOT ?= $(DEST)
+FINCH_IMAGE_LOCATION := $(FINCH_OS_IMAGE_LOCATION_ROOT)/os/$(FINCH_OS_BASENAME)
+FINCH_IMAGE_DIGEST := "sha512:$(FINCH_OS_DIGEST)"
 
 .PHONY: finch.yaml
 finch.yaml: $(OS_OUTDIR)/finch.yaml


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Recently in https://github.com/runfinch/finch/pull/969, the Makefile was refactored significantly, and the mechanism that was used to override the installation directory was removed ([used here](https://github.com/runfinch/finch/blob/main/.github/workflows/build-pkg.yaml#L57)). This just adds that mechanism back. There could be a better way to do this, but for now just reverting back to how it was done before the recent change.

*Testing done:*
Tested locally. The `_output/os/finch.yaml` file correctly used `/Applications/Finch/`, which was the path I overwrote, as a prefix


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
