### PR TITLE
fix: formatting for byo credential helper bashrc

### DIFF
--- a/pkg/config/nerdctl_config_applier.go
+++ b/pkg/config/nerdctl_config_applier.go
@@ -95,9 +95,9 @@ func updateEnvironment(fs afero.Fs, fc *Finch, finchDir, homeDir, limaVMHomeDir 
 	}
 
 	//nolint:gosec // G101: Potential hardcoded credentials false positive
-	const configureCredHelperTemplate = `([ -e "$FINCH_DIR"/cred-helpers/docker-credential-%s ] 
-|| (echo "error: docker-credential-%s not found in $FINCH_DIR/cred-helpers directory.")) && 
-([ -L /usr/local/bin/docker-credential-%s ] || sudo ln -s "$FINCH_DIR"/cred-helpers/docker-credential-%s /usr/local/bin)`
+	const configureCredHelperTemplate = `([ -e "$FINCH_DIR"/cred-helpers/docker-credential-%s ] || \
+  (echo "error: docker-credential-%s not found in $FINCH_DIR/cred-helpers directory.")) && \
+  ([ -L /usr/local/bin/docker-credential-%s ] || sudo ln -s "$FINCH_DIR"/cred-helpers/docker-credential-%s /usr/local/bin)`
 
 	for _, credHelper := range fc.CredsHelpers {
 		cmdArr = append(cmdArr, fmt.Sprintf(configureCredHelperTemplate, credHelper, credHelper, credHelper, credHelper))

--- a/pkg/config/nerdctl_config_applier_test.go
+++ b/pkg/config/nerdctl_config_applier_test.go
@@ -163,9 +163,9 @@ export DOCKER_CONFIG="$FINCH_DIR"
 						"AWS_DIR=/home/dir/.aws\n"+
 						"export DOCKER_CONFIG=\"$FINCH_DIR\"\n"+
 						"[ -L /root/.aws ] || sudo ln -fs \"$AWS_DIR\" /root/.aws\n"+
-						"([ -e \"$FINCH_DIR\"/cred-helpers/docker-credential-ecr-login ] \n"+
-						"|| (echo \"error: docker-credential-ecr-login not found in $FINCH_DIR/cred-helpers directory.\")) && \n"+
-						"([ -L /usr/local/bin/docker-credential-ecr-login ] "+
+						"([ -e \"$FINCH_DIR\"/cred-helpers/docker-credential-ecr-login ] || \\\n"+
+						"  (echo \"error: docker-credential-ecr-login not found in $FINCH_DIR/cred-helpers directory.\")) && \\\n"+
+						"  ([ -L /usr/local/bin/docker-credential-ecr-login ] "+
 						"|| sudo ln -s \"$FINCH_DIR\"/cred-helpers/docker-credential-ecr-login /usr/local/bin)\n"+
 						"[ -L /home/mock_user.linux/.finch ] || ln -s $FINCH_DIR /home/mock_user.linux/.finch"),
 					string(fileBytes),
@@ -199,13 +199,13 @@ export DOCKER_CONFIG="$FINCH_DIR"
 						"AWS_DIR=/home/dir/.aws\n"+
 						"export DOCKER_CONFIG=\"$FINCH_DIR\"\n"+
 						"[ -L /root/.aws ] || sudo ln -fs \"$AWS_DIR\" /root/.aws\n"+
-						"([ -e \"$FINCH_DIR\"/cred-helpers/docker-credential-ecr-login ] \n"+
-						"|| (echo \"error: docker-credential-ecr-login not found in $FINCH_DIR/cred-helpers directory.\")) && \n"+
-						"([ -L /usr/local/bin/docker-credential-ecr-login ] "+
+						"([ -e \"$FINCH_DIR\"/cred-helpers/docker-credential-ecr-login ] || \\\n"+
+						"  (echo \"error: docker-credential-ecr-login not found in $FINCH_DIR/cred-helpers directory.\")) && \\\n"+
+						"  ([ -L /usr/local/bin/docker-credential-ecr-login ] "+
 						"|| sudo ln -s \"$FINCH_DIR\"/cred-helpers/docker-credential-ecr-login /usr/local/bin)\n"+
-						"([ -e \"$FINCH_DIR\"/cred-helpers/docker-credential-secretservice ] \n"+
-						"|| (echo \"error: docker-credential-secretservice not found in $FINCH_DIR/cred-helpers directory.\")) && \n"+
-						"([ -L /usr/local/bin/docker-credential-secretservice ] "+
+						"([ -e \"$FINCH_DIR\"/cred-helpers/docker-credential-secretservice ] || \\\n"+
+						"  (echo \"error: docker-credential-secretservice not found in $FINCH_DIR/cred-helpers directory.\")) && \\\n"+
+						"  ([ -L /usr/local/bin/docker-credential-secretservice ] "+
 						"|| sudo ln -s \"$FINCH_DIR\"/cred-helpers/docker-credential-secretservice /usr/local/bin)\n"+
 						"[ -L /home/mock_user.linux/.finch ] || ln -s $FINCH_DIR /home/mock_user.linux/.finch"),
 					string(fileBytes),


### PR DESCRIPTION
Issue #, if available:
Follow-up to #1265 

*Description of changes:*
This change fixes bashrc formatting issue introduced with #1265 when appeasing the linter for line length.

*Testing done:*
Fixed unit tests as well.

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
