### PR TITLE
fix: conflict in parsing of -h flag for help and hostname in container run 

### DIFF
--- a/cmd/finch/nerdctl.go
+++ b/cmd/finch/nerdctl.go
@@ -110,8 +110,10 @@ func (nc *nerdctlCommand) shouldReplaceForHelp(cmdName string, args []string) bo
 		}
 	}
 
+	// this needs to handle cases of -h except for `container run`,`run`,`create`. For these options -h represent hostname
+	// TODO: Refactor this function.
 	for _, arg := range args {
-		if arg == "--help" || arg == "-h" {
+		if arg == "--help" || (arg == "-h" && !(cmdName == "container run" || cmdName == "run" || cmdName == "create")) {
 			return true
 		}
 	}

--- a/cmd/finch/nerdctl_test.go
+++ b/cmd/finch/nerdctl_test.go
@@ -30,48 +30,76 @@ func TestNerdctlCommand_shouldReplaceForHelp(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name    string
-		cmdName string
-		args    []string
-		mockSvc func(*mocks.NerdctlCmdCreator, *mocks.Logger, *gomock.Controller)
+		name     string
+		cmdName  string
+		args     []string
+		expected bool
+		mockSvc  func(*mocks.NerdctlCmdCreator, *mocks.Logger, *gomock.Controller)
 	}{
 		{
-			name:    "with --help flag",
-			cmdName: "pull",
-			args:    []string{"test:tag", "--help"},
+			name:     "with --help flag",
+			cmdName:  "pull",
+			args:     []string{"test:tag", "--help"},
+			expected: true,
 		},
 		{
-			name:    "with -h",
-			cmdName: "pull",
-			args:    []string{"test:tag", "-h"},
+			name:     "with -h",
+			cmdName:  "pull",
+			args:     []string{"test:tag", "-h"},
+			expected: true,
 		},
 		{
-			name:    "system returns help",
-			cmdName: "system",
+			name:     "system returns help",
+			cmdName:  "system",
+			expected: true,
 		},
 		{
-			name:    "builder returns help",
-			cmdName: "builder",
+			name:     "builder returns help",
+			cmdName:  "builder",
+			expected: true,
 		},
 		{
-			name:    "container returns help",
-			cmdName: "container",
+			name:     "container returns help",
+			cmdName:  "container",
+			expected: true,
 		},
 		{
-			name:    "image returns help",
-			cmdName: "image",
+			name:     "image returns help",
+			cmdName:  "image",
+			expected: true,
 		},
 		{
-			name:    "network returns help",
-			cmdName: "network",
+			name:     "network returns help",
+			cmdName:  "network",
+			expected: true,
 		},
 		{
-			name:    "volume returns help",
-			cmdName: "volume",
+			name:     "volume returns help",
+			cmdName:  "volume",
+			expected: true,
 		},
 		{
-			name:    "compose returns help",
-			cmdName: "compose",
+			name:     "compose returns help",
+			cmdName:  "compose",
+			expected: true,
+		},
+		{
+			name:     "-h argument for hostname-related command",
+			cmdName:  "run",
+			args:     []string{"-h"},
+			expected: false,
+		},
+		{
+			name:     "-h argument for hostname-related command",
+			cmdName:  "container run",
+			args:     []string{"-h"},
+			expected: false,
+		},
+		{
+			name:     "-h argument for hostname-related command",
+			cmdName:  "create",
+			args:     []string{"-h"},
+			expected: false,
 		},
 	}
 
@@ -85,7 +113,8 @@ func TestNerdctlCommand_shouldReplaceForHelp(t *testing.T) {
 			ecc := mocks.NewCommandCreator(ctrl)
 			ncsd := mocks.NewNerdctlCommandSystemDeps(ctrl)
 			logger := mocks.NewLogger(ctrl)
-			assert.True(t, newNerdctlCommand(ncc, ecc, ncsd, logger, nil, &config.Finch{}).shouldReplaceForHelp(tc.cmdName, tc.args))
+			assert.True(t, (newNerdctlCommand(ncc, ecc, ncsd, logger,
+				nil, &config.Finch{}).shouldReplaceForHelp(tc.cmdName, tc.args) == tc.expected))
 		})
 	}
 }


### PR DESCRIPTION
…r run

Issue #, if available:

*Description of changes:*
1. Fix  conflict in parsing of -h flag for help and hostname in container
2. Fix invalid ptr access error at different places of the parsing logic

*Testing done:*
1. Run with -h flag and check --help works
3. finch run -it --name edge -h edge alpine sh
4. finch compose -h
5. finch compose run --help

- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
