### PR TITLE
fix: ubuntu nightly workflow inputs

### DIFF
--- a/.github/workflows/build-and-test-deb.yaml
+++ b/.github/workflows/build-and-test-deb.yaml
@@ -6,23 +6,11 @@ on:
       ref_name:
         required: true
         type: string
-      arch:
-        type: string
-        required: true
-      output-arch:
-        type: string
-        required: true
   workflow_call:
     inputs:
       ref_name:
         required: true
         type: string
-      arch:
-        type: string
-        required: true
-      output-arch:
-        type: string
-        required: true
   schedule:
     - cron: '0 9 * * *'
 env:
@@ -65,7 +53,16 @@ jobs:
 
   ubuntu-deb-build-and-test:
     needs: get-tag-and-version
-    runs-on: codebuild-finch-${{ inputs.arch }}-2-instance-${{ github.run_id }}-${{ github.run_attempt }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ['x86_64', 'arm64']
+        include:
+          - arch: 'x86_64'
+            output-arch: 'amd64'
+          - arch: 'arm64'
+            output-arch: 'arm64'
+    runs-on: codebuild-finch-${{ matrix.arch }}-2-instance-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     steps:
         - name: Configure AWS credentials
@@ -93,15 +90,15 @@ jobs:
             sudo apt install libseccomp-dev -y
             sudo apt install pkg-config -y
             sudo apt install zlib1g-dev -y
-        - name: Build for Ubuntu ${{ inputs.output-arch }}
+        - name: Build for Ubuntu ${{ matrix.output-arch }}
           run: |
             make
         - name: Generate deb
           run: |
-            ./contrib/packaging/deb/package.sh --${{ inputs.output-arch }} --version ${{ needs.get-tag-and-version.outputs.version }}
+            ./contrib/packaging/deb/package.sh --${{ matrix.output-arch }} --version ${{ needs.get-tag-and-version.outputs.version }}
         - name: Install Finch
           run: |
-            sudo apt install ./_output/deb/runfinch-finch_${{ needs.get-tag-and-version.outputs.version }}_${{ inputs.output-arch }}.deb -y
+            sudo apt install ./_output/deb/runfinch-finch_${{ needs.get-tag-and-version.outputs.version }}_${{ matrix.output-arch }}.deb -y
             sudo systemctl daemon-reload
             sudo systemctl start containerd.service
             sudo systemctl restart finch.socket
@@ -126,5 +123,5 @@ jobs:
             sudo apt remove zlib1g-dev -y
         - name: Upload deb to S3
           run: |
-            aws s3 cp ./_output/deb s3://${{ secrets.DEB_PRIVATE_BUCKET_NAME_UNSIGNED_PROD }}/ --recursive --exclude "*" --include "runfinch-finch_${{ needs.get-tag-and-version.outputs.version }}_${{ inputs.output-arch }}.deb"
+            aws s3 cp ./_output/deb s3://${{ secrets.DEB_PRIVATE_BUCKET_NAME_UNSIGNED_PROD }}/ --recursive --exclude "*" --include "runfinch-finch_${{ needs.get-tag-and-version.outputs.version }}_${{ matrix.output-arch }}.deb"
             aws s3 cp ./contrib/packaging/deb/Release s3://${{ secrets.DEB_PRIVATE_BUCKET_NAME_UNSIGNED_PROD }}/

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -52,21 +52,10 @@ jobs:
 
   build-and-test-finch-deb:
     needs: get-latest-tag
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: ['x86_64', 'arm64']
-        include:
-          - arch: 'x86_64'
-            output-arch: 'amd64'
-          - arch: 'arm64'
-            output-arch: 'arm64'
     uses: ./.github/workflows/build-and-test-deb.yaml
     secrets: inherit
     with:
       ref_name: ${{ needs.get-latest-tag.outputs.tag }}
-      arch: ${{ matrix.arch }}
-      output-arch: ${{ matrix.output-arch }}
   
   upload-deb-to-release:
     needs:


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Remove `arch` inputs for `build-and-test-deb` and move `arch` matrix to the workflow itself

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
