### PR TITLE
ci: use setup-go for Windows and hardcode GO_VERSION

### DIFF
--- a/.github/workflows/build-and-test-msi.yaml
+++ b/.github/workflows/build-and-test-msi.yaml
@@ -16,6 +16,7 @@ on:
     - cron: '0 9 * * *'
 env:
   GO111MODULE: on
+  GO_VERSION: '1.22.9'
 
 permissions:
   # This is required for configure-aws-credentials to request an OIDC JWT ID token to access AWS resources later on.
@@ -67,6 +68,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install awscli
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ needs.get-tag-name.outputs.tag }}
@@ -183,6 +187,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install awscli
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ needs.get-tag-name.outputs.tag }}

--- a/.github/workflows/build-and-test-msi.yaml
+++ b/.github/workflows/build-and-test-msi.yaml
@@ -71,6 +71,7 @@ jobs:
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ needs.get-tag-name.outputs.tag }}
@@ -190,6 +191,7 @@ jobs:
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ needs.get-tag-name.outputs.tag }}

--- a/.github/workflows/build-pkg.yaml
+++ b/.github/workflows/build-pkg.yaml
@@ -49,6 +49,7 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
       - name: Build for macOS ${{ inputs.version }} (${{ inputs.output_arch }})
         run: |
           brew install lz4 automake autoconf libtool yq llvm

--- a/.github/workflows/build-pkg.yaml
+++ b/.github/workflows/build-pkg.yaml
@@ -25,6 +25,9 @@ permissions:
   # This is required for actions/checkout
   contents: read
 
+env:
+  GO_VERSION: '1.22.9'
+
 jobs:
   build:
     runs-on:
@@ -45,8 +48,7 @@ jobs:
           submodules: true
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version-file: go.mod
-          cache: false
+          go-version: ${{ env.GO_VERSION }}
       - name: Build for macOS ${{ inputs.version }} (${{ inputs.output_arch }})
         run: |
           brew install lz4 automake autoconf libtool yq llvm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,7 @@ permissions:
 
 env:
   DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
+  GO_VERSION: '1.22.8'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -73,8 +74,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version-file: go.mod
-          cache: false
+          go-version: ${{ env.GO_VERSION }}
       - run: make gen-code
       - run: git diff --exit-code
   unit-tests:
@@ -91,10 +91,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          # Since this repository is not meant to be used as a library,
-          # we don't need to test the latest 2 major releases like Go does: https://go.dev/doc/devel/release#policy.
-          go-version-file: go.mod
-          cache: false
+          go-version: ${{ env.GO_VERSION }}
       - run: make test-unit
   # It's recommended to run golangci-lint in a job separate from other jobs (go test, etc) because different jobs run in parallel.
   go-linter:
@@ -104,8 +101,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version-file: go.mod
-          cache: false
+          go-version: ${{ env.GO_VERSION }}
       - name: set GOOS env to windows
         run: |
           echo "GOOS=windows" >> $GITHUB_ENV
@@ -144,8 +140,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version-file: go.mod
-          cache: false
+          go-version: ${{ env.GO_VERSION }}
       # TODO: Use `go mod tidy --check` after https://github.com/golang/go/issues/27005 is fixed.
       - run: go mod tidy
       - run: git diff --exit-code
@@ -155,8 +150,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version-file: go.mod
-          cache: false
+          go-version: ${{ env.GO_VERSION }}
       - run: make check-licenses
   macos-e2e-tests:
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,7 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
       - run: make gen-code
       - run: git diff --exit-code
   unit-tests:
@@ -92,6 +93,7 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
       - run: make test-unit
   # It's recommended to run golangci-lint in a job separate from other jobs (go test, etc) because different jobs run in parallel.
   go-linter:
@@ -102,6 +104,7 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
       - name: set GOOS env to windows
         run: |
           echo "GOOS=windows" >> $GITHUB_ENV
@@ -141,6 +144,7 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
       # TODO: Use `go mod tidy --check` after https://github.com/golang/go/issues/27005 is fixed.
       - run: go mod tidy
       - run: git diff --exit-code
