### PR TITLE
ci: Update Remove Finch VM step to only shutdown if required

### DIFF
--- a/.github/workflows/build-and-test-msi.yaml
+++ b/.github/workflows/build-and-test-msi.yaml
@@ -80,16 +80,9 @@ jobs:
           role-session-name: windows-msi
           aws-region: ${{ secrets.WINDOWS_REGION }}
       - name: Remove Finch VM
-        timeout-minutes: 5
-        run: |
-          $ErrorActionPreference = 'Ignore'
-          taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
-          sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
-          wsl --list --verbose
-          wsl --list --verbose | findstr /C:"Running" > nul && wsl --shutdown
-          echo "WSL has been shut down successfully."
-          wsl --list --quiet | findstr /C:"lima-finch" > nul && wsl --unregister lima-finch
-          wsl --list --verbose --all
+        timeout-minutes: 2
+        shell: pwsh
+        run: ./scripts/cleanup_wsl.ps1
       - name: Clean up previous files
         run: |
           takeown /F C:\actions-runner\_work\finch /R
@@ -148,18 +141,10 @@ jobs:
           aws s3 cp "./msi-builder/build/signed/Finch-$tag.msi" "s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-$tag.msi" --no-progress
       - name: Remove Finch VM and Clean Up Previous Environment
         if: ${{ always() }}
-        timeout-minutes: 5
+        timeout-minutes: 2
+        shell: pwsh
         run: |
-          # We want these cleanup commands to always run, ignore errors so the step completes.
-          $ErrorActionPreference = 'Ignore'
-          taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
-          sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
-          wsl --list --verbose
-          wsl --list --verbose | findstr /C:"Running" > nul && wsl --shutdown
-          echo "WSL has been shut down successfully."
-          wsl --list --quiet | findstr /C:"lima-finch" > nul && wsl --unregister lima-finch
-          wsl --list --verbose --all
-          Remove-Item C:\Users\Administrator\AppData\Local\.finch -Recurse
+          ./scripts/cleanup_wsl.ps1
           make clean
           cd deps/finch-core && make clean
           exit 0 # Cleanup may set the exit code e.g. if a file doesn't exist; just ignore
@@ -204,17 +189,9 @@ jobs:
           role-session-name: msi-test
           aws-region: ${{ secrets.REGION }}
       - name: Remove Finch VM
-        timeout-minutes: 5
-        run: |
-          # We want these cleanup commands to always run, ignore errors so the step completes.
-          $ErrorActionPreference = 'Ignore'
-          taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
-          sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
-          wsl --list --verbose
-          wsl --list --verbose | findstr /C:"Running" > nul && wsl --shutdown
-          echo "WSL has been shut down successfully."
-          wsl --list --quiet | findstr /C:"lima-finch" > nul && wsl --unregister lima-finch
-          wsl --list --verbose --all
+        timeout-minutes: 2
+        shell: pwsh
+        run: ./scripts/cleanup_wsl.ps1
       - name: Clean up previous files
         run: |
           Remove-Item C:\Users\Administrator\.finch -Recurse -ErrorAction Ignore
@@ -252,19 +229,9 @@ jobs:
             $env:INSTALLED="true"
             make test-e2e-vm
       - name: Remove Finch VM
-        timeout-minutes: 5
-        run: |
-          # We want these cleanup commands to always run, ignore errors so the step completes.
-          $ErrorActionPreference = 'Ignore'
-          taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
-          sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
-          wsl --list --verbose
-          wsl --list --verbose | findstr /C:"Running" > nul && wsl --shutdown
-          echo "WSL has been shut down successfully."
-          Start-Sleep -s 10
-          wsl --list --quiet | findstr /C:"lima-finch" > nul && wsl --unregister lima-finch
-          Remove-Item C:\Users\Administrator\AppData\Local\.finch -Recurse
-          wsl --list --verbose --all
+        timeout-minutes: 2
+        shell: pwsh
+        run: ./scripts/cleanup_wsl.ps1
       - name: Run container e2e tests
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
         with:
@@ -290,18 +257,10 @@ jobs:
           }
       - name: Remove Finch VM and Clean Up Previous Environment
         if: ${{ always() }}
-        timeout-minutes: 5
+        timeout-minutes: 2
+        shell: pwsh
         run: |
