### PR TITLE
fix: add ci.yaml to exclude from ci-docs triggers

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -24,6 +24,7 @@ on:
       - '!.github/workflows/e2e-macos.yaml'
       - '!.github/workflows/e2e-windows.yaml'
       - '!.github/workflows/e2e-linux.yaml'
+      - '!.github/workflows/ci.yaml'
   pull_request:
     branches:
       - main
@@ -39,6 +40,7 @@ on:
       - '!.github/workflows/e2e-macos.yaml'
       - '!.github/workflows/e2e-windows.yaml'
       - '!.github/workflows/e2e-linux.yaml'
+      - '!.github/workflows/ci.yaml'
 
 jobs:
   git-secrets:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ on:
       - '.github/workflows/e2e-macos.yaml'
       - '.github/workflows/e2e-windows.yaml'
       - '.github/workflows/e2e-linux.yaml'
+      - '.github/workflows/ci.yaml'
       - 'contrib/packaging/**'
       - 'deps/**'
       - 'finch.yaml.d/**'
@@ -27,6 +28,7 @@ on:
       - '.github/workflows/e2e-macos.yaml'
       - '.github/workflows/e2e-windows.yaml'
       - '.github/workflows/e2e-linux.yaml'
+      - '.github/workflows/ci.yaml'
       - 'contrib/packaging/**'
       - 'deps/**'
       - 'finch.yaml.d/**'
@@ -201,7 +203,36 @@ jobs:
       arch: ${{ matrix.arch }}
       version: ${{ matrix.version }}
       runner-type: ${{ matrix.runner-type }}
-
+    macos-unit-test-coverage:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ['13', '14']
+        arch: ['X64', 'arm64']
+  macos-unit-test-coverage:
+    name: Run Unit Tests with Coverage
+    runs-on: macos-latest
+    steps:
+      - name: Configure git CRLF settings
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - run:
+          PKG_COVERAGE=$(paste -sd, test-coverage/macos.txt)
+          go test -cover -coverpkg="${PKG_COVERAGE}" -coverprofile=coverage.out ./...
+          COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print substr($3, 1, length($3)-1)}')
+          if (( $(echo "$COVERAGE < 75" | bc -l) )); then
+            echo "Coverage $COVERAGE% is below 75% threshold"
+            exit 1
+          else
+            echo "Coverage is $COVERAGE%, which meets the threshold"
+          fi
   mdlint:
     runs-on: ubuntu-latest
     steps:

--- a/test-coverage/macos.txt
+++ b/test-coverage/macos.txt
@@ -1,0 +1,15 @@
+./cmd/finch
+./pkg/command
+./pkg/config
+./pkg/dependency
+./pkg/disk
+./pkg/flog
+./pkg/fmemory
+./pkg/fssh
+./pkg/lima
+./pkg/path
+./pkg/support
+./pkg/system
+./pkg/templates
+./pkg/version
+./pkg/winutil


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Add ci.yaml to exclude from ci-docs triggers

*Testing done:*



- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
