### PR TITLE
revert(linux): DOCKER_CONFIG path (#1102)

### DIFF
--- a/cmd/finch/main_native.go
+++ b/cmd/finch/main_native.go
@@ -86,7 +86,6 @@ var newApp = func(
 		logger,
 		fp.NerdctlConfigFilePath(),
 		fp.BuildkitSocketPath(),
-		fp.DockerConfigDir(),
 		fp.FinchDependencyBinDir(),
 		system.NewStdLib(),
 	)

--- a/pkg/command/nerdctl_native.go
+++ b/pkg/command/nerdctl_native.go
@@ -20,7 +20,6 @@ import (
 const (
 	EnvKeyNerdctlTOML  = "NERDCTL_TOML"
 	EnvKeyBuildkitHost = "BUILDKIT_HOST"
-	EnvKeyDockerConfig = "DOCKER_CONFIG"
 )
 
 type nerdctlCmdCreator struct {
@@ -29,7 +28,6 @@ type nerdctlCmdCreator struct {
 	systemDeps         NerdctlCmdCreatorSystemDeps
 	nerdctlConfigPath  string
 	buildkitSocketPath string
-	dockerConfigPath   string
 	binPath            string
 }
 
@@ -41,7 +39,6 @@ func NewNerdctlCmdCreator(
 	logger flog.Logger,
 	nerdctlConfigPath string,
 	buildkitSocketPath string,
-	dockerConfigPath string,
 	binPath string,
 	systemDeps NerdctlCmdCreatorSystemDeps,
 ) NerdctlCmdCreator {
@@ -50,7 +47,6 @@ func NewNerdctlCmdCreator(
 		logger:             logger,
 		nerdctlConfigPath:  nerdctlConfigPath,
 		buildkitSocketPath: buildkitSocketPath,
-		dockerConfigPath:   dockerConfigPath,
 		binPath:            binPath,
 		systemDeps:         systemDeps,
 	}
@@ -69,7 +65,6 @@ func (ncc *nerdctlCmdCreator) create(stdin io.Reader, stdout, stderr io.Writer, 
 	newPathEnv = append(
 		newPathEnv,
 		fmt.Sprintf("%s=%s", EnvKeyNerdctlTOML, ncc.nerdctlConfigPath),
-		fmt.Sprintf("%s=%s", EnvKeyDockerConfig, ncc.dockerConfigPath),
 		fmt.Sprintf("%s=unix://%s", EnvKeyBuildkitHost, ncc.buildkitSocketPath),
 	)
 

--- a/pkg/command/nerdctl_native_test.go
+++ b/pkg/command/nerdctl_native_test.go
@@ -18,7 +18,6 @@ import (
 const (
 	mockNerdctlConfigPath  = "/etc/finch/nerdctl.toml"
 	mockBuildkitSocketPath = "/etc/finch/buildkit"
-	mockDockerConfigPath   = "/etc/finch/docker"
 	mockFinchBinPath       = "/usr/lib/usrexec/finch"
 	mockSystemPath         = "/usr/bin"
 	finalPath              = mockFinchBinPath + command.EnvKeyPathJoiner + mockSystemPath
@@ -48,7 +47,6 @@ func TestLimaCmdCreator_Create(t *testing.T) {
 				cmd.EXPECT().SetEnv([]string{
 					fmt.Sprintf("%s=%s", command.EnvKeyPath, finalPath),
 					fmt.Sprintf("%s=%s", command.EnvKeyNerdctlTOML, mockNerdctlConfigPath),
-					fmt.Sprintf("%s=%s", command.EnvKeyDockerConfig, mockDockerConfigPath),
 					fmt.Sprintf("%s=unix://%s", command.EnvKeyBuildkitHost, mockBuildkitSocketPath),
 				})
 				cmd.EXPECT().SetStdin(nil)
@@ -74,7 +72,6 @@ func TestLimaCmdCreator_Create(t *testing.T) {
 				logger,
 				mockNerdctlConfigPath,
 				mockBuildkitSocketPath,
-				mockDockerConfigPath,
 				mockFinchBinPath,
 				lcd,
 			).Create(mockArgs...)

--- a/pkg/path/finch_linux.go
+++ b/pkg/path/finch_linux.go
@@ -34,12 +34,6 @@ func (fp Finch) BuildkitSocketPath() string {
 	return filepath.Join(fp.FinchRuntimeDataDir(), "buildkit", "buildkitd.sock")
 }
 
-// DockerConfigDir returns the path to the docker config file.
-// nerdctl uses ${DOCKER_CONFIG}/config.json for authentication with image registries.
-func (fp Finch) DockerConfigDir() string {
-	return filepath.Join(string(fp), "docker")
-}
-
 // FinchDependencyBinDir returns the path to Finch's local helper or dependency binaries.
 // Currently used for vended version of BuildKit.
 func (Finch) FinchDependencyBinDir() string {


### PR DESCRIPTION
This reverts commit 5b45b756460a85a0dcc0a9986336a92c9b74ff7e.

Issue #, if available:

*Description of changes:*
- Reverting #1102 because the soci-snapshotter service does not use `DOCKER_CONFIG` passed by clients to get credentials. Customizing the directory causes SOCI to not find credentials at the default path, which causes performance regressions.

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
