### PR TITLE
chore: add warning message during finch vm init for windows users

### DIFF
--- a/cmd/finch/virtual_machine_init.go
+++ b/cmd/finch/virtual_machine_init.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/runfinch/finch/pkg/disk"
 
@@ -114,6 +115,13 @@ func (iva *initVMAction) run() error {
 		_ = iva.diskManager.DetachUserDataDisk()
 		return err
 	}
+
+	if runtime.GOOS == "windows" {
+		iva.logger.Warnln("Finch on Windows uses WSL, which mounts the C Drive in read-write mode by default. " +
+			"To run finch with more restricted access, follow " +
+			"https://runfinch.com/docs/managing-finch/windows/wsl-configuration/")
+	}
+
 	iva.logger.Info("Finch virtual machine started successfully")
 	return nil
 }

--- a/cmd/finch/virtual_machine_init_test.go
+++ b/cmd/finch/virtual_machine_init_test.go
@@ -8,6 +8,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/runfinch/finch/pkg/dependency"
@@ -83,6 +84,11 @@ func TestInitVMAction_runAdapter(t *testing.T) {
 				command.EXPECT().CombinedOutput()
 
 				logger.EXPECT().Info("Initializing and starting Finch virtual machine...")
+				if runtime.GOOS == "windows" {
+					logger.EXPECT().Warnln("Finch on Windows uses WSL, which mounts the C Drive in read-write mode by default. " +
+						"To run finch with more restricted access, follow " +
+						"https://runfinch.com/docs/managing-finch/windows/wsl-configuration/")
+				}
 				logger.EXPECT().Info("Finch virtual machine started successfully")
 			},
 		},
@@ -151,6 +157,11 @@ func TestInitVMAction_run(t *testing.T) {
 				command.EXPECT().CombinedOutput()
 
 				logger.EXPECT().Info("Initializing and starting Finch virtual machine...")
+				if runtime.GOOS == "windows" {
+					logger.EXPECT().Warnln("Finch on Windows uses WSL, which mounts the C Drive in read-write mode by default. " +
+						"To run finch with more restricted access, follow " +
+						"https://runfinch.com/docs/managing-finch/windows/wsl-configuration/")
+				}
 				logger.EXPECT().Info("Finch virtual machine started successfully")
 			},
 		},
@@ -276,6 +287,11 @@ func TestInitVMAction_run(t *testing.T) {
 				command.EXPECT().CombinedOutput()
 
 				logger.EXPECT().Info("Initializing and starting Finch virtual machine...")
+				if runtime.GOOS == "windows" {
+					logger.EXPECT().Warnln("Finch on Windows uses WSL, which mounts the C Drive in read-write mode by default. " +
+						"To run finch with more restricted access, follow " +
+						"https://runfinch.com/docs/managing-finch/windows/wsl-configuration/")
+				}
 				logger.EXPECT().Info("Finch virtual machine started successfully")
 			},
 		},


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*

Added a warning message during finch vm init to inform Windows users about the default behavior of WSL regarding C drive auto-mounting.

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
