### PR TITLE
ci(fix): release automation not picking up all necessary files

### DIFF
--- a/installer-builder/tools/extract-executables.sh
+++ b/installer-builder/tools/extract-executables.sh
@@ -36,7 +36,7 @@ updateQEMUEntitlement() {
 
 #$1: the file object
 extractExecutables() {
-    for file in $(ls -a "$1")
+    for file in $(ls -1a "$1")
     do
         if [ -d "$1/$file" ];
         then
@@ -44,7 +44,7 @@ extractExecutables() {
             then
                 extractExecutables "$1/$file"
             fi
-        elif [[ -x $1/$file || ($file == *.dylib && ! (-L $1/$file)) ]];
+        elif [[ -x $1/$file || (($file == *.dylib || $file == *.dylib.*) && ! (-L $1/$file)) ]];
         then
             #extract executables from all file directory to one folder
             #to have the ability to merge back, rename the executables with the file path


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Release automation is not picking up all of the necessary files, as seen in [this error log](https://github.com/runfinch/finch/actions/runs/11018224408/job/30611108682#step:13:386):
    ```
    {"level":"fatal","msg":"failed to run [/Applications/Finch/lima/bin/qemu-system-aarch64 -M none -accel help]: stdout=\"\", stderr=\"dyld[36804]: Library not loaded: @executable_path/../opt/dtc/lib/libfdt.1.dylib\\n  Referenced from: \u003cCAB6AC47-D2D1-363F-A541-48C742F68615\u003e /Applications/Finch/lima/bin/qemu-system-aarch64\\n  Reason: tried: '/Applications/Finch/lima/opt/dtc/lib/libfdt.1.dylib' (code signature in \u003c1B9F4227-11D9-3DEC-8CEE-9B58326AE7FA\u003e '/Applications/Finch/lima/Cellar/dtc/1.7.1/lib/libfdt.dylib.1.7.1' not valid for use in process: mapped file has no Team ID and is not a platform binary (signed with custom identity or adhoc?)), '/usr/lib/libfdt.1.dylib' (no such file, not in dyld cache)\\n\"","time":"2024-09-24T21:48:08Z"}
    ```
    - The reason for this is because the file in question does not match the pattern. This PR updates the pattern.


*Testing done:*
- Tested on local machine


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
