### PR TITLE
ci(fix): update conditions

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -15,7 +15,10 @@ on:
     paths:
       - '**.md'
       - 'contrib/**'
-      - '.github/CODEOWNERS'
+      - '!contrib/packaging/**'
+      - '.github/**'
+      - '!.github/workflows/ci.yaml'
+      - '!.github/workflows/e2e-*.yaml'
   pull_request:
     branches:
       - main
@@ -23,7 +26,9 @@ on:
       - '**.md'
       - 'contrib/**'
       - '!contrib/packaging/**'
-      - '.github/CODEOWNERS'
+      - '.github/**'
+      - '!.github/workflows/ci.yaml'
+      - '!.github/workflows/e2e-*.yaml'
 
 jobs:
   git-secrets:
@@ -32,10 +37,10 @@ jobs:
       - name: Pull latest awslabs/git-secrets repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
-           repository: awslabs/git-secrets
-           ref: 1.3.0
-           fetch-tags: true
-           path: git-secrets
+          repository: awslabs/git-secrets
+          ref: 1.3.0
+          fetch-tags: true
+          path: git-secrets
       - name: Install git secrets from source
         run: sudo make install
         working-directory: git-secrets
@@ -72,26 +77,42 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "Skipping CI for docs & contrib files"
-  e2e-tests:
+  macos-e2e-tests:
     strategy:
       matrix:
         os:
           [
-            [self-hosted, macos, amd64, 13, test],
-            [self-hosted, macos, amd64, 14, test],
-            [self-hosted, macos, arm64, 13, test],
-            [self-hosted, macos, arm64, 14, test],
+            [13, test-e2e-container, X64, test],
+            [13, test-e2e-container, arm64, test],
+            [13, test-e2e-vm-serial, X64, test],
+            [13, test-e2e-vm-serial, arm64, test],
+            [14, test-e2e-container, X64, test],
+            [14, test-e2e-container, arm64, test],
+            [14, test-e2e-vm-serial, X64, test],
+            [14, test-e2e-vm-serial, arm64, test],
           ]
-        test-command: ['test-e2e-vm-serial', 'test-e2e-container']
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - run: echo "Skipping CI for docs & contrib files"
   windows-e2e-tests:
     strategy:
       matrix:
-        os: [[self-hosted, windows, amd64, test]]
-        test-command: ['test-e2e-vm-serial', 'test-e2e-container']
-    runs-on: ${{ matrix.os }}
+        os:
+          [[test-e2e-container, amd64, test], [test-e2e-vm-serial, amd64, test]]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipping CI for docs & contrib files"
+  linux-e2e-tests:
+    strategy:
+      matrix:
+        os:
+          [
+            [amazonlinux, X64, 2, test-e2e-container, test],
+            [amazonlinux, X64, 2023, test-e2e-container, test],
+            [amazonlinux, arm64, 2, test-e2e-container, test],
+            [amazonlinux, arm64, 2023, test-e2e-container, test],
+          ]
+    runs-on: ubuntu-latest
     steps:
       - run: echo "Skipping CI for docs & contrib files"
   mdlint:

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -107,10 +107,10 @@ jobs:
       matrix:
         os:
           [
-            [amazonlinux, X64, 2, test-e2e-container, test],
-            [amazonlinux, X64, 2023, test-e2e-container, test],
-            [amazonlinux, arm64, 2, test-e2e-container, test],
-            [amazonlinux, arm64, 2023, test-e2e-container, test],
+            [amazonlinux, X64, 2, test],
+            [amazonlinux, X64, 2023, test],
+            [amazonlinux, arm64, 2, test],
+            [amazonlinux, arm64, 2023, test],
           ]
     uses: ./.github/workflows/e2e-docs.yaml
     with:

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -91,17 +91,13 @@ jobs:
             [14, test-e2e-vm-serial, X64, test],
             [14, test-e2e-vm-serial, arm64, test],
           ]
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Skipping CI for docs & contrib files"
+    uses: ./.github/workflows/e2e-docs.yaml
   windows-e2e-tests:
     strategy:
       matrix:
         os:
           [[test-e2e-container, amd64, test], [test-e2e-vm-serial, amd64, test]]
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Skipping CI for docs & contrib files"
+    uses: ./.github/workflows/e2e-docs.yaml
   linux-e2e-tests:
     strategy:
       matrix:
@@ -112,9 +108,7 @@ jobs:
             [amazonlinux, arm64, 2, test-e2e-container, test],
             [amazonlinux, arm64, 2023, test-e2e-container, test],
           ]
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Skipping CI for docs & contrib files"
+    uses: ./.github/workflows/e2e-docs.yaml
   mdlint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -92,12 +92,16 @@ jobs:
             [14, test-e2e-vm-serial, arm64, test],
           ]
     uses: ./.github/workflows/e2e-docs.yaml
+    with:
+      os: ${{ matrix.os }}
   windows-e2e-tests:
     strategy:
       matrix:
         os:
           [[test-e2e-container, amd64, test], [test-e2e-vm-serial, amd64, test]]
     uses: ./.github/workflows/e2e-docs.yaml
+    with:
+      os: ${{ matrix.os }}
   linux-e2e-tests:
     strategy:
       matrix:
