### PR TITLE
chore: update Amazon ECR credential helper to v0.9.0

### DIFF
--- a/pkg/dependency/credhelper/cred_helper.go
+++ b/pkg/dependency/credhelper/cred_helper.go
@@ -66,9 +66,9 @@ func newDeps(
 	configs := map[string]helperConfig{}
 	installFolder := filepath.Join(finchDir, "cred-helpers")
 
-	const versionEcr = "0.8.0"
-	const hashARM64 = "sha256:d62badea3153688ec5c24f440df9fb84ff4b02c624dff9288967267e7445daa1"
-	const hashAMD64 = "sha256:dcc7ae9915b5d8fa2d9e2b18fc30bab5bfbbce5b82401c7644e6ab97973ac35c"
+	const versionEcr = "0.9.0"
+	const hashARM64 = "sha256:76aa3bb223d4e64dd4456376334273f27830c8d818efe278ab6ea81cb0844420"
+	const hashAMD64 = "sha256:dd6bd933e439ddb33b9f005ad5575705a243d4e1e3d286b6c82928bcb70e949a"
 	credHelperURLEcr := fmt.Sprintf("https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com"+
 		"/%s/linux-%s/docker-credential-ecr-login", versionEcr, arch)
 

--- a/pkg/dependency/credhelper/cred_helper_binary_test.go
+++ b/pkg/dependency/credhelper/cred_helper_binary_test.go
@@ -249,7 +249,7 @@ func TestBinaries_Install(t *testing.T) {
 				l.EXPECT().Infof("Installing %s credential helper", "ecr")
 				creator.EXPECT().Create("curl", "--retry", "5", "--retry-max-time", "30", "--url",
 					"https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com"+
-						"/0.7.0/linux-arm64/docker-credential-ecr-login", "--output",
+						"/0.9.0/linux-arm64/docker-credential-ecr-login", "--output",
 					filepath.Join("mock_prefix", "cred-helpers", "docker-credential-ecr-login")).Return(cmd)
 			},
 			want: nil,
@@ -287,11 +287,11 @@ func TestBinaries_Install(t *testing.T) {
 			tc.mockSvc(l, cmd, creator, mFs)
 
 			credHelperURL := "https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com" +
-				"/0.7.0/linux-arm64/docker-credential-ecr-login"
+				"/0.9.0/linux-arm64/docker-credential-ecr-login"
 
 			hc := helperConfig{
 				"docker-credential-ecr-login", credHelperURL,
-				"sha256:ec5c04babea79b08dffb0c8acb67b9e28dc05be0fe9bd4df2e234d75516061d7",
+				"sha256:76aa3bb223d4e64dd4456376334273f27830c8d818efe278ab6ea81cb0844420",
 				"mock_prefix/cred-helpers/",
 				"mock_prefix/.finch/",
 			}


### PR DESCRIPTION
Issue #, if available:
Part of https://github.com/runfinch/finch/issues/868

*Description of changes:*
This change updates the version of the Amazon ECR cred helper to v0.9.0

*Testing done:*
1. I ran the credential helper binary test
2. I started a VM and verified the version of the cred helper


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
