### PR TITLE
fix(ci): run linter in ci-docs.yaml

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -77,12 +77,9 @@ jobs:
     timeout-minutes: 2
     steps:
       - run: echo "Skipping CI for docs & contrib files"
+  # Run the linter in case of workflow-only changes to our testing process
   go-linter:
-    name: lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    steps:
-      - run: echo "Skipping CI for docs & contrib files"
+    uses: ./.github/workflows/go-linter.yaml
   go-mod-tidy-check:
     runs-on: ubuntu-latest
     timeout-minutes: 2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,39 +116,8 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
       - run: make test-unit
-  # It's recommended to run golangci-lint in a job separate from other jobs (go test, etc) because different jobs run in parallel.
   go-linter:
-    name: lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: false
-      - name: set GOOS env to windows
-        run: |
-          echo "GOOS=windows" >> $GITHUB_ENV
-      - name: golangci-lint - windows
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
-        with:
-          # Pin the version in case all the builds start to fail at the same time.
-          # There may not be an automatic way (e.g., dependabot) to update a specific parameter of a GitHub Action,
-          # so we will just update it manually whenever it makes sense (e.g., a feature that we want is added).
-          version: v2.1.0
-          args: --fix=false --timeout=5m
-      - name: set GOOS env to darwin
-        run: |
-          echo "GOOS=darwin" >> $GITHUB_ENV
-      - name: golangci-lint - darwin
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
-        with:
-          # Pin the version in case all the builds start to fail at the same time.
-          # There may not be an automatic way (e.g., dependabot) to update a specific parameter of a GitHub Action,
-          # so we will just update it manually whenever it makes sense (e.g., a feature that we want is added).
-          version: v2.1.0
-          args: --fix=false --timeout=5m --skip-dirs="(^|/)deps($|/)"
+    uses: ./.github/workflows/go-linter.yaml
   shellcheck:
     name: ShellCheck
     runs-on: ubuntu-latest

--- a/.github/workflows/go-linter.yaml
+++ b/.github/workflows/go-linter.yaml
@@ -1,0 +1,38 @@
+name: go-linter
+on:
+  workflow_call:
+
+jobs:
+  # It's recommended to run golangci-lint in a job separate from other jobs (go test, etc) because different jobs run in parallel.
+  go-linter:
+    name: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+      - name: set GOOS env to windows
+        run: |
+          echo "GOOS=windows" >> $GITHUB_ENV
+      - name: golangci-lint - windows
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        with:
+          # Pin the version in case all the builds start to fail at the same time.
+          # There may not be an automatic way (e.g., dependabot) to update a specific parameter of a GitHub Action,
+          # so we will just update it manually whenever it makes sense (e.g., a feature that we want is added).
+          version: v2.1.0
+          args: --fix=false --timeout=5m
+      - name: set GOOS env to darwin
+        run: |
+          echo "GOOS=darwin" >> $GITHUB_ENV
+      - name: golangci-lint - darwin
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        with:
+          # Pin the version in case all the builds start to fail at the same time.
+          # There may not be an automatic way (e.g., dependabot) to update a specific parameter of a GitHub Action,
+          # so we will just update it manually whenever it makes sense (e.g., a feature that we want is added).
+          version: v2.1.0
+          args: --fix=false --timeout=5m --skip-dirs="(^|/)deps($|/)"


### PR DESCRIPTION
We had a case where the linter got updated but failed to report that it didn't run because it was a YAML-only change that didn't run the linter. This should help mitigate the issue as well as hopefully catch any YAML-only changes that also affect our code.

Issue #, if available:

*Description of changes:*

*Testing done:*



- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