@@ -109,6 +113,8 @@ jobs:
             [amazonlinux, arm64, 2023, test-e2e-container, test],
           ]
     uses: ./.github/workflows/e2e-docs.yaml
+    with:
+      os: ${{ matrix.os }}
   mdlint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -185,7 +185,6 @@ jobs:
         os: ['amazonlinux']
         arch: ['X64', 'arm64']
         version: ['2023', '2']
-        test-command: ['test-e2e-container']
         runner-type: ['test']
     uses: ./.github/workflows/e2e-linux.yaml
     secrets: inherit
@@ -194,7 +193,6 @@ jobs:
       arch: ${{ matrix.arch }}
       version: ${{ matrix.version }}
       runner-type: ${{ matrix.runner-type }}
-      test-command: ${{ matrix.test-command }}
 
   mdlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,18 +5,25 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "**.md"
-      - "contrib/**"
-      - ".github/CODEOWNERS"
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/ci.yaml'
+      - '.github/workflows/e2e-*.yaml'
+      - 'contrib/packaging/**'
+      - '!contrib/hello-finch/**'
   pull_request:
     branches:
       - main
     paths:
-      - "**.go"
-      - "contrib/packaging/**"
-      - "!contrib/hello-finch/**"
-      - "!.github/CODEOWNERS"
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/ci.yaml'
+      - '.github/workflows/e2e-*.yaml'
+      - 'contrib/packaging/**'
+      - '!contrib/hello-finch/**'
   workflow_dispatch:
 permissions:
   id-token: write
@@ -147,10 +154,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["13", "14"]
-        test-command: ["test-e2e-vm-serial", "test-e2e-container"]
-        arch: ["X64", "arm64"]
-        runner-type: ["test"]
+        version: ['13', '14']
+        test-command: ['test-e2e-vm-serial', 'test-e2e-container']
+        arch: ['X64', 'arm64']
+        runner-type: ['test']
     uses: ./.github/workflows/e2e-macos.yaml
     secrets: inherit
     with:
@@ -162,9 +169,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-command: ["test-e2e-vm-serial", "test-e2e-container"]
-        arch: ["amd64"]
-        runner-type: ["test"]
+        test-command: ['test-e2e-vm-serial', 'test-e2e-container']
+        arch: ['amd64']
+        runner-type: ['test']
     uses: ./.github/workflows/e2e-windows.yaml
     secrets: inherit
     with:
@@ -175,11 +182,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["amazonlinux"]
-        arch: ["X64", "arm64"]
-        version: ["2023", "2"]
-        test-command: ["test-e2e-container"]
-        runner-type: ["test"]
+        os: ['amazonlinux']
+        arch: ['X64', 'arm64']
+        version: ['2023', '2']
+        test-command: ['test-e2e-container']
+        runner-type: ['test']
     uses: ./.github/workflows/e2e-linux.yaml
     secrets: inherit
     with:
@@ -195,6 +202,6 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: avto-dev/markdown-lint@04d43ee9191307b50935a753da3b775ab695eceb # v1.5.0
         with:
-          args: "**/*.md"
+          args: '**/*.md'
           # CHANGELOG.md is only updated by release-please bot.
-          ignore: "CHANGELOG.md"
+          ignore: 'CHANGELOG.md'

--- a/.github/workflows/e2e-docs.yaml
+++ b/.github/workflows/e2e-docs.yaml
@@ -1,0 +1,11 @@
+name: e2e-docs
+on:
+  workflow_call:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip
+        run: |
+          echo "Skipping CI for docs & contrib files"

--- a/.github/workflows/e2e-docs.yaml
+++ b/.github/workflows/e2e-docs.yaml
@@ -1,10 +1,13 @@
 name: e2e-docs
 on:
   workflow_call:
-
+    inputs:
+      os:
+        type: string
+        required: true
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ['self-hosted', '${{ fromJson(inputs.os) }}']
     steps:
       - name: Skip
         run: |

--- a/.github/workflows/e2e-linux.yaml
+++ b/.github/workflows/e2e-linux.yaml
@@ -14,9 +14,6 @@ on:
       runner-type:
         type: string
         required: true
-      test-command:
-        type: string
-        required: true
 
 permissions:
   # This is required for configure-aws-credentials to request an OIDC JWT ID token to access AWS resources later on.
@@ -96,7 +93,7 @@ jobs:
           git clean -f -d
           # required by one of the tests which uses SSH_AUTH_SOCK
           eval "$(ssh-agent -s)"
-          INSTALLED=true REGISTRY=${{ steps.vars.outputs.has_creds == true && env.REGISTRY || '' }} sudo -E make ${{ inputs.test-command }}
+          INSTALLED=true REGISTRY=${{ steps.vars.outputs.has_creds == true && env.REGISTRY || '' }} sudo -E make test-e2e-container
       - name: Clean up repo AL2
         if: ${{ (startsWith(inputs.os, 'amazon') && inputs.version == '2' && always() ) }}
         run: |


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Currently, there are some files which will trigger neither the "real" e2e tests, or the linters/doc tests because they are not included in the `path` of either `ci.yaml` or `ci-docs.yaml`. This change should update those paths so all files are covered by the appropriate test suite, and also update the names of the test steps to match the expected "required" tests which are configured in the repository settings

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
