### PR TITLE
chore: update golangci-lint to v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,7 +122,7 @@ jobs:
           # Pin the version in case all the builds start to fail at the same time.
           # There may not be an automatic way (e.g., dependabot) to update a specific parameter of a GitHub Action,
           # so we will just update it manually whenever it makes sense (e.g., a feature that we want is added).
-          version: v1.64.7
+          version: v2.0.1
           args: --fix=false --timeout=5m
       - name: set GOOS env to darwin
         run: |
@@ -133,7 +133,7 @@ jobs:
           # Pin the version in case all the builds start to fail at the same time.
           # There may not be an automatic way (e.g., dependabot) to update a specific parameter of a GitHub Action,
           # so we will just update it manually whenever it makes sense (e.g., a feature that we want is added).
-          version: v1.64.7
+          version: v2.0.1
           args: --fix=false --timeout=5m --skip-dirs="(^|/)deps($|/)"
   shellcheck:
     name: ShellCheck

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,7 @@ on:
       - 'finch.yaml.d/**'
       - 'winres'
       - 'Makefile*'
+      - '.golangci.yaml'
       - '!contrib/hello-finch/**'
   pull_request:
     branches:
@@ -33,6 +34,7 @@ on:
       - 'finch.yaml.d/**'
       - 'winres'
       - 'Makefile*'
+      - '.golangci.yaml'
       - '!contrib/hello-finch/**'
   workflow_dispatch:
 permissions:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,27 +1,4 @@
-# The sections in this file are ordered in the order presented in https://golangci-lint.run/usage/configuration/.
-# The nested fields are ordered alphabetically.
-
-linters-settings:
-  goheader:
-    template-path: copyright_header
-  goimports:
-    local-prefixes: github.com/runfinch/finch
-  gosec:
-    config:
-      G306: "0o644"
-  lll:
-    # 145 is just a lax value that does not require too much work to add this check,
-    # and we don't want this to be too strict anyway.
-    line-length: 145
-    tab-width: 4
-  makezero:
-    always: true
-  nolintlint:
-    require-explanation: true
-    require-specific: true
-  stylecheck:
-    # ST1003 is left out because it is a bit opinionated.
-    checks: ["all", "-ST1003"]
+version: "2"
 linters:
   enable:
     - copyloopvar
@@ -30,9 +7,7 @@ linters:
     - forcetypeassert
     - gocritic
     - godot
-    - gofumpt
     - goheader
-    - goimports
     - gosec
     - lll
     - makezero
@@ -45,21 +20,58 @@ linters:
     - predeclared
     - reassign
     - revive
+    - staticcheck
     - testableexamples
     - unconvert
     - unparam
     - usestdlibvars
     - wastedassign
     - whitespace
-    - stylecheck
+  settings:
+    goheader:
+      template-path: copyright_header
+    gosec:
+      config:
+        G306: "0o644"
+    lll:
+      # 145 is just a lax value that does not require too much work to add this check,
+      # and we don't want this to be too strict anyway.
+      line-length: 145
+      tab-width: 4
+    makezero:
+      always: true
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+    staticcheck:
+      checks:
+        # ST1003 is left out because it is a bit opinionated.
+        - -ST1003
+        - all
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - lll
+        # A go:generate statement has to be in the same line: https://github.com/golang/go/issues/46050.  
+        source: '^//go:generate '
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude-rules:
-    - linters:
-        - lll
-      # A go:generate statement has to be in the same line: https://github.com/golang/go/issues/46050.
-      source: "^//go:generate "
-  # Some checks enabled in the stylecheck setting are disabled by default
-  # (e.g., https://golangci-lint.run/usage/false-positives/#exc0013),
-  # so we need to enable them explicitly here.
-  exclude-use-default: false
   fix: true
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/runfinch/finch
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cmd/finch/nerdctl.go
+++ b/cmd/finch/nerdctl.go
@@ -113,7 +113,7 @@ func (nc *nerdctlCommand) shouldReplaceForHelp(cmdName string, args []string) bo
 	// this needs to handle cases of -h except for `container run`,`run`,`create`. For these options -h represent hostname
 	// TODO: Refactor this function.
 	for _, arg := range args {
-		if arg == "--help" || (arg == "-h" && !(cmdName == "container run" || cmdName == "run" || cmdName == "create")) {
+		if arg == "--help" || (arg == "-h" && (cmdName != "container run" && cmdName != "run" && cmdName != "create")) {
 			return true
 		}
 	}

--- a/cmd/finch/nerdctl_remote.go
+++ b/cmd/finch/nerdctl_remote.go
@@ -299,10 +299,10 @@ func (nc *nerdctlCommand) run(cmdName string, args []string) error {
 				}
 			}
 
-			switch {
-			case arg == "--debug":
+			switch arg {
+			case "--debug":
 				nc.logger.SetLevel(flog.Debug)
-			case arg == "--help":
+			case "--help":
 				nerdctlArgs = append(nerdctlArgs, arg)
 			default:
 				nerdctlArgs = append(nerdctlArgs, arg)


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Followed the migration guide https://golangci-lint.run/product/migration-guide/#command-migrate and manually added comments back where they were still relevant
- [staticcheck](https://golangci-lint.run/usage/linters/#staticcheck) added new rules that needed to be fixed:
    ```
      # Apply De Morgan's law.
      # https://staticcheck.dev/docs/checks/#QF1001
      - QF1001
      # Convert untagged switch to tagged switch.
      # https://staticcheck.dev/docs/checks/#QF1002
      - QF1002
    ```

*Testing done:*
- Got "0 issues" output locally


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
