### PR TITLE
fix: allow finch commands to run using default config

### DIFF
--- a/cmd/finch/main_native.go
+++ b/cmd/finch/main_native.go
@@ -44,7 +44,7 @@ func xmain(logger flog.Logger,
 	)
 	if err != nil {
 		if errors.Is(err, os.ErrPermission) {
-			logger.Warnf("Failed to load config, using default values. Are you running as root? (%s)", err)
+			logger.Warnf("Failed to load config, using default values. You may need to be root or use sudo. (%s)", err)
 		} else {
 			return fmt.Errorf("failed to load config: %w", err)
 		}

--- a/cmd/finch/main_native.go
+++ b/cmd/finch/main_native.go
@@ -6,8 +6,10 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -41,7 +43,11 @@ func xmain(logger flog.Logger,
 		ecc,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
+		if errors.Is(err, os.ErrPermission) {
+			logger.Warnf("Failed to load config, using default values. Are you running as root? (%s)", err)
+		} else {
+			return fmt.Errorf("failed to load config: %w", err)
+		}
 	}
 
 	return newApp(

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -137,7 +137,7 @@ func Load(
 				return nil, fmt.Errorf("failed to ensure %q directory: %w", cfgPath, err)
 			}
 			if err := writeConfig(defCfg, fs, cfgPath); err != nil {
-				return nil, err
+				log.Warnf("Could not save default values to %q: %w", cfgPath, err)
 			}
 			return defCfg, nil
 		}


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Makes it so config requirements are not as strict. This allows basic commands, like `finch help` and `finch version` to work on Linux, even when not running as root.
- Also added a warning message when the running user does not have permission to read the config file.

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
