### PR TITLE
ci(fix): skip aws configure from fork and bot user

### DIFF
--- a/.github/workflows/e2e-linux.yaml
+++ b/.github/workflows/e2e-linux.yaml
@@ -33,7 +33,7 @@ jobs:
         "${{ inputs.runner-type }}",
       ]
     outputs:
-      vars: ${{ steps.vars.outputs.has_creds}}
+      has_creds: ${{ steps.vars.outputs.has_creds}}
       vm_report: ${{ steps.set-multiple-vars.outputs.VM_REPORT }}
       container_report: ${{ steps.set-multiple-vars.outputs.CONTAINER_REPORT }}
       vm_serial_report: ${{ steps.set-multiple-vars.outputs.VM_SERIAL_REPORT }}
@@ -154,22 +154,50 @@ jobs:
     steps:
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-        if: ${{ needs.test.outputs.vars == 'true' && ((startsWith(inputs.os, 'amazon') && inputs.version != '2' )) && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true }}
+        if: >-
+          ${{ needs.test.outputs.has_creds == 'true'
+            && ((startsWith(inputs.os, 'amazon')
+            && inputs.version != '2' ))
+            && github.event_name == 'pull_request'
+            && github.event.action == 'closed'
+            && github.event.pull_request.merged == true
+          }}
         with:
           role-to-assume: ${{ secrets.ROLE }}
           role-session-name: credhelper-test
           aws-region: ${{ secrets.REGION }}
       - name: download artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.08
-        if: ${{ needs.test.outputs.vars == 'true' && ((startsWith(inputs.os, 'amazon') && inputs.version != '2' )) && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true }}
+        if: >-
+          ${{ needs.test.outputs.has_creds == 'true'
+            && ((startsWith(inputs.os, 'amazon')
+            && inputs.version != '2' ))
+            && github.event_name == 'pull_request'
+            && github.event.action == 'closed'
+            && github.event.pull_request.merged == true
+          }}
         with:
           name: linux-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
           path: linux-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
       - name: Display structure of downloaded files
-        if: ${{ needs.test.outputs.vars == 'true' && ((startsWith(inputs.os, 'amazon') && inputs.version != '2' )) && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true }}
+        if: >-
+          ${{ needs.test.outputs.has_creds == 'true'
+            && ((startsWith(inputs.os, 'amazon')
+            && inputs.version != '2' ))
+            && github.event_name == 'pull_request'
+            && github.event.action == 'closed'
+            && github.event.pull_request.merged == true
+          }}
         run: ls -R linux-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
       - name: Check and upload e2e tests reports to s3 bucket
-        if: ${{ needs.test.outputs.vars == 'true' && ((startsWith(inputs.os, 'amazon') && inputs.version != '2' )) && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true }}
+        if: >-
+          ${{ needs.test.outputs.has_creds == 'true'
+            && ((startsWith(inputs.os, 'amazon')
+            && inputs.version != '2' ))
+            && github.event_name == 'pull_request'
+            && github.event.action == 'closed'
+            && github.event.pull_request.merged == true
+          }}
         run: |
           VM_REPORT="${{ github.workspace }}/linux-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports/${{ github.run_id }}-${{ github.run_attempt }}-e2e-vm-report.json"
           CONTAINER_REPORT="${{ github.workspace }}/linux-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports/${{ github.run_id }}-${{ github.run_attempt }}-e2e-container-report.json"

--- a/.github/workflows/e2e-linux.yaml
+++ b/.github/workflows/e2e-linux.yaml
@@ -154,22 +154,22 @@ jobs:
     steps:
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-        if: (!(startsWith(inputs.os, 'amazon') && inputs.version == '2' )) && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        if: ${{ needs.test.outputs.vars == 'true' }} && ((startsWith(inputs.os, 'amazon') && inputs.version != '2' )) && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
         with:
           role-to-assume: ${{ secrets.ROLE }}
           role-session-name: credhelper-test
           aws-region: ${{ secrets.REGION }}
       - name: download artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.08
-        if: (!(startsWith(inputs.os, 'amazon') && inputs.version == '2' )) && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        if: ${{ needs.test.outputs.vars == 'true' }} && ((startsWith(inputs.os, 'amazon') && inputs.version != '2' )) && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
         with:
           name: linux-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
           path: linux-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
       - name: Display structure of downloaded files