-          # We want these cleanup commands to always run, ignore errors so the step completes.
-          $ErrorActionPreference = 'Ignore'
-          taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
-          sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
-          wsl --list --verbose
-          wsl --list --verbose | findstr /C:"Running" > nul && wsl --shutdown
-          echo "WSL has been shut down successfully."
-          wsl --list --quiet | findstr /C:"lima-finch" > nul && wsl --unregister lima-finch
-          wsl --list --verbose --all
-          Remove-Item C:\Users\Administrator\AppData\Local\.finch -Recurse
+          ./scripts/cleanup_wsl.ps1
           make clean
           cd deps/finch-core && make clean
           exit 0 # Cleanup may set the exit code e.g. if a file doesn't exist; just ignore

--- a/.github/workflows/build-and-test-msi.yaml
+++ b/.github/workflows/build-and-test-msi.yaml
@@ -84,9 +84,9 @@ jobs:
         run: |
           $ErrorActionPreference = 'Ignore'
           taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
-          wsl --list --verbose
           sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
-          wsl --shutdown
+          wsl --list --verbose
+          wsl --list --verbose | findstr /C:"Running" > nul && wsl --shutdown
           echo "WSL has been shut down successfully."
           wsl --list --quiet | findstr /C:"lima-finch" > nul && wsl --unregister lima-finch
           wsl --list --verbose --all
@@ -153,9 +153,9 @@ jobs:
           # We want these cleanup commands to always run, ignore errors so the step completes.
           $ErrorActionPreference = 'Ignore'
           taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
-          wsl --list --verbose
           sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
-          wsl --shutdown
+          wsl --list --verbose
+          wsl --list --verbose | findstr /C:"Running" > nul && wsl --shutdown
           echo "WSL has been shut down successfully."
           wsl --list --quiet | findstr /C:"lima-finch" > nul && wsl --unregister lima-finch
           wsl --list --verbose --all
@@ -209,9 +209,9 @@ jobs:
           # We want these cleanup commands to always run, ignore errors so the step completes.
           $ErrorActionPreference = 'Ignore'
           taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
-          wsl --list --verbose
           sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
-          wsl --shutdown
+          wsl --list --verbose
+          wsl --list --verbose | findstr /C:"Running" > nul && wsl --shutdown
           echo "WSL has been shut down successfully."
           wsl --list --quiet | findstr /C:"lima-finch" > nul && wsl --unregister lima-finch
           wsl --list --verbose --all
@@ -257,9 +257,9 @@ jobs:
           # We want these cleanup commands to always run, ignore errors so the step completes.
           $ErrorActionPreference = 'Ignore'
           taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
-          wsl --list --verbose
           sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
-          wsl --shutdown
+          wsl --list --verbose
+          wsl --list --verbose | findstr /C:"Running" > nul && wsl --shutdown
           echo "WSL has been shut down successfully."
           Start-Sleep -s 10
           wsl --list --quiet | findstr /C:"lima-finch" > nul && wsl --unregister lima-finch
@@ -295,9 +295,9 @@ jobs:
           # We want these cleanup commands to always run, ignore errors so the step completes.
           $ErrorActionPreference = 'Ignore'
           taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
-          wsl --list --verbose
           sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
-          wsl --shutdown
+          wsl --list --verbose
+          wsl --list --verbose | findstr /C:"Running" > nul && wsl --shutdown
           echo "WSL has been shut down successfully."
           wsl --list --quiet | findstr /C:"lima-finch" > nul && wsl --unregister lima-finch
           wsl --list --verbose --all

--- a/.github/workflows/build-and-test-msi.yaml
+++ b/.github/workflows/build-and-test-msi.yaml
@@ -80,15 +80,16 @@ jobs:
           role-session-name: windows-msi
           aws-region: ${{ secrets.WINDOWS_REGION }}
       - name: Remove Finch VM
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: |
           $ErrorActionPreference = 'Ignore'
           taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
           wsl --list --verbose
           sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
           wsl --shutdown
-          wsl --unregister lima-finch
-          wsl --list --verbose
+          echo "WSL has been shut down successfully."
+          wsl --list --quiet | findstr /C:"lima-finch" > nul && wsl --unregister lima-finch
+          wsl --list --verbose --all
       - name: Clean up previous files
         run: |
           takeown /F C:\actions-runner\_work\finch /R
@@ -147,7 +148,7 @@ jobs:
           aws s3 cp "./msi-builder/build/signed/Finch-$tag.msi" "s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-$tag.msi" --no-progress
       - name: Remove Finch VM and Clean Up Previous Environment
         if: ${{ always() }}
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: |
           # We want these cleanup commands to always run, ignore errors so the step completes.
           $ErrorActionPreference = 'Ignore'
