### PR TITLE
feat: add finch-daemon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ GITCOMMIT ?= $(shell git rev-parse HEAD)$(shell test -z "$(git status --porcelai
 LDFLAGS = "-w -X $(PACKAGE)/pkg/version.Version=$(VERSION) -X $(PACKAGE)/pkg/version.GitCommit=$(GITCOMMIT)"
 MIN_MACOS_VERSION ?= 11.0
 
+FINCH_DAEMON_LOCATION_ROOT ?= $(FINCH_OS_IMAGE_LOCATION_ROOT)/finch-daemon
+FINCH_DAEMON_LOCATION ?= $(FINCH_DAEMON_LOCATION_ROOT)/finch-daemon
+
 GOOS ?= $(shell $(GO) env GOOS)
 ifeq ($(GOOS),windows)
 BINARYNAME := $(addsuffix .exe, $(BINARYNAME))
@@ -61,7 +64,7 @@ endif
 
 FINCH_CORE_DIR := $(CURDIR)/deps/finch-core
 
-remote-all: arch-test finch install.finch-core-dependencies finch.yaml networks.yaml config.yaml
+remote-all: arch-test finch install.finch-core-dependencies finch.yaml networks.yaml config.yaml $(OUTDIR)/finch-daemon/finch@.service
 
 ifeq ($(BUILD_OS), Windows_NT)
 include Makefile.windows
@@ -145,6 +148,9 @@ finch-all:
 
 .PHONY: release
 release: check-licenses all download-licenses
+
+$(OUTDIR)/finch-daemon/finch@.service:
+	cp finch@.service $(OUTDIR)/finch-daemon/finch@.service
 
 .PHONY: coverage
 coverage:

--- a/Makefile.darwin
+++ b/Makefile.darwin
@@ -18,20 +18,40 @@ FINCH_OS_IMAGE_LOCATION_ROOT ?= $(DEST)
 FINCH_IMAGE_LOCATION := $(FINCH_OS_IMAGE_LOCATION_ROOT)/os/$(FINCH_OS_BASENAME)
 FINCH_IMAGE_DIGEST := "sha512:$(FINCH_OS_DIGEST)"
 
+# check if finch-daemon socket is in a default path
+SHOULD_ADD_DAEMON_MOUNT = $(shell if [[ $(FINCH_DAEMON_LOCATION_ROOT) = ^\/Users\/.* ]]; then echo "0"; else echo "1"; fi)
+
 .PHONY: finch.yaml
 finch.yaml: $(OS_OUTDIR)/finch.yaml
 
+# only add the finch-daemon mount when its not in a default path
+# this scenario is common in dev, where the typical path is /Users/...
+ifeq ($(SHOULD_ADD_DAEMON_MOUNT),0)
+finch.yaml: add-daemon-mount
+endif
+
 $(OS_OUTDIR)/finch.yaml: $(OS_OUTDIR) finch.yaml.d/common.yaml finch.yaml.d/mac.yaml
 	# merge the appropriate YAMLs into a temporary finch.yaml file on the current working directory
-	cd finch.yaml.d && yq eval-all '. as $$item ireduce ({}; . *+ $$item)' mac.yaml common.yaml > ../finch.yaml.temp
+	cd finch.yaml.d && yq eval-all '. as $$item ireduce ({}; . *+ $$item)' common.yaml mac.yaml > ./../finch.yaml.temp
 
 	# using -i.bak is very intentional, it allows the following commands to succeed for both GNU / BSD sed
 	# this sed command uses the alternative separator of "|" because the image location uses "/"
 	sed -i.bak -e "s|<finch_image_location>|$(FINCH_IMAGE_LOCATION)|g" finch.yaml.temp
 	sed -i.bak -e "s/<finch_image_arch>/$(LIMA_ARCH)/g" finch.yaml.temp
 	sed -i.bak -e "s/<finch_image_digest>/$(FINCH_IMAGE_DIGEST)/g" finch.yaml.temp
+	sed -i.bak -e "s|<finch_daemon_root>|$(FINCH_DAEMON_LOCATION_ROOT)|g" finch.yaml.temp
+	sed -i.bak -e "s|<finch_daemon_location>|$(FINCH_DAEMON_LOCATION)|g" finch.yaml.temp
 
 	# Replacement was successful, so cleanup .bak
 	@rm finch.yaml.temp.bak
 
 	mv finch.yaml.temp $@
+
+.PHONY: add-daemon-mount
+add-daemon-mount:
+	cd finch.yaml.d && yq eval-all '. as $$item ireduce ({}; . *+ $$item)' $(OS_OUTDIR)/finch.yaml finch-daemon-mount.yaml > ./../finch.yaml.temp
+	sed -i.bak -e "s|<finch_daemon_root>|$(FINCH_DAEMON_LOCATION_ROOT)|g" finch.yaml.temp
+	# Replacement was successful, so cleanup .bak
+	@rm finch.yaml.temp.bak
+
+	mv finch.yaml.temp $(OS_OUTDIR)/finch.yaml

--- a/finch.yaml.d/common.yaml
+++ b/finch.yaml.d/common.yaml
@@ -85,8 +85,13 @@ provision:
       printf '[Unit]\nDescription=Delete hanging data on boot\nDefaultDependencies=no\nBefore=basic.target\n\n[Service]\nType=oneshot\nExecStart=/bin/bash -c "sudo rm -rf /var/lib/cni/networks/bridge/**; sudo rm -rf /var/lib/cni/results/bridge-finch-*"\n\n[Install]\nWantedBy=basic.target\n' | sudo tee /usr/local/lib/systemd/system/finch-cleanup-on-boot.service
       sudo systemctl enable --now finch-cleanup-on-boot.service
 
-      sudo systemctl restart containerd.service
+      # Set a default ulimit for number of files in containerd
+      sudo mkdir -p /usr/local/lib/systemd/system/containerd.service.d/
+      printf '[Service]\nLimitNOFILE=1048576\n' | sudo tee /usr/local/lib/systemd/system/containerd.service.d/finch.conf
 
+      sudo systemctl daemon-reload
+
+      sudo systemctl restart containerd.service
 env:
   # Containerd namespace is used by the lima cidata script
   # 40-install-containerd.sh. Specifically this variable is defining the

--- a/finch.yaml.d/finch-daemon-mount.yaml
+++ b/finch.yaml.d/finch-daemon-mount.yaml
@@ -1,0 +1,3 @@
+mounts:
+  - location: "<finch_daemon_root>"
+    writable: true

--- a/finch.yaml.d/mac.yaml
+++ b/finch.yaml.d/mac.yaml
@@ -7,6 +7,14 @@ provision:
   - mode: boot
     script: |
       modprobe virtiofs
+  # port this to common.yaml after windows socket forwarding is added
+  - mode: user
+    script: |
+      sudo cp <finch_daemon_location> /usr/local/bin/finch-daemon
+      sudo cp <finch_daemon_root>/finch@.service /usr/local/lib/systemd/system/finch@.service
+
+      sudo systemctl daemon-reload
+      sudo systemctl enable --now finch@${UID}
 mounts:
   - location: "~"
     mountPoint: null
@@ -22,9 +30,9 @@ mounts:
       cache: "fscache"
   - location: "/tmp/lima"
     writable: true
-  - location: "/var/folders"
+  - location: "/private"
     writable: true
-  - location: "/private/var/folders"
+  - location: "/var/folders"
     writable: true
 
 ssh:
@@ -44,3 +52,7 @@ hostResolver:
   hosts:
     host.finch.internal: host.lima.internal
     host.docker.internal: host.lima.internal
+
+portForwards:
+- guestSocket: "/run/finch.sock"
+  hostSocket: "{{.Dir}}/sock/finch.sock"

--- a/finch@.service
+++ b/finch@.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Finch daemon %I
+Documentation=https://runfinch.com https://github.com/runfinch/finch-daemon
+After=network.target local-fs.target containerd.service
+
+[Service]
+ExecStart=/usr/local/bin/finch-daemon --socket-owner %i
+ExecStartPost=-rm -rf /var/run/docker.sock
+ExecStartPost=ln -s /run/finch.sock /var/run/docker.sock
+
+Type=notify
+Delegate=yes
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This is a copy of PR https://github.com/runfinch/finch/pull/1181, adding it for the release.
[Adding a copy of the description of original PR]
Issue #, if available:

Description of changes
Adds finch-daemon, so that it starts inside the VM and is exposed to processes inside the VM (via /run/finch.sock and /var/run/docker.sock), and processes on the native macOS host (via /path/to/lima/data/finch/sock/finch.sock).

To make this possible, these changes had to be made:

Added finch-daemon specific logic to ./finch.yaml.d/mac.yaml
This logic makes it so that the finch-daemon binary and service file are copied into the VM, and then starts the daemon using systemd
In Makefile.darwin, changed the order so that the finch-daemon specific provisioning script would be the final script, after being merged
Also added a add-daemon-mount target, which makes it so that duplicate mounts are not added to Lima. This is done to avoid the default lima provisioning scripts failing due to trying to mount/unmount a directory twice (the end result is users may see cloud-final.service fail after shelling into the VM. although this should only ever really impact developers, it was easy enough to fix)
Added [finch@.service](mailto:finch@.service)
This change also currently relies on a fork of finch-core, which actually has the code necessary for building finch-daemon. Once https://github.com/runfinch/finch-core/pull/424 is merged, I'll update this PR to remove the use of a different finch-core upstream.

Testing done
finch-daemon works as expected on macOS:
DOCKER_HOST=unix:///path/to/finch/_output/lima/data/finch/sock/finch.sock docker images
REPOSITORY                                                                   TAG                IMAGE ID       CREATED        SIZE
public.ecr.aws/amazonlinux/amazonlinux                                       2023               75763d26a280   3 weeks ago    51.4MB
public.ecr.aws/docker/library/registry                                       latest             12120425f07d   2 months ago   9.47MB
public.ecr.aws/lambda/nodejs                                                 18-x86_64          97f94536a3af   3 weeks ago    180MB
 I've reviewed the guidance in CONTRIBUTING.md
License Acceptance
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.