### PR TITLE
ci: remove previous workspace before ci/cd workflows

### DIFF
--- a/.github/workflows/build-and-test-msi.yaml
+++ b/.github/workflows/build-and-test-msi.yaml
@@ -57,6 +57,9 @@ jobs:
     runs-on: [self-hosted, windows, amd64, release]
     timeout-minutes: 100
     steps:
+      - name: Clean GitHub runner workspace
+        run: |
+          Remove-Item -Path "${{ github.workspace }}\*" -Recurse -Force -ErrorAction SilentlyContinue
       - name: Configure git CRLF settings
         run: |
           git config --global core.autocrlf false
@@ -164,6 +167,9 @@ jobs:
     runs-on: [self-hosted, windows, amd64, release]
     timeout-minutes: 180
     steps:
+      - name: Clean GitHub runner workspace
+        run: |
+          Remove-Item -Path "${{ github.workspace }}\*" -Recurse -Force -ErrorAction SilentlyContinue
       - name: Configure git CRLF settings
         run: |
           git config --global core.autocrlf false

--- a/.github/workflows/build-pkg.yaml
+++ b/.github/workflows/build-pkg.yaml
@@ -40,6 +40,10 @@ jobs:
       ]
     timeout-minutes: 60
     steps:
+      - name: Clean macOS runner workspace
+        run: |
+          rm -rf ${{ github.workspace }}/*
+        shell: zsh {0}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.tag }}

--- a/.github/workflows/e2e-linux.yaml
+++ b/.github/workflows/e2e-linux.yaml
@@ -44,6 +44,9 @@ jobs:
       container_report: ${{ steps.set-multiple-vars.outputs.CONTAINER_REPORT }}
       vm_serial_report: ${{ steps.set-multiple-vars.outputs.VM_SERIAL_REPORT }}
     steps:
+      - name: Clean macOS runner workspace
+        run: |
+          rm -rf ${{ github.workspace }}/*
       - name: Allow Node16 on AL2
         if: ${{ (startsWith(inputs.os, 'amazon') && inputs.version == '2' ) }}
         run: |

--- a/.github/workflows/e2e-macos.yaml
+++ b/.github/workflows/e2e-macos.yaml
@@ -42,6 +42,9 @@ jobs:
       container_report: ${{ steps.set-multiple-vars.outputs.CONTAINER_REPORT }}
       vm_serial_report: ${{ steps.set-multiple-vars.outputs.VM_SERIAL_REPORT }}
     steps:
+      - name: Clean macOS runner workspace
+        run: |
+          rm -rf ${{ github.workspace }}/*
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # We need to get all the git tags to make version injection work. See VERSION in Makefile for more detail.

--- a/.github/workflows/e2e-windows.yaml
+++ b/.github/workflows/e2e-windows.yaml
@@ -38,6 +38,9 @@ jobs:
       container_report: ${{ steps.set-multiple-vars.outputs.CONTAINER_REPORT }}
       vm_serial_report: ${{ steps.set-multiple-vars.outputs.VM_SERIAL_REPORT }}  
     steps:
+      - name: Clean GitHub runner workspace
+        run: |
+          Remove-Item -Path "${{ github.workspace }}\*" -Recurse -Force -ErrorAction SilentlyContinue
       - name: Configure git CRLF settings
         run: |
           git config --global core.autocrlf false


### PR DESCRIPTION
Issue #, if available:
The nightly Finch build fails after submodule updates and it seems to be related to a dirty workspace.

*Description of changes:*
This change removes the workspace before CI/CD workflows to prevent dirty workspaces being left on runners.


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
