### PR TITLE
fix(ci): Add hardfail to all steps of the .pkg release-installer scipt

### DIFF
--- a/installer-builder/tools/artifact-helper.sh
+++ b/installer-builder/tools/artifact-helper.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -o errexit
+set -o pipefail
 
 #wait signed artifacts available
 MAX_RETRY=60
@@ -35,6 +37,7 @@ downloadSignedExecutables() {
     if [ $attempts -eq $MAX_RETRY ]
     then
         echo "Download failed after $MAX_RETRY attempts."
+        return 1
     fi
 
     tar xzvf "./installer-builder/output/executables/signed/finch-executables-${1//_/-}.zip" -C ./installer-builder/output/executables/signed
@@ -62,6 +65,7 @@ downloadSignedPkg() {
     if [ $attempts -eq $MAX_RETRY ]
     then
         echo "Download failed after $MAX_RETRY attempts."
+        return 1
     fi
 
     tar xzvf "./installer-builder/output/installer/signed/finch-pkg-${1//_/-}.zip" -C ./installer-builder/output/installer/signed

--- a/installer-builder/tools/build-macos-pkg.sh
+++ b/installer-builder/tools/build-macos-pkg.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -o errexit
+set -o pipefail
 
 ARCH=${1}
 VERSION=${2}

--- a/installer-builder/tools/extract-executables.sh
+++ b/installer-builder/tools/extract-executables.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -o errexit
+set -o pipefail
 
 packageUnsignedExecutables() {
     #initialize executable directory
@@ -15,7 +17,7 @@ packageUnsignedExecutables() {
     extractExecutables ./installer-builder/output/origin/_output
 
     #prepare unsigned executable into .tar
-    cd ./installer-builder/output/executables/unsigned/package || exit
+    cd ./installer-builder/output/executables/unsigned/package
     tar -cvzf artifact.gz -C artifact .
     tar -cvzf  ../package.tar.gz manifest.yaml artifact.gz
 }

--- a/installer-builder/tools/merge-back-signed-executables.sh
+++ b/installer-builder/tools/merge-back-signed-executables.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -o errexit
+set -o pipefail
 
 mergeBackSignedExecutables() {
     for file in $(ls -a ./installer-builder/output/executables/signed/Payload/EXECUTABLES_TO_SIGN)

--- a/installer-builder/tools/notarize.sh
+++ b/installer-builder/tools/notarize.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -o errexit
+set -o pipefail
 
 #$1: the account name
 #$2: the credential

--- a/installer-builder/tools/pack-unsigned-pkg.sh
+++ b/installer-builder/tools/pack-unsigned-pkg.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
+set -o errexit
+set -o pipefail
 
 createUnsignedPkgTarball() {
     #prepare unsigned .pkg into .tar
     cp -a ./installer-builder/templates/manifest_pkg.yaml ./installer-builder/output/installer/unsigned/package/manifest.yaml
-    cd ./installer-builder/output/installer/unsigned/package || exit
+    cd ./installer-builder/output/installer/unsigned/package
     tar -cvzf artifact.gz -C artifact .
     tar -cvzf  ../package.tar.gz manifest.yaml artifact.gz
 }

--- a/installer-builder/tools/release-installer.sh
+++ b/installer-builder/tools/release-installer.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -o errexit
+set -o pipefail
 
 source ./installer-builder/tools/artifact-helper.sh
 
@@ -46,10 +48,7 @@ releaseInstaller() {
     downloadSignedPkg "$ARCH" "$PKG_BUCKET"
 
     echo "[11/12] App Store Notarization"
-    if ! bash ./installer-builder/tools/notarize.sh "$NOTARIZATION_ACCOUNT" "$NOTARIZATION_CREDENTIAL"; then
-        echo "App Store Notarization failed"
-        exit 1
-    fi
+    bash ./installer-builder/tools/notarize.sh "$NOTARIZATION_ACCOUNT" "$NOTARIZATION_CREDENTIAL"
 
     echo "[12/12] Upload installer to S3 buckets"
     uploadNotarizedPkg "$ARCH" "$FINCH_VERSION" "$INSTALLER_PRIVATE_BUCKET_NAME"


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
This PR makes minor changes to the .pkg release installer script to make the script and subsequently the workflow fail if any of the steps/sub-commands fail.

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
