### PR TITLE
feat: use finch-core container runtime archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,14 @@ endif
 install.finch-core-dependencies:
 	OUTDIR=$(OUTDIR) ARCH=$(ARCH) "$(MAKE)" -C $(FINCH_CORE_DIR) install.dependencies
 
+# For Finch on macOS and Windows, the container runtime archive locations and digests are set
+# based on the values set in deps/finch-core/deps/container-runtime-full-archive.conf
+-include $(FINCH_CORE_DIR)/deps/container-runtime-full-archive.conf
+CONTAINER_RUNTIME_ARCHIVE_AARCH64_LOCATION ?= "$(ARTIFACT_BASE_URL)/$(AARCH64_ARTIFACT)"
+CONTAINER_RUNTIME_ARCHIVE_AARCH64_DIGEST ?= "sha256:$(AARCH64_256_DIGEST)"
+CONTAINER_RUNTIME_ARCHIVE_X86_64_LOCATION ?= "$(ARTIFACT_BASE_URL)/$(X86_64_ARTIFACT)"
+CONTAINER_RUNTIME_ARCHIVE_X86_64_DIGEST ?= "sha256:$(X86_64_256_DIGEST)"
+
 .PHONY: finch.yaml
 finch.yaml: $(OS_OUTDIR)/finch.yaml
 

--- a/Makefile.darwin
+++ b/Makefile.darwin
@@ -5,21 +5,18 @@
 # based on the values set in deps/finch-core/deps/full-os.conf
 -include $(FINCH_CORE_DIR)/deps/full-os.conf
 ifeq ($(ARCH),x86_64)
-FINCH_OS_BASENAME=$(X86_64_ARTIFACT)
-FINCH_OS_DIGEST=$(X86_64_512_DIGEST)
+FINCH_OS_BASENAME := $(X86_64_ARTIFACT)
+FINCH_OS_DIGEST := $(X86_64_512_DIGEST)
 else
-FINCH_OS_BASENAME=$(AARCH64_ARTIFACT)
-FINCH_OS_DIGEST=$(AARCH64_512_DIGEST)
+FINCH_OS_BASENAME := $(AARCH64_ARTIFACT)
+FINCH_OS_DIGEST := $(AARCH64_512_DIGEST)
 endif
 
 # This variable is used to generate release builds, where the OS image path should be overwritten
 # to /Applications/Finch/...
 FINCH_OS_IMAGE_LOCATION_ROOT ?= $(DEST)
-FINCH_IMAGE_LOCATION := $(FINCH_OS_IMAGE_LOCATION_ROOT)/os/$(FINCH_OS_BASENAME)
-FINCH_IMAGE_DIGEST := "sha512:$(FINCH_OS_DIGEST)"
-
-.PHONY: finch.yaml
-finch.yaml: $(OS_OUTDIR)/finch.yaml
+FINCH_IMAGE_LOCATION ?= $(FINCH_OS_IMAGE_LOCATION_ROOT)/os/$(FINCH_OS_BASENAME)
+FINCH_IMAGE_DIGEST ?= "sha512:$(FINCH_OS_DIGEST)"
 
 $(OS_OUTDIR)/finch.yaml: $(OS_OUTDIR) finch.yaml.d/common.yaml finch.yaml.d/mac.yaml
 	# merge the appropriate YAMLs into a temporary finch.yaml file on the current working directory
@@ -30,6 +27,10 @@ $(OS_OUTDIR)/finch.yaml: $(OS_OUTDIR) finch.yaml.d/common.yaml finch.yaml.d/mac.
 	sed -i.bak -e "s|<finch_image_location>|$(FINCH_IMAGE_LOCATION)|g" finch.yaml.temp
 	sed -i.bak -e "s/<finch_image_arch>/$(LIMA_ARCH)/g" finch.yaml.temp
 	sed -i.bak -e "s/<finch_image_digest>/$(FINCH_IMAGE_DIGEST)/g" finch.yaml.temp
+	sed -i.bak -e "s|<container_runtime_archive_aarch64_location>|$(CONTAINER_RUNTIME_ARCHIVE_AARCH64_LOCATION)|g" finch.yaml.temp
+	sed -i.bak -e "s/<container_runtime_archive_aarch64_digest>/$(CONTAINER_RUNTIME_ARCHIVE_AARCH64_DIGEST)/g" finch.yaml.temp
+	sed -i.bak -e "s|<container_runtime_archive_x86_64_location>|$(CONTAINER_RUNTIME_ARCHIVE_X86_64_LOCATION)|g" finch.yaml.temp
+	sed -i.bak -e "s/<container_runtime_archive_x86_64_digest>/$(CONTAINER_RUNTIME_ARCHIVE_X86_64_DIGEST)/g" finch.yaml.temp
 
 	# Replacement was successful, so cleanup .bak
 	@rm finch.yaml.temp.bak

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -5,8 +5,8 @@
 # based on the values in deps/finch-core/deps/rootfs.conf
 -include $(FINCH_CORE_DIR)/deps/rootfs.conf
 ifeq ($(ARCH),x86_64)