@@ -155,8 +156,9 @@ jobs:
           wsl --list --verbose
           sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
           wsl --shutdown
-          wsl --unregister lima-finch
-          wsl --list --verbose
+          echo "WSL has been shut down successfully."
+          wsl --list --quiet | findstr /C:"lima-finch" > nul && wsl --unregister lima-finch
+          wsl --list --verbose --all
           Remove-Item C:\Users\Administrator\AppData\Local\.finch -Recurse
           make clean
           cd deps/finch-core && make clean
@@ -202,7 +204,7 @@ jobs:
           role-session-name: msi-test
           aws-region: ${{ secrets.REGION }}
       - name: Remove Finch VM
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: |
           # We want these cleanup commands to always run, ignore errors so the step completes.
           $ErrorActionPreference = 'Ignore'
@@ -210,8 +212,9 @@ jobs:
           wsl --list --verbose
           sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
           wsl --shutdown
-          wsl --unregister lima-finch
-          wsl --list --verbose
+          echo "WSL has been shut down successfully."
+          wsl --list --quiet | findstr /C:"lima-finch" > nul && wsl --unregister lima-finch
+          wsl --list --verbose --all
       - name: Clean up previous files
         run: |
           Remove-Item C:\Users\Administrator\.finch -Recurse -ErrorAction Ignore
@@ -249,7 +252,7 @@ jobs:
             $env:INSTALLED="true"
             make test-e2e-vm
       - name: Remove Finch VM
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: |
           # We want these cleanup commands to always run, ignore errors so the step completes.
           $ErrorActionPreference = 'Ignore'
@@ -257,10 +260,11 @@ jobs:
           wsl --list --verbose
           sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
           wsl --shutdown
+          echo "WSL has been shut down successfully."
           Start-Sleep -s 10
-          wsl --unregister lima-finch
+          wsl --list --quiet | findstr /C:"lima-finch" > nul && wsl --unregister lima-finch
           Remove-Item C:\Users\Administrator\AppData\Local\.finch -Recurse
-          wsl --list --verbose    
+          wsl --list --verbose --all
       - name: Run container e2e tests
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
         with:
@@ -286,7 +290,7 @@ jobs:
           }
       - name: Remove Finch VM and Clean Up Previous Environment
         if: ${{ always() }}
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: |
           # We want these cleanup commands to always run, ignore errors so the step completes.
           $ErrorActionPreference = 'Ignore'
@@ -294,8 +298,9 @@ jobs:
           wsl --list --verbose
           sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
           wsl --shutdown
-          wsl --unregister lima-finch
-          wsl --list --verbose
+          echo "WSL has been shut down successfully."
+          wsl --list --quiet | findstr /C:"lima-finch" > nul && wsl --unregister lima-finch
+          wsl --list --verbose --all
           Remove-Item C:\Users\Administrator\AppData\Local\.finch -Recurse
           make clean
           cd deps/finch-core && make clean

--- a/.github/workflows/e2e-windows.yaml
+++ b/.github/workflows/e2e-windows.yaml
@@ -58,16 +58,8 @@ jobs:
           role-session-name: credhelper-test
           aws-region: ${{ secrets.REGION }}
       - name: Remove Finch VM
-        timeout-minutes: 5
-        run: |
-          # We want these cleanup commands to always run, ignore errors so the step completes.
-          $ErrorActionPreference = 'Ignore'
-          taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
-          wsl --list --verbose
-          sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
-          wsl --list --verbose | findstr /C:"Running" > nul && wsl --shutdown
-          wsl --list --quiet | findstr /C:"lima-finch" > nul && wsl --unregister lima-finch
-          wsl --list --verbose --all
+        timeout-minutes: 2
+        run: ./scripts/cleanup_wsl.ps1
       - name: Clean up previous files
         run: |
           Remove-Item C:\Users\Administrator\.finch -Recurse -ErrorAction Ignore
@@ -92,17 +84,9 @@ jobs:
           make ${{ inputs.test-command }}
       - name: Remove Finch VM and Clean Up Previous Environment
         if: ${{ always() }}
-        timeout-minutes: 5
+        timeout-minutes: 2
         run: |
