### PR TITLE
fix: remove additional e2e run test

### DIFF
--- a/.github/workflows/update-ubuntu-finch-dependencies.yaml
+++ b/.github/workflows/update-ubuntu-finch-dependencies.yaml
@@ -32,17 +32,8 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
-  ubuntu-e2e-tests:
-    needs: update-dependencies
-    if: needs.update-dependencies.outputs.changed == 'true'
-    uses: ./.github/workflows/e2e-ubuntu.yaml
-    secrets: inherit
-    with:
-      arch: ubuntu-x86-64
-      output-arch: amd64
-
   create-pr:
-    needs: [update-dependencies, ubuntu-e2e-tests]
+    needs: [update-dependencies]
     if: needs.update-dependencies.outputs.changed == 'true'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Update dependency update Workflow was not working as the ubuntu runner were not getting secrets. We can fix the issue by inheriting the secrets, but the workflow is repeated as it is run during pr creation. Removing the extra step as remedy.


*Testing done:*
NA



- [ x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
