### PR TITLE
ci: Update workflow logic to fix release automation trigger

### DIFF
--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -1,9 +1,7 @@
 name: Release Finch latest version
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_call:
 
 jobs:
   get-latest-tag:

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -7,5 +7,13 @@ name: release-please
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
+        id: release
+  trigger-release-automation:
+    name: Trigger release-automation.yaml if PR is merged
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/release-automation.yaml


### PR DESCRIPTION
Issue #, if available:
Release Automation is manually triggered via the Github UI today

*Description of changes:*
- Added trigger-release-automation step to the release-please.yaml file
- replace 'push: tag' event trigger with  'workflow_call:' trigger event in release-automation.yaml file

*Testing done:*
- was able to trigger the complete workflow in [my fork](https://github.com/coderbirju/finch/actions/runs/10802141399)

Although I have not seen it through completely as I don't have AWS credentials configured in my fork.

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
