### PR TITLE
chore: group dependabot docker updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,6 +12,11 @@ updates:
     # Re. how that is achieved, see `changelog-types` in workflows/release-please.yml.
     prefix: "build"
     include: "scope"
+  groups:
+    docker:
+      patterns:
+        - "github.com/docker/docker"
+        - "github.com/docker/cli"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Grouping docker updates saves testing resources and time by not needing to run tests 2 extra times for every docker go.mod dependency upgrade. Right now, they will result in these two PRs (https://github.com/runfinch/finch/pull/1477, https://github.com/runfinch/finch/pull/1478), and one of them will require a re-run after rebase.
  - docs: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
