### PR TITLE
feat: allow user configurable docker compose version env variable

### DIFF
--- a/cmd/finch/nerdctl.go
+++ b/cmd/finch/nerdctl.go
@@ -32,6 +32,7 @@ type NerdctlCommandSystemDeps interface {
 	system.FilePathJoiner
 	system.AbsFilePath
 	system.FilePathToSlash
+	system.EnvGetter
 }
 
 type nerdctlCommandCreator struct {

--- a/cmd/finch/nerdctl_native.go
+++ b/cmd/finch/nerdctl_native.go
@@ -88,6 +88,10 @@ func (nc *nerdctlCommand) run(cmdName string, args []string) error {
 		return inspectContainerOutputHandler(cmd)
 	}
 
+	if err := handleDockerCompatComposeVersion(cmdName, *nc, cmdArgs); err == nil {
+		return nil
+	}
+
 	return nc.ncc.Create(cmdArgs...).Run()
 
 }

--- a/cmd/finch/nerdctl_remote.go
+++ b/cmd/finch/nerdctl_remote.go
@@ -340,6 +340,10 @@ func (nc *nerdctlCommand) run(cmdName string, args []string) error {
 		return inspectContainerOutputHandler(cmd)
 	}
 
+	if err := handleDockerCompatComposeVersion(cmdName, *nc, cmdArgs); err == nil {
+		return nil
+	}
+
 	return nc.ncc.Create(runArgs...).Run()
 }
 

--- a/pkg/mocks/nerdctl_cmd_system_deps.go
+++ b/pkg/mocks/nerdctl_cmd_system_deps.go
@@ -36,6 +36,20 @@ func (m *NerdctlCommandSystemDeps) EXPECT() *NerdctlCommandSystemDepsMockRecorde
 	return m.recorder
 }
 
+// Env mocks base method.
+func (m *NerdctlCommandSystemDeps) Env(key string) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Env", key)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Env indicates an expected call of Env.
+func (mr *NerdctlCommandSystemDepsMockRecorder) Env(key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Env", reflect.TypeOf((*NerdctlCommandSystemDeps)(nil).Env), key)
+}
+
 // FilePathAbs mocks base method.
 func (m *NerdctlCommandSystemDeps) FilePathAbs(elem string) (string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*

Dev containers depends on docker compose version to name their applications. So sending nerdctl compose version breaks functionality

*Testing done:*
1. Run with dockercompat flag and env variable set
2. Run with dockercompat flag and no env variable set
3. Run without dockercompat flag. 

- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