-          # We want these cleanup commands to always run, ignore errors so the step completes.
-          $ErrorActionPreference = 'Ignore'
-          taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
-          wsl --list --verbose
-          sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
-          wsl --list --verbose | findstr /C:"Running" > nul && wsl --shutdown
-          wsl --list --quiet | findstr /C:"lima-finch" > nul && wsl --unregister lima-finch
-          wsl --list --verbose --all
-          Remove-Item C:\Users\Administrator\AppData\Local\.finch -Recurse
+          ./scripts/cleanup_wsl.ps1
           make clean
           cd deps/finch-core && make clean
           exit 0 # Cleanup may set the exit code e.g. if a file doesn't exist; just ignore

--- a/.github/workflows/e2e-windows.yaml
+++ b/.github/workflows/e2e-windows.yaml
@@ -58,7 +58,7 @@ jobs:
           role-session-name: credhelper-test
           aws-region: ${{ secrets.REGION }}
       - name: Remove Finch VM
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: |
           # We want these cleanup commands to always run, ignore errors so the step completes.
           $ErrorActionPreference = 'Ignore'
@@ -66,8 +66,8 @@ jobs:
           wsl --list --verbose
           sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
           wsl --shutdown
-          wsl --unregister lima-finch
-          wsl --list --verbose
+          wsl --list --quiet | findstr /C:"lima-finch" > nul && wsl --unregister lima-finch
+          wsl --list --verbose --all
       - name: Clean up previous files
         run: |
           Remove-Item C:\Users\Administrator\.finch -Recurse -ErrorAction Ignore
@@ -92,7 +92,7 @@ jobs:
           make ${{ inputs.test-command }}
       - name: Remove Finch VM and Clean Up Previous Environment
         if: ${{ always() }}
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: |
           # We want these cleanup commands to always run, ignore errors so the step completes.
           $ErrorActionPreference = 'Ignore'
@@ -100,8 +100,8 @@ jobs:
           wsl --list --verbose
           sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
           wsl --shutdown
-          wsl --unregister lima-finch
-          wsl --list --verbose
+          wsl --list --quiet | findstr /C:"lima-finch" > nul && wsl --unregister lima-finch
+          wsl --list --verbose --all
           Remove-Item C:\Users\Administrator\AppData\Local\.finch -Recurse
           make clean
           cd deps/finch-core && make clean

--- a/.github/workflows/e2e-windows.yaml
+++ b/.github/workflows/e2e-windows.yaml
@@ -65,7 +65,7 @@ jobs:
           taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
           wsl --list --verbose
           sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
-          wsl --shutdown
+          wsl --list --verbose | findstr /C:"Running" > nul && wsl --shutdown
           wsl --list --quiet | findstr /C:"lima-finch" > nul && wsl --unregister lima-finch
           wsl --list --verbose --all
       - name: Clean up previous files
@@ -99,7 +99,7 @@ jobs:
           taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
           wsl --list --verbose
           sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
-          wsl --shutdown
+          wsl --list --verbose | findstr /C:"Running" > nul && wsl --shutdown
           wsl --list --quiet | findstr /C:"lima-finch" > nul && wsl --unregister lima-finch
           wsl --list --verbose --all
           Remove-Item C:\Users\Administrator\AppData\Local\.finch -Recurse

--- a/scripts/cleanup_wsl.ps1
+++ b/scripts/cleanup_wsl.ps1
@@ -1,0 +1,28 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# We want these cleanup commands to always run, ignore errors so the step completes.
+$ErrorActionPreference = 'Ignore'
+
+taskkill /f /im wslservice.exe 2> nul || cmd /c "exit /b 0"
+sc query LxssManager | findstr "STATE" | findstr /C:"STOPPED" > nul && net start LxssManager
+wsl --list --verbose --all
+
+# Attempt to shut down WSL if any distribution is running
+if (wsl --list --verbose | findstr /C:"Running" > nul) {
+    timeout 60s wsl --shutdown
+    # Forcefully kill WSL if still running
+    if (Get-Process -Name "wsl" -ErrorAction SilentlyContinue) {
+        Stop-Process -Name "wsl" -Force
+    }
+    echo "WSL has been shut down successfully."
+}
+
+# Unregister 'lima-finch' distribution if it exists
+if (wsl --list --quiet | findstr /C:"lima-finch" > nul) {
+    wsl --unregister lima-finch
+    echo "'lima-finch' has been unregistered successfully."
+}
+
+wsl --list --verbose --all
+Remove-Item C:\Users\Administrator\AppData\Local\.finch -Recurse


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*

*Testing done:* During Remove Finch VM step, run shutdown/unregister commands only if required after listing current status of distributions.

Successfully ran `Build, test and upload .msi to S3` workflow couple of times against test branch

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
