### PR TITLE
fix: container runtime full archive parse artifact path variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,8 +98,14 @@ install.finch-core-dependencies:
 # For Finch on macOS and Windows, the container runtime archive locations and digests are set
 # based on the values set in deps/finch-core/deps/container-runtime-full-archive.conf
 -include $(FINCH_CORE_DIR)/deps/container-runtime-full-archive.conf
+ifneq ($(strip $(AARCH64_ARTIFACT_PATHING)),)
+	AARCH64_ARTIFACT := "$(AARCH64_ARTIFACT_PATHING)/$(AARCH64_ARTIFACT)"
+endif
 CONTAINER_RUNTIME_ARCHIVE_AARCH64_LOCATION ?= "$(ARTIFACT_BASE_URL)/$(AARCH64_ARTIFACT)"
 CONTAINER_RUNTIME_ARCHIVE_AARCH64_DIGEST ?= "sha256:$(AARCH64_256_DIGEST)"
+ifneq ($(strip $(X86_64_ARTIFACT_PATHING)),)
+	X86_64_ARTIFACT := "$(X86_64_ARTIFACT_PATHING)/$(X86_64_ARTIFACT)"
+endif
 CONTAINER_RUNTIME_ARCHIVE_X86_64_LOCATION ?= "$(ARTIFACT_BASE_URL)/$(X86_64_ARTIFACT)"
 CONTAINER_RUNTIME_ARCHIVE_X86_64_DIGEST ?= "sha256:$(X86_64_256_DIGEST)"
 


### PR DESCRIPTION
Issue #, if available:
Found in #1249 on Windows if environment variable is not defined then Make is not handling the same as on macOS and Linux.

*Description of changes:*
This change adds strip to environment variable check which will return an empty string if environment variable does not exist which is more robust on all platforms.

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
