### PR TITLE
ci: consolidate upload test report into a reusable action

### DIFF
--- a/.github/workflows/e2e-linux.yaml
+++ b/.github/workflows/e2e-linux.yaml
@@ -134,93 +134,23 @@ jobs:
         if: ${{ steps.vars.outputs.has_creds == 'true' && (!(startsWith(inputs.os, 'amazon') && inputs.version == '2' ))}}
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
-          name: linux-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
+          name: linux-${{ inputs.version }}-test-e2e-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
           path: ${{ github.workspace }}/reports/${{ github.run_id }}-${{ github.run_attempt }}-*.json
       - name: Clean up repo AL2
         if: ${{ (startsWith(inputs.os, 'amazon') && inputs.version == '2' && always() ) }}
         run: |
           rm -rf "${GITHUB_WORKSPACE}"
-  upload-linux-e2e-test-report:
+  upload-e2e-test-reports:
     needs: test
     if: always()
-    runs-on:
-      [
-        "self-hosted",
-        "linux",
-        "${{ inputs.arch }}",
-        "${{ inputs.version }}",
-        "${{ inputs.runner-type }}",
-      ]
-    steps:
-      - name: Set output variables to check AL2
-        id: linux2
-        run: |
-          is_al2=${{ (startsWith(inputs.os, 'amazon') && inputs.version == '2' ) }}
-          echo "is_al2=$is_al2" >> $GITHUB_OUTPUT
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@4fc4975a852c8cd99761e2de1f4ba73402e44dd9 # v4.0.3
-        if: |
-            steps.linux2.outputs.is_al2 == 'false'
-            && needs.test.outputs.has_creds == 'true'
-            && github.event_name == 'pull_request'
-            && github.event.action == 'closed'
-            && github.event.pull_request.merged == true
-        with:
-          role-to-assume: ${{ secrets.ROLE }}
-          role-session-name: credhelper-test
-          aws-region: ${{ secrets.REGION }}
-      - name: download artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.08
-        if: |
-            steps.linux2.outputs.is_al2 == 'false'
-            && needs.test.outputs.has_creds == 'true'
-            && github.event_name == 'pull_request'
-            && github.event.action == 'closed'
-            && github.event.pull_request.merged == true
-        with:
-          name: linux-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
-          path: linux-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
-      - name: Display structure of downloaded files
-        if: |
-            steps.linux2.outputs.is_al2 == 'false'
-            && needs.test.outputs.has_creds == 'true'
-            && github.event_name == 'pull_request'
-            && github.event.action == 'closed'
-            && github.event.pull_request.merged == true
-        run: ls -R linux-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
-      - name: Check and upload e2e tests reports to s3 bucket
-        if: |
-            steps.linux2.outputs.is_al2 == 'false'
-            && needs.test.outputs.has_creds == 'true'
-            && github.event_name == 'pull_request'
-            && github.event.action == 'closed'
-            && github.event.pull_request.merged == true
-
-        run: |
-          VM_REPORT="${{ github.workspace }}/linux-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports/${{ github.run_id }}-${{ github.run_attempt }}-e2e-vm-report.json"
-          CONTAINER_REPORT="${{ github.workspace }}/linux-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports/${{ github.run_id }}-${{ github.run_attempt }}-e2e-container-report.json"
-          VM_SERIAL_REPORT="${{ github.workspace }}/linux-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports/${{ github.run_id }}-${{ github.run_attempt }}-e2e-vm-serial-report.json"
-
-          if [ -f "$VM_REPORT" ]; then
-            echo "VM report file exists. Uploading to S3..."
-            aws s3 cp "$VM_REPORT" "s3://finch-e2e-test-log-reports/linux-${{ inputs.arch }}/${{ needs.test.outputs.vm_report }}"
-            echo "VM report uploaded successfully."
-          else
-            echo "VM report file does not exist. Skipping upload."
-          fi
-
-          if [ -f "$CONTAINER_REPORT" ]; then
-            echo "Container report file exists. Uploading to S3..."
-            aws s3 cp "$CONTAINER_REPORT" "s3://finch-e2e-test-log-reports/linux-${{ inputs.arch }}/${{ needs.test.outputs.container_report }}"
-            echo "Container report uploaded successfully."
-          else
-            echo "Container report file does not exist. Skipping upload."
-          fi
-
-          if [ -f "$VM_SERIAL_REPORT" ]; then
-            echo "VM serial report file exists. Uploading to S3..."
-            aws s3 cp "$VM_SERIAL_REPORT" "s3://finch-e2e-test-log-reports/linux-${{ inputs.arch }}/${{ needs.test.outputs.vm_serial_report }}"
-            echo "VM serial report uploaded successfully."
-          else
-            echo "VM serial report file does not exist. Skipping upload."
-          fi
+    uses: ./.github/workflows/upload-test-report.yaml
+    secrets: inherit
+    with:
+      os: ${{ inputs.os }}
+      arch: ${{ inputs.arch }}
+      version: ${{ inputs.version }}
+      test-command: "test-e2e"
+      has-creds: ${{ needs.test.outputs.has_creds }}
+      vm_report: ${{ needs.test.outputs.vm_report }}
+      container_report: ${{ needs.test.outputs.container_report }}
+      vm_serial_report: ${{ needs.test.outputs.vm_serial_report }}

