### PR TITLE
feat: make finch config available in VM at $HOME/.finch

### DIFF
--- a/pkg/config/nerdctl_config_applier_test.go
+++ b/pkg/config/nerdctl_config_applier_test.go
@@ -68,7 +68,8 @@ FINCH_DIR=/finch/dir
 AWS_DIR=/home/dir/.aws
 export DOCKER_CONFIG="$FINCH_DIR"
 [ -L /usr/local/bin/docker-credential-ecr-login ] || sudo ln -s "$FINCH_DIR"/cred-helpers/docker-credential-ecr-login /usr/local/bin/
-[ -L /root/.aws ] || sudo ln -fs "$AWS_DIR" /root/.aws`), string(fileBytes))
+[ -L /root/.aws ] || sudo ln -fs "$AWS_DIR" /root/.aws
+[ -L /home/mock_user.linux/.finch ] || ln -s $FINCH_DIR /home/mock_user.linux/.finch`), string(fileBytes))
 			},
 			want: nil,
 		},
@@ -95,7 +96,8 @@ FINCH_DIR=/finch/dir
 AWS_DIR=/home/dir/.aws
 export DOCKER_CONFIG="$FINCH_DIR"
 [ -L /usr/local/bin/docker-credential-ecr-login ] || sudo ln -s "$FINCH_DIR"/cred-helpers/docker-credential-ecr-login /usr/local/bin/
-[ -L /root/.aws ] || sudo ln -fs "$AWS_DIR" /root/.aws)`,
+[ -L /root/.aws ] || sudo ln -fs "$AWS_DIR" /root/.aws)
+[ -L /home/mock_user.linux/.finch ] || ln -s $FINCH_DIR /home/mock_user.linux/.finch`,
 						),
 						0o644,
 					),
@@ -109,7 +111,8 @@ FINCH_DIR=/finch/dir
 AWS_DIR=/home/dir/.aws
 export DOCKER_CONFIG="$FINCH_DIR"
 [ -L /usr/local/bin/docker-credential-ecr-login ] || sudo ln -s "$FINCH_DIR"/cred-helpers/docker-credential-ecr-login /usr/local/bin/
-[ -L /root/.aws ] || sudo ln -fs "$AWS_DIR" /root/.aws)`), string(fileBytes))
+[ -L /root/.aws ] || sudo ln -fs "$AWS_DIR" /root/.aws)
+[ -L /home/mock_user.linux/.finch ] || ln -s $FINCH_DIR /home/mock_user.linux/.finch`), string(fileBytes))
 			},
 			want: nil,
 		},


### PR DESCRIPTION


Issue #, if available:
N/A

*Description of changes:*

NerdctlConfigApplier updates the user's bash rc in the VM to point DOCKER_CONFIG to the mounted .finch dir from the host OS. This works when the bash rc is loaded, but doesn't work for, e.g., systemd user services.

This change makes the finch config available available at $HOME/.finch in the VM so there is a clear place to load config via systemd user services without relying on any bash rcs.

*Testing done:*
Verified the updated unit test

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
