### PR TITLE
ci: disable Go cache

### DIFF
--- a/.github/workflows/build-pkg.yaml
+++ b/.github/workflows/build-pkg.yaml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       - name: Build for macOS ${{ inputs.version }} (${{ inputs.output_arch }})
         run: |
           brew install lz4 automake autoconf libtool yq llvm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       - run: make gen-code
       - run: git diff --exit-code
   unit-tests:
@@ -94,7 +94,7 @@ jobs:
           # Since this repository is not meant to be used as a library,
           # we don't need to test the latest 2 major releases like Go does: https://go.dev/doc/devel/release#policy.
           go-version-file: go.mod
-          cache: true
+          cache: false
       - run: make test-unit
   # It's recommended to run golangci-lint in a job separate from other jobs (go test, etc) because different jobs run in parallel.
   go-linter:
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: go.mod
-          cache: false # caching can result in tar errors that files already exist
+          cache: false
       - name: set GOOS env to windows
         run: |
           echo "GOOS=windows" >> $GITHUB_ENV
@@ -145,7 +145,7 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       # TODO: Use `go mod tidy --check` after https://github.com/golang/go/issues/27005 is fixed.
       - run: go mod tidy
       - run: git diff --exit-code
@@ -156,7 +156,7 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       - run: make check-licenses
   macos-e2e-tests:
     strategy:

--- a/.github/workflows/e2e-macos.yaml
+++ b/.github/workflows/e2e-macos.yaml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       - name: Set output variables
         id: vars
         run: |

--- a/.github/workflows/test-pkg.yaml
+++ b/.github/workflows/test-pkg.yaml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       - name: Clean up previous files
         run: |
           sudo rm -rf /opt/finch

--- a/.github/workflows/upload-build-to-S3.yaml
+++ b/.github/workflows/upload-build-to-S3.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       - name: Make macos aarch64 build
         run: |
           brew install lz4 automake autoconf libtool yq
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       - name: Make macos x86_64 build
         run: |
           brew install lz4 automake autoconf libtool yq


### PR DESCRIPTION
Issue #, if available:
N/A

*Description of changes:*
This change disables Go cache which is taking 5-7 minutes to compression dependencies on workflow teardown. The macOS caches are ~2GB in size and putting us over storage limit (10GB) which results in the caches be evicted frequently.

*Testing done:*
CI runs faster with caching disabled.

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
