### PR TITLE
fix(ci): Add error handling for notarization step in release-installer script

### DIFF
--- a/installer-builder/tools/notarize.sh
+++ b/installer-builder/tools/notarize.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+set -o errexit
 
 #$1: the account name
 #$2: the credential
-cd ./installer-builder/output/installer/signed/Payload || exit
+cd ./installer-builder/output/installer/signed/Payload
 ditto -c -k --sequesterRsrc --keepParent Finch.pkg Finch.zip
 xcrun notarytool submit Finch.zip --apple-id "${1}" --password "${2}" --team-id 94KV3E626L --wait

--- a/installer-builder/tools/release-installer.sh
+++ b/installer-builder/tools/release-installer.sh
@@ -46,7 +46,10 @@ releaseInstaller() {
     downloadSignedPkg "$ARCH" "$PKG_BUCKET"
 
     echo "[11/12] App Store Notarization"
-    bash ./installer-builder/tools/notarize.sh "$NOTARIZATION_ACCOUNT" "$NOTARIZATION_CREDENTIAL"
+    if ! bash ./installer-builder/tools/notarize.sh "$NOTARIZATION_ACCOUNT" "$NOTARIZATION_CREDENTIAL"; then
+        echo "App Store Notarization failed"
+        exit 1
+    fi
 
     echo "[12/12] Upload installer to S3 buckets"
     uploadNotarizedPkg "$ARCH" "$FINCH_VERSION" "$INSTALLER_PRIVATE_BUCKET_NAME"


### PR DESCRIPTION
We have an issue where the .pkg build and test pipeline proceeds normally even if the app notarization step fails. This PR adds error handling specifically to the notarization step.

Issue #, if available:

*Description of changes:*
- The notarization script will now fail if any of the subcommands fail.
- The release-installer script will now fail if the notarization step fails.

*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
