### PR TITLE
chore: update finch-daemon version for deb package

### DIFF
--- a/contrib/packaging/deb/package.sh
+++ b/contrib/packaging/deb/package.sh
@@ -56,8 +56,8 @@ TEMP_BUILD_DIR="${SCRIPT_DIR}/TMP/build"
 
 # finch daemon
 FINCHD_PACKAGE="github.com/runfinch/finch-daemon"
-FINCHD_RELEASE="0.18.1"
-FINCHD_COMMIT="beee9549dd791ebfe2c79bb9d476b368d027c9e7"
+FINCHD_RELEASE="0.19.1"
+FINCHD_COMMIT="7ee991cb3be01fdb0013649b9e8fc6b5e3c5a35d"
 FINCHD_SRC=finch-daemon-"${FINCHD_COMMIT}"
 
 # nerdctl


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Syncs the version of finch-daemon used to generate the deb package. Needed to be manually done until https://github.com/runfinch/finch/pull/1458 is merged

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
