### PR TITLE
fix: check config file before accessing values

### DIFF
--- a/cmd/finch/main.go
+++ b/cmd/finch/main.go
@@ -45,7 +45,7 @@ func initializeNerdctlCommands(
 		allNerdctlCommands = append(allNerdctlCommands, nerdctlCommandCreator.create(cmdName, cmdDescription))
 	}
 
-	if fc.DockerCompat {
+	if fc != nil && fc.DockerCompat {
 		for cmdName, cmdDescription := range dockerCompatCmds {
 			allNerdctlCommands = append(allNerdctlCommands, nerdctlCommandCreator.create(cmdName, cmdDescription))
 		}

--- a/cmd/finch/nerdctl.go
+++ b/cmd/finch/nerdctl.go
@@ -246,7 +246,7 @@ var cmdFlagSetMap = map[string]map[string]sets.Set[string]{
 
 // converts "docker build --load" flag to "nerdctl build --output=type=docker".
 func handleDockerBuildLoad(_ NerdctlCommandSystemDeps, fc *config.Finch, nerdctlCmdArgs []string, index int) error {
-	if fc.DockerCompat {
+	if fc != nil && fc.DockerCompat {
 		nerdctlCmdArgs[index] = "--output=type=docker"
 	}
 
@@ -277,7 +277,7 @@ func handleBuildx(_ NerdctlCommandSystemDeps, fc *config.Finch, cmdName *string,
 }
 
 func handleDockerCompatInspect(_ NerdctlCommandSystemDeps, fc *config.Finch, cmdName *string, args *[]string) error {
-	if !fc.DockerCompat {
+	if fc == nil || !fc.DockerCompat {
 		return nil
 	}
 


### PR DESCRIPTION
Issue #, if available: N/A

*Description of changes:*
Adding null pointer checks for finch config file prior to attempting to access the `fc.dockercompat` configuration option.

According to `main_native.go:45-46`, in the specific scenario that the `finch.yaml` config fails to load due to `os.ErrPermission`, then a null pointer is passed to the application when initializing NerdctlCommands.
The recently introduced dependence upon the `fc.DockerCompat` configuration option resulted in a segmentation violation of nil pointer dereference for Finch on Linux use-case.

*Testing done:*
- Manual debugger testing


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
