### PR TITLE
fix: e2e ubuntu workflow should use non-release fleet

### DIFF
--- a/.github/workflows/e2e-ubuntu.yaml
+++ b/.github/workflows/e2e-ubuntu.yaml
@@ -58,7 +58,7 @@ jobs:
   
   e2e-test:
     needs: get-tag-and-version
-    runs-on: codebuild-finch-${{ inputs.arch }}-2-instance-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-finch-${{ inputs.arch }}-1-instance-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 60
     outputs:
       has_creds: ${{ steps.vars.outputs.has_creds}}


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
The `e2e-ubuntu` workflows should use the correct fleet


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
