### PR TITLE
build(deps): Bump github.com/containerd/nerdctl/v2 from 2.1.2 to 2.1.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.11
 require (
 	github.com/aws/aws-sdk-go-v2 v1.38.0
 	github.com/containerd/cgroups v1.1.0
-	github.com/containerd/nerdctl/v2 v2.1.2
+	github.com/containerd/nerdctl/v2 v2.1.3
 	github.com/docker/cli v28.3.3+incompatible
 	github.com/docker/docker v28.3.3+incompatible
 	github.com/docker/go-connections v0.5.0
@@ -34,7 +34,7 @@ require (
 )
 
 require (
-	github.com/Masterminds/semver/v3 v3.3.1 // indirect
+	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Microsoft/hcsshim v0.13.0 // indirect
 	github.com/a8m/envsubst v1.4.2 // indirect
@@ -44,7 +44,7 @@ require (
 	github.com/containerd/cgroups/v3 v3.0.5 // indirect
 	github.com/containerd/console v1.0.5 // indirect
 	github.com/containerd/containerd/api v1.9.0 // indirect
-	github.com/containerd/containerd/v2 v2.1.1 // indirect
+	github.com/containerd/containerd/v2 v2.1.3 // indirect
 	github.com/containerd/continuity v0.4.5 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg6
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
 github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
+github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.13.0 h1:/BcXOiS6Qi7N9XqUcv27vkIuVOkBEcWstd2pMlWSeaA=
@@ -39,6 +41,8 @@ github.com/containerd/containerd/api v1.9.0 h1:HZ/licowTRazus+wt9fM6r/9BQO7S0vD5
 github.com/containerd/containerd/api v1.9.0/go.mod h1:GhghKFmTR3hNtyznBoQ0EMWr9ju5AqHjcZPsSpTKutI=
 github.com/containerd/containerd/v2 v2.1.1 h1:znnkm7Ajz8lg8BcIPMhc/9yjBRN3B+OkNKqKisKfwwM=
 github.com/containerd/containerd/v2 v2.1.1/go.mod h1:zIfkQj4RIodclYQkX7GSSswSwgP8d/XxDOtOAoSDIGU=
+github.com/containerd/containerd/v2 v2.1.3 h1:eMD2SLcIQPdMlnlNF6fatlrlRLAeDaiGPGwmRKLZKNs=
+github.com/containerd/containerd/v2 v2.1.3/go.mod h1:8C5QV9djwsYDNhxfTCFjWtTBZrqjditQ4/ghHSYjnHM=
 github.com/containerd/continuity v0.4.5 h1:ZRoN1sXq9u7V6QoHMcVWGhOwDFqZ4B9i5H6un1Wh0x4=
 github.com/containerd/continuity v0.4.5/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
@@ -55,6 +59,8 @@ github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containerd/nerdctl/v2 v2.1.2 h1:ykM+PtsTUWplav2vmf/YxyMwiAdEsaLM0FgkM4d95+c=
 github.com/containerd/nerdctl/v2 v2.1.2/go.mod h1:yMsrdkIWe73vaknK5vOPLHxo57Up1w48061VwxAde8s=
+github.com/containerd/nerdctl/v2 v2.1.3 h1:8QpZrEdTFE0V26kVpeKz8/EyQQfh9VAQTx+PdjSJF1A=
+github.com/containerd/nerdctl/v2 v2.1.3/go.mod h1:1Xs+sxCETHjwvNiL80QEzAyGxbWK3FHrNEm4T4nHNBo=
 github.com/containerd/platforms v1.0.0-rc.1 h1:83KIq4yy1erSRgOVHNk1HYdPvzdJ5CnsWaRoJX4C41E=
 github.com/containerd/platforms v1.0.0-rc.1/go.mod h1:J71L7B+aiM5SdIEqmd9wp6THLVRzJGXfNuWCZCllLA4=
 github.com/containerd/plugin v1.0.0 h1:c8Kf1TNl6+e2TtMHZt+39yAPDbouRH9WAToRjex483Y=


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Bump github.com/containerd/nerdctl/v2 from 2.1.2 to 2.1.3
- some needed go deps of 2.1.3 installed

*Testing done:*
- tested on MacOS 15.5
- successful build with`make`
- successful `./_output/bin/finch vm init` and `./_output/bin/finch version`
- successful `make test-unit`
- successful e2d tests: `./_output/bin/finch vm stop` and `./_output/bin/finch vm remove` then `make test-e2e`

```./_output/bin/finch vm init
INFO[0000] Requesting root access to finish network dependency configuration
INFO[0011] Initializing and starting Finch virtual machine...
```
```./_output/bin/finch version
Client:
 Version:	531e62eb0d89ea647f068819d2c126761b514102
 GitCommit:	531e62eb0d89ea647f068819d2c126761b514102
 OS/Arch:	linux/arm64
 nerdctl:
  Version:	v2.1.3
  GitCommit:	ff9323859a8d7892d8d72380a17b99395ef9a516
 buildctl:
  Version:	v0.23.2
  GitCommit:	40b2ede0ac0a37030f9959b4a28e9c6c8ea036e7

Server:
 containerd:
  Version:	v2.1.3
  GitCommit:	c787fb98911740dd3ff2d0e45ce88cdf01410486
 runc:
  Version:	1.3.0
  GitCommit:	v1.3.0-0-g4ca628d
```

```
make test-unit                                                  git:upgrade-nerdctl-2-1-3
go test -coverprofile=coverage.out github.com/runfinch/finch/cmd/finch github.com/runfinch/finch/pkg/command github.com/runfinch/finch/pkg/config github.com/runfinch/finch/pkg/dependency github.com/runfinch/finch/pkg/dependency/credhelper github.com/runfinch/finch/pkg/dependency/vmnet github.com/runfinch/finch/pkg/disk github.com/runfinch/finch/pkg/fssh github.com/runfinch/finch/pkg/lima github.com/runfinch/finch/pkg/lima/wrapper github.com/runfinch/finch/pkg/path github.com/runfinch/finch/pkg/support github.com/runfinch/finch/pkg/templates github.com/runfinch/finch/pkg/winutil -shuffle on
ok  	github.com/runfinch/finch/cmd/finch	1.498s	coverage: 80.9% of statements
ok  	github.com/runfinch/finch/pkg/command	0.480s	coverage: 90.0% of statements
ok  	github.com/runfinch/finch/pkg/config	0.941s	coverage: 74.1% of statements
ok  	github.com/runfinch/finch/pkg/dependency	0.804s	coverage: 96.0% of statements
ok  	github.com/runfinch/finch/pkg/dependency/credhelper	1.735s	coverage: 65.3% of statements
ok  	github.com/runfinch/finch/pkg/dependency/vmnet	1.047s	coverage: 91.4% of statements
ok  	github.com/runfinch/finch/pkg/disk	1.290s	coverage: 73.1% of statements
ok  	github.com/runfinch/finch/pkg/fssh	0.255s	coverage: 88.2% of statements
ok  	github.com/runfinch/finch/pkg/lima	0.691s	coverage: 96.6% of statements
ok  	github.com/runfinch/finch/pkg/lima/wrapper	0.585s	coverage: 100.0% of statements
ok  	github.com/runfinch/finch/pkg/path	1.155s	coverage: 79.3% of statements
ok  	github.com/runfinch/finch/pkg/support	1.371s	coverage: 82.2% of statements
ok  	github.com/runfinch/finch/pkg/templates	1.593s	coverage: 87.5% of statements
ok  	github.com/runfinch/finch/pkg/winutil	0.144s	coverage: 100.0% of statements
go run coverage/coverage.go 60
Total Coverage: 80%
Coverage 80% meets the 60% threshold
```

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
