### PR TITLE
ci(release): fix MSI release build rootfs path

### DIFF
--- a/.github/workflows/build-and-test-msi.yaml
+++ b/.github/workflows/build-and-test-msi.yaml
@@ -3,6 +3,10 @@ name: Build, test and upload .msi to S3
 # TODO: add scheduler and tests
 on:
   workflow_dispatch:
+    inputs:
+      ref_name:
+        required: true
+        type: string
   workflow_call:
     inputs:
       ref_name:

--- a/.github/workflows/build-and-test-msi.yaml
+++ b/.github/workflows/build-and-test-msi.yaml
@@ -92,7 +92,7 @@ jobs:
           cd deps/finch-core && make clean
       - name: Build project
         run: |
-          make FINCH_ROOTFS_LOCATION_ROOT=/__INSTALLFOLDER__
+          make FINCH_OS_IMAGE_LOCATION_ROOT=/__INSTALLFOLDER__
       - name: generate and download signed msi
         run: |
           $version="${{ needs.get-tag-name.outputs.version }}"

--- a/.github/workflows/build-and-test-msi.yaml
+++ b/.github/workflows/build-and-test-msi.yaml
@@ -92,7 +92,7 @@ jobs:
           cd deps/finch-core && make clean
       - name: Build project
         run: |
-          make FINCH_OS_IMAGE_LOCATION_ROOT=/__INSTALLFOLDER__
+          make FINCH_OS_IMAGE_LOCATION_ROOT=__INSTALLFOLDER__
       - name: generate and download signed msi
         run: |
           $version="${{ needs.get-tag-name.outputs.version }}"

--- a/Makefile.darwin
+++ b/Makefile.darwin
@@ -12,7 +12,7 @@ FINCH_OS_BASENAME=$(AARCH64_ARTIFACT)
 FINCH_OS_DIGEST=$(AARCH64_512_DIGEST)
 endif
 
-# This variable is used to generate release builds, where the OS iamge path should be overwritten
+# This variable is used to generate release builds, where the OS image path should be overwritten
 # to /Applications/Finch/...
 FINCH_OS_IMAGE_LOCATION_ROOT ?= $(DEST)
 FINCH_IMAGE_LOCATION := $(FINCH_OS_IMAGE_LOCATION_ROOT)/os/$(FINCH_OS_BASENAME)

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -13,7 +13,7 @@ endif
 
 # This variable is used to generate release builds, where the OS rootfs path should be overwritten
 # to C:/Program Files/Finch/...
-FINCH_OS_IMAGE_LOCATION_ROOT ?= $(DEST)
+FINCH_OS_IMAGE_LOCATION_ROOT ?= $(OUTDIR)
 FINCH_IMAGE_LOCATION := $(FINCH_OS_IMAGE_LOCATION_ROOT)/os/$(FINCH_ROOTFS_BASENAME)
 FINCH_IMAGE_DIGEST := "sha512:$(FINCH_ROOTFS_DIGEST)"
 

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -11,7 +11,10 @@ else
 $(error Finch on Windows ARM not supported)
 endif
 
-FINCH_IMAGE_LOCATION := $(OS_OUTDIR)/$(FINCH_ROOTFS_BASENAME)
+# This variable is used to generate release builds, where the OS rootfs path should be overwritten
+# to C:/Program Files/Finch/...
+FINCH_OS_IMAGE_LOCATION_ROOT ?= $(DEST)
+FINCH_IMAGE_LOCATION := $(FINCH_OS_IMAGE_LOCATION_ROOT)/os/$(FINCH_ROOTFS_BASENAME)
 FINCH_IMAGE_DIGEST := "sha512:$(FINCH_ROOTFS_DIGEST)"
 
 $(OS_OUTDIR)/finch.yaml: $(OS_OUTDIR) finch.yaml.d/common.yaml finch.yaml.d/windows.yaml

--- a/msi-builder/README.md
+++ b/msi-builder/README.md
@@ -4,7 +4,7 @@ Finch Windows MSI Tool to generate MSI installer from Finch build
 
 ## Instructions
 
-[1] Build finch:  `make FINCH_OS_IMAGE_LOCATION_ROOT=/__INSTALLFOLDER__`
+[1] Build finch:  `make FINCH_OS_IMAGE_LOCATION_ROOT=__INSTALLFOLDER__`
 
 - It will inject the placeholder `__INSTALLFOLDER__` into `os\finch.yaml` for the rootfs location
 

--- a/msi-builder/README.md
+++ b/msi-builder/README.md
@@ -4,7 +4,7 @@ Finch Windows MSI Tool to generate MSI installer from Finch build
 
 ## Instructions
 
-[1] Build finch:  `make FINCH_ROOTFS_LOCATION_ROOT=/__INSTALLFOLDER__`
+[1] Build finch:  `make FINCH_OS_IMAGE_LOCATION_ROOT=/__INSTALLFOLDER__`
 
 - It will inject the placeholder `__INSTALLFOLDER__` into `os\finch.yaml` for the rootfs location
 


### PR DESCRIPTION
Issue #, if available:
- MSI release builds are broken, as seen in [this automated run](https://github.com/runfinch/finch/actions/runs/9764308833/job/26959973907)
    - Debugged by looking at the lima stderr logs and found:
    ```
    {"level":"fatal","msg":"failed to download \"file://C:/actions-runner/_work/finch/finch/_output/os/finch-rootfs-production-amd64-1719439880.tar.gz\": open C:/actions-runner/_work/finch/finch/_output/os/finch-rootfs-production-amd64-1719439880.tar.gz: The system cannot find the path specified.","time":"2024-07-02T19:14:36Z"}
    ```

*Description of changes:*
- This regression occurred because `FINCH_ROOTFS_LOCATION_ROOT` was removed from the Makefile during recent refactoring. `FINCH_ROOTFS_LOCATION_ROOT` was used to override the path of the rootfs file used at runtime by Lima. Removing it means that release builds, which are installed to different locations than dev builds, will not function. This PR makes it so Windows follows the macOS Makefile variable name (`FINCH_OS_IMAGE_LOCATION_ROOT`), as seen in https://github.com/runfinch/finch/pull/1007

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
