### PR TITLE
ci: add review dependencies workflow

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,9 @@
+# Fail third party dependency usage if not covered by the curated set of pre-approved licenses.
+#
+# List was generated from guidance set forth by Amazon open source usage policies.
+allow-licenses:
+  - 'Apache-2.0'
+  - 'BSD-2-Clause'
+  - 'BSD-3-Clause'
+  - 'ISC'
+  - 'MIT'

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -67,10 +67,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "Skipping CI for docs & contrib files"
-  check-licenses:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Skipping CI for docs & contrib files"
   e2e-tests:
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -132,15 +132,6 @@ jobs:
       # TODO: Use `go mod tidy --check` after https://github.com/golang/go/issues/27005 is fixed.
       - run: go mod tidy
       - run: git diff --exit-code
-  check-licenses:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
-        with:
-          go-version-file: go.mod
-          cache: true
-      - run: make check-licenses
   e2e-tests:
     strategy:
       fail-fast: false

--- a/.github/workflows/review-dependencies.yaml
+++ b/.github/workflows/review-dependencies.yaml
@@ -1,0 +1,24 @@
+name: Review dependencies
+
+on:
+  pull_request:
+    branches: ['main', 'release/**']
+    paths:
+      - 'go.*'
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Write permissions needed to comment review results on PR.
+      # Pwn request risk mitigated by using pull_request workflow trigger
+      # and external contributor workflow runs require maintainer approval.
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/dependency-review-action@5a2ce3f5b92ee19cbb1541a4984c76d921601d7c # v4.3.4
+        with:
+          config-file: './.github/dependency-review-config.yml'
+          comment-summary-in-pr: always

--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,13 @@ download-licenses:
 
     ### dependencies in release-please.yaml - end ###
 
+    ### dependencies in review-dependencies.yaml - start ###
+
+	mkdir -p "$(LICENSEDIR)/github.com/actions/dependency-review-action"
+	curl https://github.com/actions/dependency-review-action/main/LICENSE --output "$(LICENSEDIR)/github.com/actions/dependency-review-action/LICENSE"
+
+    ### dependencies in review-dependencies.yaml - end ###
+
     ### system-level dependencies - start ###
 
 	mkdir -p "$(LICENSEDIR)/github.com/lima-vm/lima"


### PR DESCRIPTION
Issue #, if available:
N/A

*Description of changes:*
This change improves on the current license check mechanism by using actions/dependency-review-action which also provides known vulnerability protection and insight into dependency OpenSSF Scorecard values for added third-party dependencies.

*Testing done:*
N/A

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
