### PR TITLE
build(deps): update nerdctl-full and soci versions

### DIFF
--- a/e2e/vm/version_remote_test.go
+++ b/e2e/vm/version_remote_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 const (
-	nerdctlVersion    = "v1.7.6"
-	buildKitVersion   = "v0.12.5"
-	containerdVersion = "v1.7.16"
-	runcVersion       = "1.1.12"
+	nerdctlVersion    = "v1.7.7"
+	buildKitVersion   = "v0.15.2"
+	containerdVersion = "v1.7.22"
+	runcVersion       = "1.1.14"
 )
 
 type Versions struct {

--- a/finch.yaml.d/common.yaml
+++ b/finch.yaml.d/common.yaml
@@ -8,13 +8,13 @@ containerd:
   user: false
   # Override containerd archive
   # 🟢 Builtin default: hard-coded URL with hard-coded digest (see the output of `limactl info | jq .defaultTemplate.containerd.archives`)
-  #   archives:
-  #   - location: "https://deps.runfinch.com/x86-64/nerdctl-full-1.7.2-1-linux-amd64.tar.gz"
-  #     arch: "x86_64"
-  #     digest: "sha256:90851068e58417551384dafb3fced8165cbfa2799b51849f85f44c0ebef2c37a"
-  #   - location: "https://deps.runfinch.com/aarch64/nerdctl-full-1.7.2-1-linux-arm64.tar.gz"
-  #     arch: "aarch64"
-  #     digest: "sha256:f354541e6234235f2ea32d6ed64e9d59a7cc4e0b7f15e63deef9cd5e90a298ef"
+  archives:
+  - location: "https://deps.runfinch.com/x86-64/nerdctl-full-1.7.7-linux-amd64.tar.gz"
+    arch: "x86_64"
+    digest: "sha256:a731eac93e8e9dda1a0d76dc1606438deb0668ea7d6bd5c5af436353ed9f65c5"
+  - location: "https://deps.runfinch.com/aarch64/nerdctl-full-1.7.7-linux-arm64.tar.gz"
+    arch: "aarch64"
+    digest: "sha256:b161a20c0e41f9ad999e8411e23c58ece4b3e584ae90b4252b76a39eee4a0c31"
 
 provision:
   - mode: system

--- a/pkg/config/lima_config_applier.go
+++ b/pkg/config/lima_config_applier.go
@@ -43,7 +43,7 @@ if [ ! -f /usr/local/bin/soci ]; then
 	  (echo "error: shasum verification failed for SOCI release tarball" && rm -f "${release_tarball}" && exit 1)
 
 	# move to usr/local/bin
-	tar -C /usr/local/bin -xvf ${release_tarball} ./soci ./soci-snapshotter-grpc
+	tar -C /usr/local/bin -xvf ${release_tarball} soci soci-snapshotter-grpc
 
 	# install as a systemd service
 	curl --retry 2 --retry-max-time 120 -OL "%s"

--- a/pkg/config/lima_config_applier.go
+++ b/pkg/config/lima_config_applier.go
@@ -20,9 +20,9 @@ import (
 )
 
 const (
-	sociVersion                              = "0.5.0"
-	sociAMD64Sha256Sum                       = "768f73dbd2c772386df1d12d0a371e9cbcefebea4856623335a2e8ea5170691c"
-	sociARM64Sha256Sum                       = "9238e00426ec67a725d511e232476248f2379d66a4ccab224a50ad4c56a0292e"
+	sociVersion                              = "0.7.0"
+	sociAMD64Sha256Sum                       = "8766cdd479272dcc86299e70a0f7a9343f940c98285c1491bb3c3cdc05b26f47"
+	sociARM64Sha256Sum                       = "731d846b0884840feeba5dcc0f10d0b326d843d991b2ba1bee7ad2c90c225032"
 	snapshotterProvisioningScriptHeader      = "# snapshotter provisioning script"
 	sociInstallationProvisioningScriptHeader = snapshotterProvisioningScriptHeader + ": soci"
 	sociFileNameFormat                       = "soci-snapshotter-%s-linux-%s.tar.gz"


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Uses the latest nerdctl-full archive from nerdctl v1.7.7 to update nerdctl, containerd, buildkit, cni, and runc
- Updates to the latest SOCI version

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
