### PR TITLE
chore: increase Finch Vm cleanup in release to 5 minutes

### DIFF
--- a/.github/workflows/build-and-test-msi.yaml
+++ b/.github/workflows/build-and-test-msi.yaml
@@ -86,7 +86,7 @@ jobs:
           role-session-name: windows-msi
           aws-region: ${{ secrets.WINDOWS_REGION }}
       - name: Remove Finch VM
-        timeout-minutes: 2
+        timeout-minutes: 5
         shell: pwsh
         run: ./scripts/cleanup_wsl.ps1
       - name: Clean up previous files
@@ -147,7 +147,7 @@ jobs:
           aws s3 cp "./msi-builder/build/signed/Finch-$tag.msi" "s3://${{ secrets.INSTALLER_PRIVATE_BUCKET_NAME }}/Finch-$tag.msi" --no-progress
       - name: Remove Finch VM and Clean Up Previous Environment
         if: ${{ always() }}
-        timeout-minutes: 2
+        timeout-minutes: 5
         shell: pwsh
         run: |
           ./scripts/cleanup_wsl.ps1
@@ -199,7 +199,7 @@ jobs:
           role-session-name: msi-test
           aws-region: ${{ secrets.REGION }}
       - name: Remove Finch VM
-        timeout-minutes: 2
+        timeout-minutes: 5
         shell: pwsh
         run: ./scripts/cleanup_wsl.ps1
       - name: Clean up previous files
@@ -239,7 +239,7 @@ jobs:
             $env:INSTALLED="true"
             make test-e2e-vm
       - name: Remove Finch VM
-        timeout-minutes: 2
+        timeout-minutes: 5
         shell: pwsh
         run: ./scripts/cleanup_wsl.ps1
       - name: Run container e2e tests
@@ -267,7 +267,7 @@ jobs:
           }
       - name: Remove Finch VM and Clean Up Previous Environment
         if: ${{ always() }}
-        timeout-minutes: 2
+        timeout-minutes: 5
         shell: pwsh
         run: |
           ./scripts/cleanup_wsl.ps1


### PR DESCRIPTION
Issue #, if available:
When the timeout for this job was originally set, the cleanup response was immediate so the 2 minute timeout made sense. What we have observed is when wsl is in this bad state, the time to kill the service increases.

*Description of changes:*
This change increases the vm cleanup timeout to five minutes to match the behavior of e2e test cleanup timeout.

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
