### PR TITLE
ci: allow manual runs with ref_name parameter for pkg build workflow

### DIFF
--- a/.github/workflows/build-and-test-pkg.yaml
+++ b/.github/workflows/build-and-test-pkg.yaml
@@ -3,6 +3,10 @@ name: Build, test and upload .pkg to S3
 # The scheduler runs at 9 am UTC every day.
 on:
   workflow_dispatch:
+    inputs:
+      ref_name:
+        required: true
+        type: string
   workflow_call:
     inputs:
       ref_name:


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Allow providing a ref_name when workflow is manually triggered

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