-FINCH_ROOTFS_BASENAME ?= $(X86_64_ARTIFACT)
-FINCH_ROOTFS_DIGEST ?= $(X86_64_512_DIGEST)
+FINCH_ROOTFS_BASENAME := $(X86_64_ARTIFACT)
+FINCH_ROOTFS_DIGEST := $(X86_64_512_DIGEST)
 else
 $(error Finch on Windows ARM not supported)
 endif
@@ -14,8 +14,8 @@ endif
 # This variable is used to generate release builds, where the OS rootfs path should be overwritten
 # to C:/Program Files/Finch/...
 FINCH_OS_IMAGE_LOCATION_ROOT ?= $(OUTDIR)
-FINCH_IMAGE_LOCATION := $(FINCH_OS_IMAGE_LOCATION_ROOT)/os/$(FINCH_ROOTFS_BASENAME)
-FINCH_IMAGE_DIGEST := "sha512:$(FINCH_ROOTFS_DIGEST)"
+FINCH_IMAGE_LOCATION ?= $(FINCH_OS_IMAGE_LOCATION_ROOT)/os/$(FINCH_ROOTFS_BASENAME)
+FINCH_IMAGE_DIGEST ?= "sha512:$(FINCH_ROOTFS_DIGEST)"
 
 $(OS_OUTDIR)/finch.yaml: $(OS_OUTDIR) finch.yaml.d/common.yaml finch.yaml.d/windows.yaml
 	# merge the appropriate YAMLs into a temporary finch.yaml file on the current working directory
@@ -28,6 +28,10 @@ $(OS_OUTDIR)/finch.yaml: $(OS_OUTDIR) finch.yaml.d/common.yaml finch.yaml.d/wind
 	sed -i.bak -e "s|<finch_image_location>|file://$(FINCH_IMAGE_LOCATION)|g" finch.yaml.temp
 	sed -i.bak -e "s/<finch_image_arch>/$(LIMA_ARCH)/g" finch.yaml.temp
 	sed -i.bak -e "s/<finch_image_digest>/$(FINCH_IMAGE_DIGEST)/g" finch.yaml.temp
+	sed -i.bak -e "s|<container_runtime_archive_aarch64_location>|$(CONTAINER_RUNTIME_ARCHIVE_AARCH64_LOCATION)|g" finch.yaml.temp
+	sed -i.bak -e "s/<container_runtime_archive_aarch64_digest>/$(CONTAINER_RUNTIME_ARCHIVE_AARCH64_DIGEST)/g" finch.yaml.temp
+	sed -i.bak -e "s|<container_runtime_archive_x86_64_location>|$(CONTAINER_RUNTIME_ARCHIVE_X86_64_LOCATION)|g" finch.yaml.temp
+	sed -i.bak -e "s/<container_runtime_archive_x86_64_digest>/$(CONTAINER_RUNTIME_ARCHIVE_X86_64_DIGEST)/g" finch.yaml.temp
 
 	# Replacement was successful, so cleanup .bak
 	@rm finch.yaml.temp.bak

--- a/finch.yaml.d/common.yaml
+++ b/finch.yaml.d/common.yaml
@@ -9,12 +9,12 @@ containerd:
   # Override containerd archive
   # 🟢 Builtin default: hard-coded URL with hard-coded digest (see the output of `limactl info | jq .defaultTemplate.containerd.archives`)
   archives:
-  - location: "https://deps.runfinch.com/x86-64/nerdctl-full-1.7.7-linux-amd64.tar.gz"
-    arch: "x86_64"
-    digest: "sha256:a731eac93e8e9dda1a0d76dc1606438deb0668ea7d6bd5c5af436353ed9f65c5"
-  - location: "https://deps.runfinch.com/aarch64/nerdctl-full-1.7.7-linux-arm64.tar.gz"
+  - location: <container_runtime_archive_aarch64_location>
     arch: "aarch64"
-    digest: "sha256:b161a20c0e41f9ad999e8411e23c58ece4b3e584ae90b4252b76a39eee4a0c31"
+    digest: <container_runtime_archive_aarch64_digest>
+  - location: <container_runtime_archive_x86_64_location>
+    arch: "x86_64"
+    digest: <container_runtime_archive_x86_64_digest>
 
 provision:
   - mode: system


### PR DESCRIPTION
Issue #, if available:
Container runtime archive updates are currently a two-step process:

1. updates to finch-core 
2. updates to finch

*Description of changes:*
This change updates finch.yaml generation to use the container runtime archive from finch-core.

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
