### PR TITLE
ci: increase cleanup timeout

### DIFF
--- a/.github/workflows/e2e-windows.yaml
+++ b/.github/workflows/e2e-windows.yaml
@@ -66,7 +66,7 @@ jobs:
           role-session-name: credhelper-test
           aws-region: ${{ secrets.REGION }}
       - name: Remove Finch VM
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: ./scripts/cleanup_wsl.ps1
       - name: Clean up previous files
         run: |
@@ -110,7 +110,7 @@ jobs:
           path: ${{ github.workspace }}/reports/${{ github.run_id }}-${{ github.run_attempt }}-*.json
       - name: Remove Finch VM and Clean Up Previous Environment
         if: ${{ always() }}
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: |
           ./scripts/cleanup_wsl.ps1
           make clean


### PR DESCRIPTION
Issue #, if available:
Quite a few of the Windows release test runs have been failing at a cleanup step:
> SUCCESS: The process "wslservice.exe" with PID 1348 has been terminated.
> Error: The action 'Remove Finch VM' has timed out after 2 minutes.

*Description of changes:*
Increases the timeout of the cleanup step

*Testing done:*
Testing on instances shows that it is possible for the cleanup script to exit successfully within 5 minutes. The intention of this timeout is to short-circuit runs of the script which will never succeed. 


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
