### PR TITLE
fix(vm): Don't fail if settings match existing one

### DIFF
--- a/cmd/finch/virtual_machine_settings_darwin.go
+++ b/cmd/finch/virtual_machine_settings_darwin.go
@@ -74,14 +74,20 @@ func (sva *settingsVMAction) runAdapter(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	cpusChanged := cmd.Flags().Changed("cpus")
+	memoryChanged := cmd.Flags().Changed("memory")
+
 	// check if any flags were provided by the user
-	if !cmd.Flags().Changed("cpus") && !cmd.Flags().Changed("memory") {
+	if !cpusChanged && !memoryChanged {
 		return cmd.Help()
 	}
 
-	opts := config.VMConfigOpts{
-		CPUs:   cpus,
-		Memory: memory,
+	opts := config.VMConfigOpts{}
+	if cpusChanged {
+		opts.CPUs = &cpus
+	}
+	if memoryChanged {
+		opts.Memory = &memory
 	}
 
 	return sva.run(opts)
@@ -98,7 +104,9 @@ func (sva *settingsVMAction) run(opts config.VMConfigOpts) error {
 		return err
 	}
 
-	if isConfigUpdated {
+	if !isConfigUpdated {
+		sva.logger.Warnln("Provided flags match existing settings, no changes made.")
+	} else {
 		_, err = fmt.Fprintln(sva.stdout, "Configurations have been successfully updated.")
 	}
 

--- a/cmd/finch/virtual_machine_settings_darwin_test.go
+++ b/cmd/finch/virtual_machine_settings_darwin_test.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"bytes"
-	"errors"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -140,21 +139,30 @@ func TestSettingsVMAction_runAdapter(t *testing.T) {
 func TestSettingsVMAction_run(t *testing.T) {
 	t.Parallel()
 
+	intPtr := func(i int) *int {
+		return &i
+	}
+	stringPtr := func(str string) *string {
+		return &str
+	}
+
 	testCases := []struct {
 		name             string
-		wantErr          error
+		wantErr          string
 		wantStatusOutput string
+		wantWarnOutput   string
 		mockSvc          func(
 			*mocks.LimaConfigApplier,
 			afero.Fs,
 		)
-		cpus   int
-		memory string
+		cpus   *int
+		memory *string
 	}{
 		{
 			name:             "should update vm settings",
-			wantErr:          nil,
+			wantErr:          "",
 			wantStatusOutput: "Configurations have been successfully updated.\n",
+			wantWarnOutput:   "",
 			mockSvc: func(
 				lca *mocks.LimaConfigApplier,
 				fs afero.Fs,
@@ -165,13 +173,14 @@ func TestSettingsVMAction_run(t *testing.T) {
 
 				lca.EXPECT().GetFinchConfigPath().Return(finchConfigPath)
 			},
-			cpus:   1,
-			memory: "2GiB",
+			cpus:   intPtr(1),
+			memory: stringPtr("2GiB"),
 		},
 		{
-			name:             "should return an error if the configuration of CPU or memory is invalid",
-			wantErr:          errors.New("the number of CPUs or the amount of memory should be at least one valid value"),
-			wantStatusOutput: "",
+			name:             "should update vm settings if a value is not specified",
+			wantErr:          "",
+			wantStatusOutput: "Configurations have been successfully updated.\n",
+			wantWarnOutput:   "",
 			mockSvc: func(
 				lca *mocks.LimaConfigApplier,
 				fs afero.Fs,
@@ -182,13 +191,14 @@ func TestSettingsVMAction_run(t *testing.T) {
 
 				lca.EXPECT().GetFinchConfigPath().Return(finchConfigPath)
 			},
-			cpus:   0,
-			memory: "",
+			cpus:   nil,
+			memory: stringPtr("2GiB"),
 		},
 		{
-			name:             "should return an error if the configuration of CPU or memory is invalid",
-			wantErr:          errors.New("the number of CPUs or the amount of memory should be at least one valid value"),
+			name:             "should return an error if the configuration of CPU is invalid",
+			wantErr:          "failed to validate config file: specified number of CPUs (0) must be greater than 0",
 			wantStatusOutput: "",
+			wantWarnOutput:   "",
 			mockSvc: func(
 				lca *mocks.LimaConfigApplier,
 				fs afero.Fs,
@@ -199,8 +209,44 @@ func TestSettingsVMAction_run(t *testing.T) {
 
 				lca.EXPECT().GetFinchConfigPath().Return(finchConfigPath)
 			},
-			cpus:   2,
-			memory: "6GiB",
+			cpus:   intPtr(0),
+			memory: stringPtr("2GiB"),
+		},
+		{
+			name:             "should return an error if the configuration of memory is invalid",
+			wantErr:          "failed to validate config file: failed to parse memory to uint: invalid suffix: 'gi'",
+			wantStatusOutput: "",
+			wantWarnOutput:   "",
+			mockSvc: func(
+				lca *mocks.LimaConfigApplier,
+				fs afero.Fs,
+			) {
+				finchConfigPath := "/config.yaml"
+				data := "cpus: 2\nmemory: 6GiB"
+				require.NoError(t, afero.WriteFile(fs, finchConfigPath, []byte(data), 0o600))
+
+				lca.EXPECT().GetFinchConfigPath().Return(finchConfigPath)
+			},
+			cpus:   intPtr(1),
+			memory: stringPtr("2gi"),
+		},
+		{
+			name:             "should not return an error if the configuration of CPU and memory matches existing config",
+			wantErr:          "",
+			wantStatusOutput: "",
+			wantWarnOutput:   "Provided flags match existing settings, no changes made.",
+			mockSvc: func(
+				lca *mocks.LimaConfigApplier,
+				fs afero.Fs,
+			) {
+				finchConfigPath := "/config.yaml"
+				data := "cpus: 2\nmemory: 6GiB"
+				require.NoError(t, afero.WriteFile(fs, finchConfigPath, []byte(data), 0o600))
+
+				lca.EXPECT().GetFinchConfigPath().Return(finchConfigPath)
+			},
+			cpus:   intPtr(2),
+			memory: stringPtr("6GiB"),
 		},
 	}
 
@@ -219,9 +265,16 @@ func TestSettingsVMAction_run(t *testing.T) {
 			}
 
 			tc.mockSvc(lca, fs)
+			if tc.wantWarnOutput != "" {
+				logger.EXPECT().Warnln(tc.wantWarnOutput)
+			}
 
 			err := newSettingsVMAction(logger, lca, fs, &stdout).run(opts)
-			assert.Equal(t, err, tc.wantErr)
+			errMsg := ""
+			if err != nil {
+				errMsg = err.Error()
+			}
+			assert.Equal(t, tc.wantErr, errMsg)
 			assert.Equal(t, tc.wantStatusOutput, stdout.String())
 		})
 	}

--- a/e2e/vm/config_remote_test.go
+++ b/e2e/vm/config_remote_test.go
@@ -139,7 +139,7 @@ var _ = func(o *option.Option) {
 		})
 
 		ginkgo.It("fails to launch when the config file file doesn't specify enough CPUs", func() {
-			startCmdSession := updateAndApplyConfig(o, []byte("cpus: 0"))
+			startCmdSession := updateAndApplyConfig(o, []byte("cpus: -1"))
 			gomega.Expect(startCmdSession).Should(gexec.Exit(1))
 		})
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,8 +66,8 @@ type Nerdctl struct {
 
 // VMConfigOpts represents the Options for finch vm settings command.
 type VMConfigOpts struct {
-	CPUs   int
-	Memory string
+	CPUs   *int
+	Memory *string
 }
 
 // Default values for the command line arguments --cpus and --memory.

--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -72,17 +72,21 @@ func ModifyFinchConfig(fs afero.Fs, logger flog.Logger, finchConfigPath string, 
 	}
 
 	cpus, memory := opts.CPUs, opts.Memory
-	if cpus != DefaultCPUs && cpus != *finchCfg.CPUs {
-		*finchCfg.CPUs = cpus
+	// This should never happen when called from the CLI, but good to cover just in case
+	if cpus == nil && memory == nil {
+		return isConfigUpdated, fmt.Errorf("specify at least one flag")
+	}
+	if cpus != nil && *cpus != *finchCfg.CPUs {
+		*finchCfg.CPUs = *cpus
 		isConfigUpdated = true
 	}
-	if memory != DefaultMemory && memory != *finchCfg.Memory {
-		*finchCfg.Memory = memory
+	if memory != nil && *memory != *finchCfg.Memory {
+		*finchCfg.Memory = *memory
 		isConfigUpdated = true
 	}
 
 	if !isConfigUpdated {
-		return isConfigUpdated, fmt.Errorf("the number of CPUs or the amount of memory should be at least one valid value")
+		return isConfigUpdated, nil
 	}
 
 	if err := validate(finchCfg, logger, systemDeps, mem); err != nil {


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Currently if we run `finch vm settings` we can set the CPU and memory via flags. However, if the flags do not change anything, we print an error `the number of CPUs or the amount of memory should be at least one valid value`. IMO, this is not a particularly clear error message, and it might be better to print a more benign error in its place, so this PR does that.

Not sure if we're opinionated yet on this but IMO this is a little cleaner and removes some confusion, feel free to close if we don't want to do this.

*Testing done:*
`make test-unit`

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
