### PR TITLE
fix: remove extra quotation in deb workflow

### DIFF
--- a/.github/workflows/build-and-test-deb.yaml
+++ b/.github/workflows/build-and-test-deb.yaml
@@ -59,7 +59,7 @@ jobs:
             echo "Version matches format: $version"
           else
             echo "Version $version doesn't match format. Using test version: 0.0.1+{commit}"
-            version="0.0.1+${{ github.sha }}""
+            version="0.0.1+${{ github.sha }}"
           fi
           echo "version=$version" >> ${GITHUB_OUTPUT}
 


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Remove the extra quotation in the `build-and-test-deb` workflow

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
