### PR TITLE
feat: integrate nerdctl v2.0.2 container runtime archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,14 @@ install.finch-core-dependencies:
 # For Finch on macOS and Windows, the container runtime archive locations and digests are set
 # based on the values set in deps/finch-core/deps/container-runtime-full-archive.conf
 -include $(FINCH_CORE_DIR)/deps/container-runtime-full-archive.conf
+ifneq ($(AARCH64_ARTIFACT_PATHING),)
+	AARCH64_ARTIFACT := "$(AARCH64_ARTIFACT_PATHING)/$(AARCH64_ARTIFACT)"
+endif
 CONTAINER_RUNTIME_ARCHIVE_AARCH64_LOCATION ?= "$(ARTIFACT_BASE_URL)/$(AARCH64_ARTIFACT)"
 CONTAINER_RUNTIME_ARCHIVE_AARCH64_DIGEST ?= "sha256:$(AARCH64_256_DIGEST)"
+ifneq ($(X86_64_ARTIFACT_PATHING),)
+	X86_64_ARTIFACT := "$(X86_64_ARTIFACT_PATHING)/$(X86_64_ARTIFACT)"
+endif
 CONTAINER_RUNTIME_ARCHIVE_X86_64_LOCATION ?= "$(ARTIFACT_BASE_URL)/$(X86_64_ARTIFACT)"
 CONTAINER_RUNTIME_ARCHIVE_X86_64_DIGEST ?= "sha256:$(X86_64_256_DIGEST)"
 

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -31,6 +31,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/runfinch/common-tests/option"
 )
@@ -63,7 +64,12 @@ func CreateOption() (*option.Option, error) {
 		args = append(args, "--debug")
 	}
 
-	o, err := option.New(args)
+	mods := []option.Modifier{}
+	if runtime.GOOS == "linux" {
+		mods = append(mods, option.WithNerdctlVersion("1.7.7"))
+	}
+
+	o, err := option.New(args, mods...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize a testing option: %w", err)
 	}

--- a/e2e/vm/version_remote_test.go
+++ b/e2e/vm/version_remote_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 const (
-	nerdctlVersion    = "v1.7.7"
-	buildKitVersion   = "v0.15.2"
-	containerdVersion = "v1.7.22"
-	runcVersion       = "1.1.14"
+	nerdctlVersion    = "v2.0.2.m"
+	buildKitVersion   = "v0.18.1"
+	containerdVersion = "v2.0.0"
+	runcVersion       = "1.2.2"
 )
 
 type Versions struct {
@@ -53,7 +53,7 @@ var testVersion = func(o *option.Option) {
  OS\/Arch:	[A-Za-z0-9]+\/[A-Za-z0-9]+
  nerdctl:
   Version:	{{ .NerdctlVersion }}
-  GitCommit:	[a-z0-9]{40}
+  GitCommit:	[a-z0-9]{40}.m
  buildctl:
   Version:	{{ .BuildKitVersion }}
   GitCommit:	[a-z0-9]{40}

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onsi/gomega v1.36.2
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/sftp v1.13.7
-	github.com/runfinch/common-tests v0.8.0
+	github.com/runfinch/common-tests v0.9.1
 	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af
 	github.com/spf13/afero v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -272,8 +272,8 @@ github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/rootless-containers/rootlesskit/v2 v2.3.1 h1:wdYtdKxWFvVLby9ThMP6O6/v2q/GmOXbkRi+4m9nPW0=
 github.com/rootless-containers/rootlesskit/v2 v2.3.1/go.mod h1:tdtfS9ak4bGmwJRmcjsAzcHN5rJ3c5dB7yhSV10KTbk=
-github.com/runfinch/common-tests v0.8.0 h1:ctMpeHjUemEQaJ28EZ0oFsAxYopmhkslqQzd8pAoFYE=
-github.com/runfinch/common-tests v0.8.0/go.mod h1:Kf6ofmyppurRrGGaZVj43J++fDJ2wQ2lFRg8J6YYbwM=
+github.com/runfinch/common-tests v0.9.1 h1:O5+M+ThFPYprXhqs0UR54lbph0mTgcVhIX533k79Xbg=
+github.com/runfinch/common-tests v0.9.1/go.mod h1:vkWvXw8vc4f9LQFTYT1Fc6Q4eJvrBvunx4yn5WUjpiE=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
This change updates integrate Finch with nerdctl v2 container runtime archives.

Runtime dependencies updates:
* nerdctl v2.0.2 + https://github.com/containerd/nerdctl/commit/f917e5c1c886bee1b776de1ef827db1f8a1e4078
* buildkit v0.18.1
* containerd v2.0.0
* runc v1.2.2

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
