### PR TITLE
fix: remove llvm copy to fix build errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ UNAME := $(shell uname -m)
 ARCH ?= $(UNAME)
 SUPPORTED_ARCH = false
 LICENSEDIR := $(OUTDIR)/license-files
-VERSION := $(shell git describe --match 'v[0-9]*' --dirty='.modified' --always --tags)
+VERSION ?= $(shell git describe --match 'v[0-9]*' --dirty='.modified' --always --tags)
 GITCOMMIT := $(shell git rev-parse HEAD)$(shell test -z "$(git status --porcelain)" || echo .m)
 LDFLAGS = "-w -X $(PACKAGE)/pkg/version.Version=$(VERSION) -X $(PACKAGE)/pkg/version.GitCommit=$(GITCOMMIT)"
 MIN_MACOS_VERSION ?= 11.0

--- a/installer-builder/tools/extract-executables.sh
+++ b/installer-builder/tools/extract-executables.sh
@@ -60,12 +60,6 @@ extractExecutables() {
             newpath="./installer-builder/output/executables/unsigned/package/artifact/EXECUTABLES_TO_SIGN/$newname"
             cp -a "$1/$file" "$newpath"
             codesign --remove-signature "$newpath"
-            "$(brew --prefix)"/opt/llvm/bin/llvm-objcopy \
-                --keep-undefined \
-                --add-section \
-                __TEXT,__info_plist=./installer-builder/darwin/Info.plist \
-                "$newpath" \
-                "$newpath"
             #qemu needs specific entitlement, handle it separately
             if [[ $file == "qemu-system-x86_64" || $file == "qemu-system-aarch64" ]];
             then


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
remove llvm copy as the step is not required and was causing inconsistent build failures

*Testing done:*
Local Testing and pipeline test


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