--- a/.github/workflows/e2e-macos.yaml
+++ b/.github/workflows/e2e-macos.yaml
@@ -102,73 +102,17 @@ jobs:
         with:
           name: macos-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
           path: ${{ github.workspace }}/reports/${{ github.run_id }}-${{ github.run_attempt }}-*.json
-  upload-macos-e2e-test-report:
+  upload-e2e-test-reports:
     needs: test
     if: always()
-    runs-on:
-      [
-        "self-hosted",
-        "macos",
-        "${{ inputs.arch }}",
-        "${{ inputs.version }}",
-        "${{ inputs.runner-type }}",
-      ]
-    steps:
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@4fc4975a852c8cd99761e2de1f4ba73402e44dd9 # v4.0.3
-        if: |
-          needs.test.outputs.has_creds == 'true'
-          && github.event_name == 'pull_request'
-          && github.event.action == 'closed'
-          && github.event.pull_request.merged == true
-        with:
-          role-to-assume: ${{ secrets.ROLE }}
-          role-session-name: credhelper-test
-          aws-region: ${{ secrets.REGION }}
-      - name: download artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.08
-        if: |
-          needs.test.outputs.has_creds == 'true'
-          && github.event_name == 'pull_request'
-          && github.event.action == 'closed'
-          && github.event.pull_request.merged == true
-        with:
-          name: macos-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
-          path: macos-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
-      - name: Display structure of downloaded files
-        if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
-        run: ls -R macos-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
-      - name: Check and upload e2e tests reports to s3 bucket
-        if: |
-          needs.test.outputs.has_creds == 'true'
-          && github.event_name == 'pull_request'
-          && github.event.action == 'closed'
-          && github.event.pull_request.merged == true
-        run: |
-          VM_REPORT="${{ github.workspace }}/macos-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports/${{ github.run_id }}-${{ github.run_attempt }}-e2e-vm-report.json"
-          CONTAINER_REPORT="${{ github.workspace }}/macos-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports/${{ github.run_id }}-${{ github.run_attempt }}-e2e-container-report.json"
-          VM_SERIAL_REPORT="${{ github.workspace }}/macos-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports/${{ github.run_id }}-${{ github.run_attempt }}-e2e-vm-serial-report.json"
-
-          if [ -f "$VM_REPORT" ]; then
-            echo "VM report file exists. Uploading to S3..."
-            aws s3 cp "$VM_REPORT" "s3://finch-e2e-test-log-reports/macos-${{ inputs.arch }}/${{ needs.test.outputs.vm_report }}"
-            echo "VM report uploaded successfully."
-          else
-            echo "VM report file does not exist. Skipping upload."
-          fi
-
-          if [ -f "$CONTAINER_REPORT" ]; then
-            echo "Container report file exists. Uploading to S3..."
-            aws s3 cp "$CONTAINER_REPORT" "s3://finch-e2e-test-log-reports/macos-${{ inputs.arch }}/${{ needs.test.outputs.container_report }}"
-            echo "Container report uploaded successfully."
-          else
-            echo "Container report file does not exist. Skipping upload."
-          fi
-
-          if [ -f "$VM_SERIAL_REPORT" ]; then
-            echo "VM serial report file exists. Uploading to S3..."
-            aws s3 cp "$VM_SERIAL_REPORT" "s3://finch-e2e-test-log-reports/macos-${{ inputs.arch }}/${{ needs.test.outputs.vm_serial_report }}"
-            echo "VM serial report uploaded successfully."
-          else
-            echo "VM serial report file does not exist. Skipping upload."
-          fi
+    uses: ./.github/workflows/upload-test-report.yaml
+    secrets: inherit
+    with:
+      os: "mac"
+      arch: ${{ inputs.arch }}
+      version: ${{ inputs.version }}
+      test-command: ${{ inputs.test-command }}
+      has-creds: ${{ needs.test.outputs.has_creds }}
+      vm_report: ${{ needs.test.outputs.vm_report }}
+      container_report: ${{ needs.test.outputs.container_report }}
+      vm_serial_report: ${{ needs.test.outputs.vm_serial_report }}

--- a/.github/workflows/e2e-windows.yaml
+++ b/.github/workflows/e2e-windows.yaml
@@ -32,6 +32,11 @@ jobs:
         "${{ inputs.arch }}",
         "${{ inputs.runner-type }}",
       ]
