### PR TITLE
fix: workflow trigger and typo in upload-verified-artifacts-to-s3.yaml

### DIFF
--- a/.github/workflows/upload-verified-artifacts-to-s3.yaml
+++ b/.github/workflows/upload-verified-artifacts-to-s3.yaml
@@ -50,7 +50,7 @@ jobs:
           }' > $MANIFEST_FILE
           
           # Upload to S3
-          aws s3 cp $MANIFEST_FILE s3://${{ secrets.ARTFACT_BUCKET_NAME }}/manifest/latest-os-artifacts.json --content-type "application/json"
+          aws s3 cp $MANIFEST_FILE s3://${{ secrets.ARTIFACT_BUCKET_NAME }}/manifest/latest-os-artifacts.json --content-type "application/json"
 
       - name: Update latest rootfs information in S3
         run: |

--- a/.github/workflows/upload-verified-artifacts-to-s3.yaml
+++ b/.github/workflows/upload-verified-artifacts-to-s3.yaml
@@ -1,6 +1,7 @@
 name: Upload Verified Artifacts to S3
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
*Description of changes:*
- typo fix for "ARTIFACT"
- Allow manual workflow triggering

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