-        if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        if: ${{ needs.test.outputs.vars == 'true' }} && ((startsWith(inputs.os, 'amazon') && inputs.version != '2' )) && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
         run: ls -R linux-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
       - name: Check and upload e2e tests reports to s3 bucket
-        if: (!(startsWith(inputs.os, 'amazon') && inputs.version == '2' )) && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        if: ${{ needs.test.outputs.vars == 'true' }} && ((startsWith(inputs.os, 'amazon') && inputs.version != '2' )) && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
         run: |
           VM_REPORT="${{ github.workspace }}/linux-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports/${{ github.run_id }}-${{ github.run_attempt }}-e2e-vm-report.json"
           CONTAINER_REPORT="${{ github.workspace }}/linux-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports/${{ github.run_id }}-${{ github.run_attempt }}-e2e-container-report.json"
@@ -198,4 +198,3 @@ jobs:
           else
             echo "VM serial report file does not exist. Skipping upload."
           fi
-          

--- a/.github/workflows/e2e-linux.yaml
+++ b/.github/workflows/e2e-linux.yaml
@@ -154,22 +154,22 @@ jobs:
     steps:
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-        if: ${{ needs.test.outputs.vars == 'true' }} && ((startsWith(inputs.os, 'amazon') && inputs.version != '2' )) && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        if: ${{ needs.test.outputs.vars == 'true' && ((startsWith(inputs.os, 'amazon') && inputs.version != '2' )) && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true }}
         with:
           role-to-assume: ${{ secrets.ROLE }}
           role-session-name: credhelper-test
           aws-region: ${{ secrets.REGION }}
       - name: download artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.08
-        if: ${{ needs.test.outputs.vars == 'true' }} && ((startsWith(inputs.os, 'amazon') && inputs.version != '2' )) && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        if: ${{ needs.test.outputs.vars == 'true' && ((startsWith(inputs.os, 'amazon') && inputs.version != '2' )) && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true }}
         with:
           name: linux-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
           path: linux-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
       - name: Display structure of downloaded files
-        if: ${{ needs.test.outputs.vars == 'true' }} && ((startsWith(inputs.os, 'amazon') && inputs.version != '2' )) && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        if: ${{ needs.test.outputs.vars == 'true' && ((startsWith(inputs.os, 'amazon') && inputs.version != '2' )) && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true }}
         run: ls -R linux-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
       - name: Check and upload e2e tests reports to s3 bucket
-        if: ${{ needs.test.outputs.vars == 'true' }} && ((startsWith(inputs.os, 'amazon') && inputs.version != '2' )) && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        if: ${{ needs.test.outputs.vars == 'true' && ((startsWith(inputs.os, 'amazon') && inputs.version != '2' )) && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true }}
         run: |
           VM_REPORT="${{ github.workspace }}/linux-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports/${{ github.run_id }}-${{ github.run_attempt }}-e2e-vm-report.json"
           CONTAINER_REPORT="${{ github.workspace }}/linux-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports/${{ github.run_id }}-${{ github.run_attempt }}-e2e-container-report.json"

--- a/.github/workflows/e2e-macos.yaml
+++ b/.github/workflows/e2e-macos.yaml
@@ -36,7 +36,7 @@ jobs:
         "${{ inputs.runner-type }}",
       ]
     outputs:
-      vars: ${{ steps.vars.outputs.has_creds}}
+      has_creds: ${{ steps.vars.outputs.has_creds}}
       vm_report: ${{ steps.set-multiple-vars.outputs.VM_REPORT }}
       container_report: ${{ steps.set-multiple-vars.outputs.CONTAINER_REPORT }}
       vm_serial_report: ${{ steps.set-multiple-vars.outputs.VM_SERIAL_REPORT }}
@@ -116,14 +116,24 @@ jobs:
     steps:
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-        if: ${{ needs.test.outputs.vars == 'true' }} && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        if: >-
+          ${{ needs.test.outputs.has_creds == 'true'
+            && github.event_name == 'pull_request'
+            && github.event.action == 'closed'
+            && github.event.pull_request.merged == true
+          }}
         with:
           role-to-assume: ${{ secrets.ROLE }}
           role-session-name: credhelper-test
           aws-region: ${{ secrets.REGION }}
       - name: download artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.08