+    outputs:
+      has_creds: ${{ steps.vars.outputs.has_creds}}
+      vm_report: ${{ steps.set-multiple-vars.outputs.VM_REPORT }}
+      container_report: ${{ steps.set-multiple-vars.outputs.CONTAINER_REPORT }}
+      vm_serial_report: ${{ steps.set-multiple-vars.outputs.VM_SERIAL_REPORT }}  
     steps:
       - name: Configure git CRLF settings
         run: |
@@ -101,7 +106,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
-          name: windows-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
+          name: windows-${{ inputs.test-command }}-2022-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
           path: ${{ github.workspace }}/reports/${{ github.run_id }}-${{ github.run_attempt }}-*.json
       - name: Remove Finch VM and Clean Up Previous Environment
         if: ${{ always() }}
@@ -111,64 +116,17 @@ jobs:
           make clean
           cd deps/finch-core && make clean
           exit 0 # Cleanup may set the exit code e.g. if a file doesn't exist; just ignore
-  upload-windows-e2e-test-report:
+  upload-e2e-test-reports:
     needs: test
     if: always()
-    timeout-minutes: 180
-    runs-on:
-      [
-        "self-hosted",
-        "windows",
-        "${{ inputs.arch }}",
-        "${{ inputs.runner-type }}",
-      ]
-    steps:
-      - name: Set output variables
-        id: vars
-        run: |
-          $has_creds="${{ github.repository == github.event.pull_request.head.repo.full_name && github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true }}"
-          echo "has_creds=$has_creds" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-          exit 0 # if $has_creds is false, powershell will exit with code 1 and this step will fail
-      - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@4fc4975a852c8cd99761e2de1f4ba73402e44dd9 # v4.0.3
-        if: env.has_creds == 'true'
-        with:
-          role-to-assume: ${{ secrets.ROLE }}
-          role-session-name: credhelper-test
-          aws-region: ${{ secrets.REGION }}
-      - name: download artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.08
-        if: env.has_creds == 'true'
-        with:
-          name: windows-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
-          path: windows-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
-      - name: Check and upload e2e tests reports to s3 bucket
-        if: env.has_creds == 'true'
-        run: |
-          $env:VM_REPORT = "${{ github.workspace }}\windows-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports\${{ github.run_id }}-${{ github.run_attempt }}-e2e-vm-report.json"
-          $env:CONTAINER_REPORT = "${{ github.workspace }}\windows-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports\${{ github.run_id }}-${{ github.run_attempt }}-e2e-container-report.json"
-          $env:VM_SERIAL_REPORT = "${{ github.workspace }}\windows-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports\${{ github.run_id }}-${{ github.run_attempt }}-e2e-vm-serial-report.json"
-
-          if (Test-Path $env:VM_REPORT) {
-            Write-Host "VM report file exists. Uploading to S3..."
-            aws s3 cp $env:VM_REPORT "s3://finch-e2e-test-log-reports/windows-${{ inputs.arch }}/${{ github.run_id }}-${{ github.run_attempt }}-e2e-vm-report.json"
-            Write-Host "VM report uploaded successfully."
-          } else {
-            Write-Host "VM report file does not exist. Skipping upload."
-          }
-
-          if (Test-Path $env:CONTAINER_REPORT) {
-            Write-Host "Container report file exists. Uploading to S3..."
-            aws s3 cp $env:CONTAINER_REPORT "s3://finch-e2e-test-log-reports/windows-${{ inputs.arch }}/${{ github.run_id }}-${{ github.run_attempt }}-e2e-container-report.json"
-            Write-Host "Container report uploaded successfully."
-          } else {
-            Write-Host "Container report file does not exist. Skipping upload."
-          }
-
-          if (Test-Path $env:VM_SERIAL_REPORT) {
-            Write-Host "VM serial report file exists. Uploading to S3..."
-            aws s3 cp $env:VM_SERIAL_REPORT "s3://finch-e2e-test-log-reports/windows-${{ inputs.arch }}/${{ github.run_id }}-${{ github.run_attempt }}-e2e-vm-serial-report.json"
-            Write-Host "VM serial report uploaded successfully."
-          } else {
-            Write-Host "VM serial report file does not exist. Skipping upload."
-          }
+    uses: ./.github/workflows/upload-test-report.yaml
+    secrets: inherit
+    with:
+      os: "windows"
+      arch: ${{ inputs.arch }}
+      version: "2022"
+      test-command: ${{ inputs.test-command }}
+      has-creds: ${{ needs.test.outputs.has_creds }}
+      vm_report: ${{ needs.test.outputs.vm_report }}
+      container_report: ${{ needs.test.outputs.container_report }}
+      vm_serial_report: ${{ needs.test.outputs.vm_serial_report }}

