### PR TITLE
fix: ubuntu workflow fixes

### DIFF
--- a/.github/workflows/build-and-test-deb.yaml
+++ b/.github/workflows/build-and-test-deb.yaml
@@ -58,10 +58,11 @@ jobs:
           if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Version matches format: $version"
           else
-            echo "Error: Version $version doesn't match format."
-            exit 1
+            echo "Version $version doesn't match format. Using test version: 0.0.1+{commit}"
+            version="0.0.1+${{ github.sha }}""
           fi
           echo "version=$version" >> ${GITHUB_OUTPUT}
+
   ubuntu-deb-build-and-test:
     needs: get-tag-and-version
     runs-on: codebuild-finch-${{ inputs.arch }}-2-instance-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/upload-deb-to-release.yaml
+++ b/.github/workflows/upload-deb-to-release.yaml
@@ -197,11 +197,11 @@ jobs:
         with:
           tag_name: ${{ needs.get-tag-name.outputs.version }}
           files: |
-            runfinch-finch_${{ needs.get-tag-and-version.outputs.version }}_amd64.deb
-            runfinch-finch_${{ needs.get-tag-and-version.outputs.version }}_amd64.deb.sig
-            runfinch-finch_${{ needs.get-tag-and-version.outputs.version }}_arm64.deb
-            runfinch-finch_${{ needs.get-tag-and-version.outputs.version }}_arm64.deb.sig
-            publickey.pem
+            pool/main/f/runfinch-finch/runfinch-finch_${{ needs.get-tag-and-version.outputs.version }}_amd64.deb
+            pool/main/f/runfinch-finch/runfinch-finch_${{ needs.get-tag-and-version.outputs.version }}_amd64.deb.sig
+            pool/main/f/runfinch-finch/runfinch-finch_${{ needs.get-tag-and-version.outputs.version }}_arm64.deb
+            pool/main/f/runfinch-finch/runfinch-finch_${{ needs.get-tag-and-version.outputs.version }}_arm64.deb.sig
+            pool/main/f/runfinch-finch/publickey.pem
       - name: Delete deb and signature files
         run: |
           rm -rf runfinch-finch_* publcikey.pem pool/ dists/ GPG_KEY.pub PackagesAMD64 PackagesARM64


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Fixes in the workflow files
 - `build-and-tet-deb.yaml` should not error on an invalid version. Instead it should set the version to `0.0.1+{commit}`
 - Use the correct paths when uploading the Finch archives from runners to GitHub releases


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
