### PR TITLE
ci: apply WSL hanging workaround to MSI builder

### DIFF
--- a/.github/workflows/build-and-test-msi.yaml
+++ b/.github/workflows/build-and-test-msi.yaml
@@ -199,6 +199,9 @@ jobs:
           aws-region: ${{ secrets.REGION }}
       - name: Remove Finch VM
         run: |
+          # We want these cleanup commands to always run, ignore errors so the step completes.
+          $ErrorActionPreference = 'Ignore'
+          taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
           wsl --list --verbose
           wsl --shutdown
           wsl --unregister lima-finch
@@ -241,6 +244,9 @@ jobs:
             make test-e2e-vm
       - name: Remove Finch VM
         run: |
+          # We want these cleanup commands to always run, ignore errors so the step completes.
+          $ErrorActionPreference = 'Ignore'
+          taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
           wsl --list --verbose
           wsl --shutdown
           Start-Sleep -s 10

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -240,6 +240,9 @@ jobs:
           aws-region: ${{ secrets.REGION }}
       - name: Remove Finch VM
         run: |
+          # We want these cleanup commands to always run, ignore errors so the step completes.
+          $ErrorActionPreference = 'Ignore'
+          taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
           wsl --list --verbose
           wsl --shutdown
           wsl --unregister lima-finch


### PR DESCRIPTION
Issue #, if available:
The MSI builder workflow is stuck due to WSL hanging issue.

*Description of changes:*
This change applies the workaround for WSL hanging to the MSI builder workflow.

*Testing done:*
CI is successful

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
