### PR TITLE
fix: typo causing error while downloading license

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ download-licenses:
 	curl https://raw.githubusercontent.com/golangci/golangci-lint-action/master/LICENSE --output "$(LICENSEDIR)/github.com/golangci/golangci-lint-action/LICENSE"
 	mkdir -p "$(LICENSEDIR)/github.com/avto-dev/markdown-lint"
 	curl https://raw.githubusercontent.com/avto-dev/markdown-lint/master/LICENSE --output "$(LICENSEDIR)/github.com/avto-dev/markdown-lint/LICENSE"
-	mkdir -p "$(LICENSEDIR)"/github.com/ludeeus/action-shellcheck"
+	mkdir -p "$(LICENSEDIR)/github.com/ludeeus/action-shellcheck"
 	curl https://raw.githubusercontent.com/ludeeus/action-shellcheck/blob/2.0.0/LICENSE --output "$(LICENSEDIR)/github.com/ludeeus/action-shellcheck/LICENSE"
 
     ### dependencies in ci.yaml - end ###


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
typo causing license download failure
```
mkdir -p "/Users/ec2-user/ar/_work/finch/finch/_output/license-files"/github.com/ludeeus/action-shellcheck"
/bin/sh: -c: line 0: unexpected EOF while looking for matching `"'
/bin/sh: -c: line 1: syntax error: unexpected end of file
```

*Testing done:*
Successfully downloaded all licenses

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
