### PR TITLE
ci: drop macOS 11 runners in packager testing

### DIFF
--- a/.github/workflows/build-and-test-pkg.yaml
+++ b/.github/workflows/build-and-test-pkg.yaml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [11, 13, 14]
+        version: [13, 14]
     needs:
       - get-tag-name
       - macos-aarch64-pkg-build
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [11, 13, 14]
+        version: [13, 14]
     needs:
       - get-tag-name
       - macos-x86-64-pkg-build


### PR DESCRIPTION
Issue #, if available:
https://github.com/runfinch/infrastructure/issues/649

*Description of changes:*
macOS 11 is EOL so packaging testing can be dropped to reduce macOS runner costs for CI.

*Testing done:*
CI is successful

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
