### PR TITLE
ci(fix): Restart LxssManager if it shutsdown during remove finch VM step

### DIFF
--- a/.github/workflows/build-and-test-msi.yaml
+++ b/.github/workflows/build-and-test-msi.yaml
@@ -85,6 +85,7 @@ jobs:
           $ErrorActionPreference = 'Ignore'
           taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
           wsl --list --verbose
+          sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
           wsl --shutdown
           wsl --unregister lima-finch
           wsl --list --verbose
@@ -152,6 +153,7 @@ jobs:
           $ErrorActionPreference = 'Ignore'
           taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
           wsl --list --verbose
+          sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
           wsl --shutdown
           wsl --unregister lima-finch
           wsl --list --verbose
@@ -206,6 +208,7 @@ jobs:
           $ErrorActionPreference = 'Ignore'
           taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
           wsl --list --verbose
+          sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
           wsl --shutdown
           wsl --unregister lima-finch
           wsl --list --verbose
@@ -252,6 +255,7 @@ jobs:
           $ErrorActionPreference = 'Ignore'
           taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
           wsl --list --verbose
+          sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
           wsl --shutdown
           Start-Sleep -s 10
           wsl --unregister lima-finch
@@ -288,6 +292,7 @@ jobs:
           $ErrorActionPreference = 'Ignore'
           taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
           wsl --list --verbose
+          sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
           wsl --shutdown
           wsl --unregister lima-finch
           wsl --list --verbose

--- a/.github/workflows/e2e-windows.yaml
+++ b/.github/workflows/e2e-windows.yaml
@@ -64,6 +64,7 @@ jobs:
           $ErrorActionPreference = 'Ignore'
           taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
           wsl --list --verbose
+          sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
           wsl --shutdown
           wsl --unregister lima-finch
           wsl --list --verbose
@@ -97,6 +98,7 @@ jobs:
           $ErrorActionPreference = 'Ignore'
           taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
           wsl --list --verbose
+          sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
           wsl --shutdown
           wsl --unregister lima-finch
           wsl --list --verbose


### PR DESCRIPTION
Issue #, if available:

*Description of changes:* 

In *Build, test and upload .msi to S3* workflow, during remove finch VM step, we observed that `wsl --shutdown` is getting hung and causing workflow failure. Upon deep dive we found that LxssManager which is required to pass commands to WSL is getting stopped. 

This change checks the status of LxssManager and restarts it,if its in `STOPPED` state.

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