@@ -151,6 +155,7 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
       - run: make check-licenses
   macos-e2e-tests:
     strategy:

--- a/.github/workflows/e2e-macos.yaml
+++ b/.github/workflows/e2e-macos.yaml
@@ -45,6 +45,7 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
       - name: Set output variables
         id: vars
         run: |

--- a/.github/workflows/e2e-macos.yaml
+++ b/.github/workflows/e2e-macos.yaml
@@ -22,6 +22,9 @@ permissions:
   # This is required for actions/checkout
   contents: read
 
+env:
+  GO_VERSION: '1.22.9'
+
 jobs:
   test:
     runs-on:
@@ -41,8 +44,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version-file: go.mod
-          cache: false
+          go-version: ${{ env.GO_VERSION }}
       - name: Set output variables
         id: vars
         run: |

--- a/.github/workflows/e2e-windows.yaml
+++ b/.github/workflows/e2e-windows.yaml
@@ -19,6 +19,9 @@ permissions:
   # This is required for actions/checkout
   contents: read
 
+env:
+  GO_VERSION: '1.22.9'
+
 jobs:
   test:
     timeout-minutes: 180
@@ -74,6 +77,9 @@ jobs:
           Remove-Item C:\Users\Administrator\AppData\Local\.finch -Recurse -ErrorAction Ignore
           make clean
           cd deps/finch-core && make clean
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version: ${{ env.GO_VERSION }}
       - name: Build project
         run: |
           git status

--- a/.github/workflows/e2e-windows.yaml
+++ b/.github/workflows/e2e-windows.yaml
@@ -80,6 +80,7 @@ jobs:
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
       - name: Build project
         run: |
           git status

--- a/.github/workflows/test-pkg.yaml
+++ b/.github/workflows/test-pkg.yaml
@@ -25,6 +25,9 @@ permissions:
   # This is required for actions/checkout
   contents: read
 
+env:
+  GO_VERSION: '1.22.9'
+
 jobs:
   test:
     runs-on:
@@ -48,8 +51,7 @@ jobs:
           submodules: true
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version-file: go.mod
-          cache: false
+          go-version: ${{ env.GO_VERSION }}
       - name: Clean up previous files
         run: |
           sudo rm -rf /opt/finch

--- a/.github/workflows/test-pkg.yaml
+++ b/.github/workflows/test-pkg.yaml
@@ -52,6 +52,7 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
       - name: Clean up previous files
         run: |
           sudo rm -rf /opt/finch

--- a/.github/workflows/upload-build-to-S3.yaml
+++ b/.github/workflows/upload-build-to-S3.yaml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
       - name: Make macos aarch64 build
         run: |
           brew install lz4 automake autoconf libtool yq
@@ -53,6 +54,7 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
       - name: Make macos x86_64 build
         run: |
           brew install lz4 automake autoconf libtool yq

--- a/.github/workflows/upload-build-to-S3.yaml
+++ b/.github/workflows/upload-build-to-S3.yaml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 env:
   GO111MODULE: on
+  GO_VERSION: '1.22.9'
 
 permissions:
   # This is required for configure-aws-credentials to request an OIDC JWT ID token to access AWS resources later on.
@@ -23,8 +24,7 @@ jobs:
           submodules: true
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version-file: go.mod
-          cache: false
+          go-version: ${{ env.GO_VERSION }}
       - name: Make macos aarch64 build
         run: |
           brew install lz4 automake autoconf libtool yq
@@ -52,8 +52,7 @@ jobs:
           submodules: true
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version-file: go.mod
-          cache: false
+          go-version: ${{ env.GO_VERSION }}
       - name: Make macos x86_64 build
         run: |
           brew install lz4 automake autoconf libtool yq


### PR DESCRIPTION
Issue #, if available:

## Description of changes
- Adds actions/setup-go to Windows workflows
- Does not use `check-latest: true` because our dependencies require 1.22.0, and go considers 1.22 (without the patch version) to not satisfy that criteria. We will have to periodically manually update `GO_VERSION` to align with new Go releases.

## Testing done
None, need to test this on the runners themselves.

## Contribution agreement
- [x] I've reviewed the guidance in CONTRIBUTING.md


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
