### PR TITLE
fix: Add Buildctl cache prune

### DIFF
--- a/e2e/vm/vm_cache_cleanup_test.go
+++ b/e2e/vm/vm_cache_cleanup_test.go
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build darwin
+
+package vm
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/runfinch/common-tests/command"
+	"github.com/runfinch/common-tests/ffs"
+	"github.com/runfinch/common-tests/option"
+)
+
+var testVMPrune = func(o *option.Option, installed bool) {
+	ginkgo.Describe("Test System Prune Cleans Up Build Cache, Images, Containers", func() {
+		ginkgo.It("check prune cleans up build cache, images and containers", func() {
+			limaCtlO, err := limaCtlOpt(installed)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			command.Stdout(limaCtlO, "shell", "finch", "mount")
+			setupTestContainer(o)
+			verifyResourcesExist(o, limaCtlO)
+			restartVM(o)
+			verifyResourcesExist(o, limaCtlO)
+
+			// Run system prune
+			pruneOutput := command.StdoutStr(o, "system", "prune", "--all", "--force")
+			gomega.Expect(strings.TrimSpace(pruneOutput)).ToNot(gomega.Equal(""),
+				"System prune should produce output indicating resources were cleaned")
+
+			// Verify all resources are cleaned up after prune
+			verifyResourcesCleaned(o, limaCtlO)
+		})
+	})
+}
+
+func setupTestContainer(o *option.Option) {
+	alpineImage := "public.ecr.aws/docker/library/alpine:latest"
+	buildContext := ffs.CreateBuildContext(fmt.Sprintf(`FROM %s
+	CMD ["echo", "finch-test-dummy-output"]
+	`, alpineImage))
+
+	command.Run(o, "build", "-t", "test:tag", buildContext)
+	command.Run(o, "run", "--name", "test-container", "test:tag")
+	// TODO: Fix Issue with nerdctl namestore when we try to delete with prune
+	// name-store error\ncannot release name \"test-4c8e9\" (used by ID \"\", not by <>
+	command.Run(o, "container", "rm", "-f", "test-container")
+}
+
+func verifyResourcesExist(o *option.Option, limaCtlO *option.Option) {
+	gomega.Expect(command.StdoutStr(o, "images", "-q")).ToNot(gomega.BeEmpty(),
+		"Expected at least one image to exist")
+	buildCacheOutput := command.Stdout(limaCtlO, "shell", "finch", "sudo", "buildctl", "du", "--format=json")
+	gomega.Expect(strings.TrimSpace(string(buildCacheOutput))).ToNot(gomega.Equal("null"),
+		"Expected build cache to exist")
+}
+
+func restartVM(o *option.Option) {
+	command.New(o, "vm", "remove", "-f").WithoutCheckingExitCode().WithTimeoutInSeconds(20).Run()
+	time.Sleep(5 * time.Second)
+	command.New(o, "vm", "init").WithTimeoutInSeconds(160).Run()
+}
+
+func verifyResourcesCleaned(o *option.Option, limaCtlO *option.Option) {
+	gomega.Expect(command.StdoutStr(o, "images", "ls", "-q")).To(gomega.Equal(""),
+		"Expected no images after prune")
+	gomega.Expect(command.StdoutStr(o, "container", "ls", "-a", "-q")).To(gomega.Equal(""),
+		"Expected no containers after prune")
+	buildCacheOutput := command.Stdout(limaCtlO, "shell", "finch", "sudo", "buildctl", "du", "--format=json")
+	gomega.Expect(strings.TrimSpace(string(buildCacheOutput))).To(gomega.Equal("null"),
+		"Expected build cache to be cleaned up after prune")
+}

--- a/e2e/vm/vm_darwin_test.go
+++ b/e2e/vm/vm_darwin_test.go
@@ -61,6 +61,7 @@ func TestVM(t *testing.T) {
 	})
 
 	ginkgo.Describe("", func() {
+		testVMPrune(o, *e2e.Installed)
 		testVMLifecycle(o)
 		testAdditionalDisk(o, *e2e.Installed)
 		testConfig(o, *e2e.Installed)

--- a/e2e/vm/vm_windows_test.go
+++ b/e2e/vm/vm_windows_test.go
@@ -46,6 +46,12 @@ func TestVM(t *testing.T) {
 	}, func() {})
 
 	ginkgo.Describe("", func() {
+		/*
+			TODO: Fix issue with prune in windows. Error:
+			failed marshalling json out of network configuration file \"/etc/cni/net.d/nerdctl-bridge.conflist\":
+			error parsing configuration list:unexpected end of JSON input\nFor details on the schema"
+		*/
+		// testVMPrune(o, *e2e.Installed)
 		testVMLifecycle(o)
 		testAdditionalDisk(o, *e2e.Installed)
 		testFinchConfigFile(o)

--- a/finch.yaml.d/common.yaml
+++ b/finch.yaml.d/common.yaml
@@ -71,6 +71,10 @@ provision:
       sudo mkdir -p /mnt/lima-finch/soci-snapshotter-grpc/snapshotter/snapshots /var/lib/soci-snapshotter-grpc
       sudo mount --bind /mnt/lima-finch/soci-snapshotter-grpc /var/lib/soci-snapshotter-grpc
 
+      # Mounting buildkit dir to make the metadata persistent
+      sudo mkdir -p /mnt/lima-finch/buildkit /var/lib/buildkit
+      sudo mount --bind /mnt/lima-finch/buildkit /var/lib/buildkit
+
       # Make sure stargz and buildkit are restarted with containerd
       sudo mkdir -p /usr/local/lib/systemd/system/buildkit.service.d/
       printf '[Unit]\nPartOf=containerd.service\n' | sudo tee /usr/local/lib/systemd/system/buildkit.service.d/finch.conf


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Finch system prune didn't clean up build cache once vm was restarted or re-init as buildkit dir was not mounted to persistent disk. This fix, mounts the buildkit dir to persistent disk while provisioning and adds a test to verify the clean up of cache on a re-init

*Testing done:*
Local Testing done to verify system prune is able to clean up the cache.


- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