--- a/.github/workflows/upload-test-report.yaml
+++ b/.github/workflows/upload-test-report.yaml
@@ -1,0 +1,113 @@
+name: upload-test-report
+on:
+  workflow_call:
+    inputs:
+      os:
+        type: string
+        required: true
+      arch:
+        type: string
+        required: true
+      version:
+        type: string
+        required: true
+      test-command:
+        type: string
+        required: true
+      has-creds:
+        type: string
+        required: true
+      vm_report:
+        type: string
+        required: true
+      container_report:
+        type: string
+        required: true
+      vm_serial_report:
+        type: string
+        required: true
+
+permissions:
+  # This is required for configure-aws-credentials to request an OIDC JWT ID token to access AWS resources later on.
+  # More info: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
+  id-token: write
+  # This is required for actions/checkout
+  contents: read
+
+jobs:
+ upload-e2e-test-report:
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set output variables to check AL2
+        id: linux2
+        run: |
+          is_al2=${{ (startsWith(inputs.os, 'amazon') && inputs.version == '2' ) }}
+          echo "is_al2=$is_al2" >> $GITHUB_OUTPUT
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@4fc4975a852c8cd99761e2de1f4ba73402e44dd9 # v4.0.3
+        if: |
+            steps.linux2.outputs.is_al2 == 'false'
+            && inputs.has-creds == 'true'
+            && github.event_name == 'pull_request'
+            && github.event.action == 'closed'
+            && github.event.pull_request.merged == true
+        with:
+          role-to-assume: ${{ secrets.ROLE }}
+          role-session-name: credhelper-test
+          aws-region: ${{ secrets.REGION }}
+      - name: download artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.08
+        if: |
+            steps.linux2.outputs.is_al2 == 'false'
+            && inputs.has-creds == 'true'
+            && github.event_name == 'pull_request'
+            && github.event.action == 'closed'
+            && github.event.pull_request.merged == true
+        with:
+          name: ${{ inputs.os }}-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
+          path: ${{ inputs.os }}-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
+      - name: Display structure of downloaded files
+        if: |
+            steps.linux2.outputs.is_al2 == 'false'
+            && inputs.has-creds == 'true'
+            && github.event_name == 'pull_request'
+            && github.event.action == 'closed'
+            && github.event.pull_request.merged == true
+        run: ls -R ${{ inputs.os }}-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports
+      - name: Check and upload e2e tests reports to s3 bucket
+        if: |
+            steps.linux2.outputs.is_al2 == 'false'
+            && inputs.has-creds == 'true'
+            && github.event_name == 'pull_request'
+            && github.event.action == 'closed'
+            && github.event.pull_request.merged == true
+
+        run: |
+          VM_REPORT="${{ github.workspace }}/${{ inputs.os }}-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports/${{ github.run_id }}-${{ github.run_attempt }}-e2e-vm-report.json"
+          CONTAINER_REPORT="${{ github.workspace }}/${{ inputs.os }}-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports/${{ github.run_id }}-${{ github.run_attempt }}-e2e-container-report.json"
+          VM_SERIAL_REPORT="${{ github.workspace }}/${{ inputs.os }}-${{ inputs.version }}-${{ inputs.test-command }}-${{ inputs.arch }}-${{ github.run_id }}-${{ github.run_attempt }}-e2e-reports/${{ github.run_id }}-${{ github.run_attempt }}-e2e-vm-serial-report.json"
+
+          if [ -f "$VM_REPORT" ]; then
+            echo "VM report file exists. Uploading to S3..."
+            aws s3 cp "$VM_REPORT" "s3://finch-e2e-test-log-reports/${{ inputs.os }}-${{ inputs.arch }}/${{ inputs.vm_report }}"
+            echo "VM report uploaded successfully."
+          else
+            echo "VM report file does not exist. Skipping upload."
+          fi
+
+          if [ -f "$CONTAINER_REPORT" ]; then
+            echo "Container report file exists. Uploading to S3..."
+            aws s3 cp "$CONTAINER_REPORT" "s3://finch-e2e-test-log-reports/${{ inputs.os }}-${{ inputs.arch }}/${{ inputs.container_report }}"
+            echo "Container report uploaded successfully."
+          else
+            echo "Container report file does not exist. Skipping upload."
+          fi
+
+          if [ -f "$VM_SERIAL_REPORT" ]; then
+            echo "VM serial report file exists. Uploading to S3..."
+            aws s3 cp "$VM_SERIAL_REPORT" "s3://finch-e2e-test-log-reports/${{ inputs.os }}-${{ inputs.arch }}/${{ inputs.vm_serial_report }}"
+            echo "VM serial report uploaded successfully."
+          else
+            echo "VM serial report file does not exist. Skipping upload."
+          fi


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Uses a standard ubuntu-latest runner instead of self-hosted runners for uploading test reports and consolidates all of the logic into one reusable action

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