-        if: ${{ needs.test.outputs.vars == 'true' }} && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        if: >-
+          ${{ needs.test.outputs.has_creds == 'true'
+            && github.event_name == 'pull_request'
+            && github.event.action == 'closed'
+            && github.event.pull_request.merged == true
+          }}
         with:
           name: macos-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
           path: macos-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
@@ -131,7 +141,12 @@ jobs:
         if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
         run: ls -R macos-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
       - name: Check and upload e2e tests reports to s3 bucket
-        if: ${{ needs.test.outputs.vars == 'true' }} && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        if: >-
+          ${{ needs.test.outputs.has_creds == 'true'
+            && github.event_name == 'pull_request'
+            && github.event.action == 'closed'
+            && github.event.pull_request.merged == true
+          }}
         run: |
           VM_REPORT="${{ github.workspace }}/macos-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports/${{ github.run_id }}-${{ github.run_attempt }}-e2e-vm-report.json"
           CONTAINER_REPORT="${{ github.workspace }}/macos-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports/${{ github.run_id }}-${{ github.run_attempt }}-e2e-container-report.json"

--- a/.github/workflows/e2e-macos.yaml
+++ b/.github/workflows/e2e-macos.yaml
@@ -123,7 +123,7 @@ jobs:
           aws-region: ${{ secrets.REGION }}
       - name: download artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.08
-        if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        if: ${{ needs.test.outputs.vars == 'true' }} && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
         with:
           name: macos-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
           path: macos-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
@@ -131,7 +131,7 @@ jobs:
         if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
         run: ls -R macos-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
       - name: Check and upload e2e tests reports to s3 bucket
-        if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        if: ${{ needs.test.outputs.vars == 'true' }} && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
         run: |
           VM_REPORT="${{ github.workspace }}/macos-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports/${{ github.run_id }}-${{ github.run_attempt }}-e2e-vm-report.json"
           CONTAINER_REPORT="${{ github.workspace }}/macos-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports/${{ github.run_id }}-${{ github.run_attempt }}-e2e-container-report.json"
@@ -160,4 +160,3 @@ jobs:
           else
             echo "VM serial report file does not exist. Skipping upload."
           fi
-          

--- a/.github/workflows/e2e-windows.yaml
+++ b/.github/workflows/e2e-windows.yaml
@@ -126,34 +126,27 @@ jobs:
       - name: Set output variables
         id: vars
         run: |
-          $has_creds="${{ (github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name) && github.actor != 'dependabot[bot]'}}"
+          $has_creds="${{ github.repository == github.event.pull_request.head.repo.full_name && github.actor != 'dependabot[bot]' &&
+            github.event_name == 'pull_request' &&
+            github.event.action == 'closed' &&
+            github.event.pull_request.merged == true}}"
           echo "has_creds=$has_creds" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
           exit 0 # if $has_creds is false, powershell will exit with code 1 and this step will fail
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-        if: |
-          env.has_creds == 'true' &&
-          github.event_name == 'pull_request' &&
-          github.event.action == 'closed' &&
-          github.event.pull_request.merged == true
+        if: ${{ env.has_creds == 'true' }}
         with:
           role-to-assume: ${{ secrets.ROLE }}
           role-session-name: credhelper-test
           aws-region: ${{ secrets.REGION }}
       - name: download artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.08
-        if: |
-          github.event_name == 'pull_request' &&
-          github.event.action == 'closed' &&
-          github.event.pull_request.merged == true
+        if: ${{ env.has_creds == 'true' }}
         with:
           name: windows-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
           path: windows-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
       - name: Check and upload e2e tests reports to s3 bucket
-        if: |
-          github.event_name == 'pull_request' &&
-          github.event.action == 'closed' &&
-          github.event.pull_request.merged == true
+        if: ${{ env.has_creds == 'true' }}
         run: |
           $env:VM_REPORT = "${{ github.workspace }}\windows-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports\${{ github.run_id }}-${{ github.run_attempt }}-e2e-vm-report.json"
           $env:CONTAINER_REPORT = "${{ github.workspace }}\windows-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports\${{ github.run_id }}-${{ github.run_attempt }}-e2e-container-report.json"
@@ -182,4 +175,3 @@ jobs:
           } else {
             Write-Host "VM serial report file does not exist. Skipping upload."
           }
-          


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
bot user and fork need to be skip

*Testing done:*
same condition in windows skip the uploading process in this run
[example](https://github.com/runfinch/finch/actions/runs/12959269469/job/36152658935?pr=1181)


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
