### PR TITLE
ci: Add comparison benchmark [WIP]

### DIFF
--- a/.github/workflows/benchmark-comparision.yaml
+++ b/.github/workflows/benchmark-comparision.yaml
@@ -1,0 +1,68 @@
+# - When a third-party action is added (i.e., `uses`), please also add it to `download-licenses` in Makefile.
+# - When a job is added/removed/renamed, please make corresponding changes in ci-docs.yaml.
+name: Comparison Benchmark
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'contrib/**'
+
+permissions:
+  # deployments permission to deploy GitHub pages website
+  deployments: write
+  # contents permission to update benchmark contents in gh-pages branch
+  contents: write
+
+jobs:
+  benchmark:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          [ ubuntu-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          # We need to get all the git tags to make version injection work. See VERSION in Makefile for more detail.
+          fetch-depth: 0
+          submodules: true
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Clean up previous files
+        run: |
+          sudo rm -rf /opt/finch
+          sudo rm -rf ~/.finch
+          sudo rm -rf ./_output
+          if pgrep '^qemu-system'; then
+            sudo pkill '^qemu-system'
+          fi
+          if pgrep '^socket_vmnet'; then
+            sudo pkill '^socket_vmnet'
+          fi
+      - name: Install Dependencies
+        run: | 
+          sudo apt-get install -y lz4 automake autoconf libtool
+          sudo snap install yq
+      - name: Build project
+        run: |
+          make
+      - name: Run benchmark
+        run: make test-benchmark-container | tee benchmark-container.txt
+      - name: Set OS info as env variable
+        run: |
+          echo "OS_VERSION=$(lsb_release -sr)" >> $GITHUB_ENV
+          echo "ARCH=$(uname -m)" >> $GITHUB_ENV
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@4de1bed97a47495fc4c5404952da0499e31f5c29 # v1.20.3
+        with:
+          name: Finch Benchmark
+          tool: 'go'
+          benchmark-data-dir-path: "dev/bench/comparison/${{ env.OS_VERSION }}/${{ env.ARCH }}"
+          output-file-path: benchmark-container.txt
+      - name: Push benchmark result
+        run: git push 'https://github.com/coderbirju/finch.git' gh-pages:gh-pages

--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ test-benchmark-vm:
 
 .PHONY: test-benchmark-container
 test-benchmark-container:
-	cd benchmark/container && go test -ldflags $(LDFLAGS) -bench=. -benchmem --installed="$(INSTALLED)"
+	cd benchmark/container && go test -ldflags $(LDFLAGS) -bench=. -benchmem -benchtime=1x -timeout 2h --installed="$(INSTALLED)"
 
 .PHONY: gen-code
 # Since different projects may have different versions of tool binaries,

--- a/benchmark/all/all_test.go
+++ b/benchmark/all/all_test.go
@@ -31,11 +31,11 @@ func BenchmarkAll(b *testing.B) {
 	}
 
 	b.Run("BenchmarkContainerRun", func(b *testing.B) {
-		suite.BenchmarkContainerRun(b)
+		suite.BenchmarkContainerRun(b, "finch")
 	})
 
 	b.Run("BenchmarkImageBuild", func(b *testing.B) {
-		suite.BenchmarkImageBuild(b)
+		suite.BenchmarkImageBuild(b, "finch")
 	})
 
 	err = suite.StopVM()

--- a/benchmark/benchmark.go
+++ b/benchmark/benchmark.go
@@ -57,6 +57,59 @@ func GetSubject() (string, error) {
 	return subject, nil
 }
 
+// GetDocker gets the path of docker installation
+func GetDocker() (string, error) {
+	subject := filepath.Join("/usr/bin/", "docker")
+	return subject, nil
+}
+
+// func CleanUpFunc() error {
+// cmd0 := exec.Command("sudo", "systemctl", "stop", "docker")
+// if err := cmd0.Run(); err != nil {
+// 	return fmt.Errorf("docker stop failed: %v", err)
+// }
+// cmd1 := exec.Command("sudo", "rm", "-rf", "/var/lib/docker")
+// if err := cmd1.Run(); err != nil {
+// 	return fmt.Errorf("docker cleanup failed: %v", err)
+// }
+// cmd2 := exec.Command("sudo", "rm", "-rf", "/var/run/docker.pid")
+// if err := cmd2.Run(); err != nil {
+// 	return fmt.Errorf("failed to stop docker process: %v", err)
+// }
+// cmd3 := exec.Command("sudo", "systemctl", "restart", "docker")
+// if err := cmd3.Run(); err != nil {
+// 	return fmt.Errorf("docker failed to restart: %v", err)
+// }
+
+// cmd4 := exec.Command("sudo", "rm", "-rf", "/var/lib/finch/buildkit/cache.db")
+// if err := cmd4.Run(); err != nil {
+// 	return fmt.Errorf("finch buildkit cleanup failed: %v", err)
+// }
+
+// cmd5 := exec.Command("sudo", "docker", "builder", "prune", "-a", "-f")
+// if err := cmd5.Run(); err != nil {
+// 	return fmt.Errorf("docker builder prune failed: %v", err)
+// }
+
+// cmd6 := exec.Command("sudo", "docker", "image", "prune", "-a", "-f")
+// if err := cmd6.Run(); err != nil {
+// 	return fmt.Errorf("docker image prune failed: %v", err)
+// }
+
+// cmd7 := exec.Command("sudo", "rm", "-rf", "/var/lib/containerd")
+// if err := cmd7.Run(); err != nil {
+// 	return fmt.Errorf("containerd cleanup failed: %v", err)
+// }
+
+// cmd8 := exec.Command("sudo", "systemctl", "restart", "containerd")
+// if err := cmd8.Run(); err != nil {
+// 	return fmt.Errorf("docker failed to restart: %v", err)
+// }
+
+// return nil
+
+// }
+
 // Wrapper reports the benchmarking metrics of targetFunc to testing.B.
 func Wrapper(b *testing.B, targetFunc func(), cleanupFunc func()) {
 	metricsSum := Metrics{}

--- a/benchmark/container/container_test.go
+++ b/benchmark/container/container_test.go
@@ -17,11 +17,36 @@ func BenchmarkContainer(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	b.Run("BenchmarkContainerRun", func(b *testing.B) {
-		suite.BenchmarkContainerRun(b)
+	b.Run("BenchmarkContainerRun-docker", func(b *testing.B) {
+		suite.BenchmarkContainerRun(b, "docker")
 	})
 
-	b.Run("BenchmarkImageBuild", func(b *testing.B) {
-		suite.BenchmarkImageBuild(b)
+	b.Run("BenchmarkContainerRun-finch", func(b *testing.B) {
+		suite.BenchmarkContainerRun(b, "finch")
 	})
+
+	b.Run("BenchmarkContainerPull-docker", func(b *testing.B) {
+		suite.BenchmarkContainerPull(b, "docker")
+	})
+
+	b.Run("BenchmarkContainerPull-finch", func(b *testing.B) {
+		suite.BenchmarkContainerPull(b, "finch")
+	})
+
+	b.Run("BenchmarkImageBuild-docker", func(b *testing.B) {
+		suite.BenchmarkImageBuild(b, "docker")
+	})
+
+	b.Run("BenchmarkImageBuild-finch", func(b *testing.B) {
+		suite.BenchmarkImageBuild(b, "finch")
+	})
+
+	b.Run("BenchmarkImageDelete-docker", func(b *testing.B) {
+		suite.BenchmarkImageDelete(b, "docker")
+	})
+
+	b.Run("BenchmarkImageDelete-finch", func(b *testing.B) {
+		suite.BenchmarkImageDelete(b, "finch")
+	})
+
 }


### PR DESCRIPTION
Issue #, if available:
This PR is a WIP, currently only adds comparison benchmark data on linux and dumps it into the gh:pages branch
Remaining work to be done is to test out the following 
- [ ] Add support for benchmarking on macOS instances


*Description of changes:*

*Testing done:*



- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
