### PR TITLE
feat: optimize vm lifecycle tests

### DIFF
--- a/e2e/vm/lifecycle_test.go
+++ b/e2e/vm/lifecycle_test.go
@@ -6,39 +6,15 @@
 package vm
 
 import (
-	"runtime"
-	"time"
-
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/runfinch/common-tests/command"
 	"github.com/runfinch/common-tests/option"
 )
 
-var restoreVM = func(o *option.Option) {
-	origFinchCfg := readFile(finchConfigFilePath)
-	writeFile(finchConfigFilePath, origFinchCfg)
-	command.New(o, virtualMachineRootCmd, "stop", "-f").WithoutCheckingExitCode().WithTimeoutInSeconds(20).Run()
-	time.Sleep(1 * time.Second)
-	command.New(o, virtualMachineRootCmd, "remove", "-f").WithoutCheckingExitCode().WithTimeoutInSeconds(10).Run()
-	time.Sleep(1 * time.Second)
-	if runtime.GOOS == "windows" {
-		// clean up iptables
-		//nolint:lll // link to explanation
-		// https://docs.rancherdesktop.io/troubleshooting-tips/#q-how-do-i-fix-fata0005-subnet-1040024-overlaps-with-other-one-on-this-address-space-when-running-a-container-using-nerdctl-run
-		gomega.Expect(shutdownWSL()).Should(gomega.BeNil())
-	}
-	time.Sleep(1 * time.Second)
-	command.New(o, virtualMachineRootCmd, "init").WithoutCheckingExitCode().WithTimeoutInSeconds(160).Run()
-}
-
 var testVMLifecycle = func(o *option.Option) {
-	ginkgo.Describe("virtual machine lifecycle", ginkgo.Serial, func() {
+	ginkgo.Describe("virtual machine lifecycle", ginkgo.Serial, ginkgo.Ordered, func() {
 		ginkgo.Describe("when the virtual machine is in running status", func() {
-			ginkgo.AfterEach(func() {
-				restoreVM(o)
-			})
-
 			ginkgo.It("should fail to init/remove the virtual machine", func() {
 				command.New(o, virtualMachineRootCmd, "init").WithoutSuccessfulExit().Run()
 				command.New(o, virtualMachineRootCmd, "remove").WithoutSuccessfulExit().Run()
@@ -48,33 +24,10 @@ var testVMLifecycle = func(o *option.Option) {
 				gomega.Expect(command.StdoutStr(o, virtualMachineRootCmd, "status")).To(gomega.Equal("Running"))
 			})
 
-			ginkgo.It("should be able to force stop the virtual machine", func() {
-				command.Run(o, "images")
-				command.New(o, virtualMachineRootCmd, "stop", "--force").WithTimeoutInSeconds(180).Run()
-				command.RunWithoutSuccessfulExit(o, "images")
-				command.New(o, virtualMachineRootCmd, "start").WithTimeoutInSeconds(240).Run()
-			})
-
-			ginkgo.It("should be able to force remove the virtual machine", func() {
-				command.Run(o, "images")
-				command.New(o, virtualMachineRootCmd, "remove", "--force").WithTimeoutInSeconds(160).Run()
-				command.RunWithoutSuccessfulExit(o, "images")
-			})
-
 			ginkgo.It("should be able to stop the virtual machine", func() {
 				command.Run(o, "images")
 				command.New(o, virtualMachineRootCmd, "stop").WithTimeoutInSeconds(90).Run()
 				command.RunWithoutSuccessfulExit(o, "images")
-			})
-		})
-
-		ginkgo.Describe("when the virtual machine is in stopped status", func() {
-			ginkgo.BeforeEach(func() {
-				command.New(o, virtualMachineRootCmd, "stop", "--force").WithTimeoutInSeconds(90).Run()
-			})
-
-			ginkgo.AfterEach(func() {
-				restoreVM(o)
 			})
 
 			ginkgo.It("should fail to init/stop", func() {
@@ -92,24 +45,16 @@ var testVMLifecycle = func(o *option.Option) {
 				command.New(o, virtualMachineRootCmd, "stop").WithTimeoutInSeconds(90).Run()
 			})
 
+			ginkgo.It("should be able to force stop the virtual machine after restarting", func() {
+				command.New(o, virtualMachineRootCmd, "start").WithTimeoutInSeconds(240).Run()
+				command.Run(o, "images")
+				command.New(o, virtualMachineRootCmd, "stop", "--force").WithTimeoutInSeconds(180).Run()
+				command.RunWithoutSuccessfulExit(o, "images")
+			})
+
 			ginkgo.It("should be able to remove the virtual machine", func() {
 				command.New(o, virtualMachineRootCmd, "remove").WithTimeoutInSeconds(160).Run()
 				command.RunWithoutSuccessfulExit(o, "images")
-			})
-
-			ginkgo.It("should be able to force remove the virtual machine", func() {
-				command.New(o, virtualMachineRootCmd, "remove", "--force").WithTimeoutInSeconds(160).Run()
-				command.RunWithoutSuccessfulExit(o, "images")
-			})
-		})
-
-		ginkgo.Describe("when the virtual machine instance does not exist", func() {
-			ginkgo.BeforeEach(func() {
-				command.New(o, virtualMachineRootCmd, "remove", "--force").WithTimeoutInSeconds(160).Run()
-			})
-
-			ginkgo.AfterEach(func() {
-				restoreVM(o)
 			})
 
 			ginkgo.It("should fail to start/stop", func() {
@@ -119,11 +64,6 @@ var testVMLifecycle = func(o *option.Option) {
 
 			ginkgo.It("should get nonexistent status", func() {
 				gomega.Expect(command.StdoutStr(o, virtualMachineRootCmd, "status")).To(gomega.Equal("Nonexistent"))
-			})
-
-			ginkgo.It("should be able to init", func() {
-				command.New(o, virtualMachineRootCmd, "init").WithTimeoutInSeconds(160).Run()
-				command.Run(o, "images")
 			})
 		})
 	})

--- a/e2e/vm/vm_disk_test.go
+++ b/e2e/vm/vm_disk_test.go
@@ -6,11 +6,23 @@
 package vm
 
 import (
+	"time"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/runfinch/common-tests/command"
 	"github.com/runfinch/common-tests/option"
 )
+
+var restoreVM = func(o *option.Option) {
+	origFinchCfg := readFile(finchConfigFilePath)
+	writeFile(finchConfigFilePath, origFinchCfg)
+	command.New(o, virtualMachineRootCmd, "stop", "-f").WithoutCheckingExitCode().WithTimeoutInSeconds(20).Run()
+	time.Sleep(1 * time.Second)
+	command.New(o, virtualMachineRootCmd, "remove", "-f").WithoutCheckingExitCode().WithTimeoutInSeconds(10).Run()
+	time.Sleep(1 * time.Second)
+	command.New(o, virtualMachineRootCmd, "init").WithoutCheckingExitCode().WithTimeoutInSeconds(160).Run()
+}
 
 func testVMDisk(o *option.Option) {
 	ginkgo.Describe("vm disk commands", ginkgo.Serial, func() {


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Reorder the test to reduce the number of vm restarts. Currently the most expensive test suite is running vm test on x86 which takes 1hr30 mins. With these optimization that can be brought down to ~55 mins, which is improving 40% on the current time.

*Testing done:*


- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
