### PR TITLE
fix: vm settings w/o flag show settings help

### DIFF
--- a/cmd/finch/virtual_machine_settings_darwin.go
+++ b/cmd/finch/virtual_machine_settings_darwin.go
@@ -74,6 +74,11 @@ func (sva *settingsVMAction) runAdapter(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	// check if any flags were provided by the user
+	if !cmd.Flags().Changed("cpus") && !cmd.Flags().Changed("memory") {
+		return cmd.Help()
+	}
+
 	opts := config.VMConfigOpts{
 		CPUs:   cpus,
 		Memory: memory,

--- a/cmd/finch/virtual_machine_settings_darwin_test.go
+++ b/cmd/finch/virtual_machine_settings_darwin_test.go
@@ -101,6 +101,20 @@ func TestSettingsVMAction_runAdapter(t *testing.T) {
 				lca.EXPECT().GetFinchConfigPath().Return(finchConfigPath)
 			},
 		},
+		{
+			name:    "should show settings --help when no flags are provided",
+			wantErr: nil,
+			command: &cobra.Command{
+				Use: "settings",
+			},
+			args: []string{},
+			mockSvc: func(
+				_ *mocks.LimaConfigApplier,
+				_ afero.Fs,
+			) {
+				// no expectations since help should be shown
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
*Description of changes:* finch vm settings with no flags was causing an error. Updated so then when the settings command contains no flags, it will default to display settings --help. 

*Testing done:* Added simple test case.

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
