### PR TITLE
ci: Upload latest Finch tag to s3 on release

### DIFF
--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -49,3 +49,32 @@ jobs:
     secrets: inherit
     with:
       ref_name: ${{ needs.get-latest-tag.outputs.tag }}
+    
+  update-latest-version-in-s3:
+    needs: 
+      - get-latest-tag
+      - upload-pkg-and-dependency-source-code-to-release
+      - upload-msi-to-release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        with:
+          role-to-assume: ${{ secrets.ROLE }}
+          role-session-name: update-latest-version-in-s3
+          aws-region: ${{ secrets.REGION }}
+          
+      - name: Update latest version in S3
+        run: |
+          # Create latest-version.json with the latest Finch release version to track updates
+          cat > latest-version.json << EOF
+          {
+            "latest_version": "${{ needs.get-latest-tag.outputs.tag }}"
+          }
+          EOF
+          
+          # Upload to S3
+          aws s3 cp latest-version.json s3://${{ secrets.ARTIFACT_BUCKET_NAME }}/manifest/latest-version.json --content-type "application/json"


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Added update-latest-version-in-s3 step to the release-automation.yaml file
- The added step uploads a latest-version.json file to s3 to track most recent Finch versions

*Testing done:*
- Manually triggered the workflow in my fork
- Verified that latest-version.json was uploaded to a test s3 bucket


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.