### PR TITLE
fix: update permission to create pr

### DIFF
--- a/.github/workflows/update-ubuntu-finch-dependencies.yaml
+++ b/.github/workflows/update-ubuntu-finch-dependencies.yaml
@@ -8,15 +8,20 @@ on:
     - cron: '0 9 * * *'  # Run daily at 9 AM UTC
   workflow_dispatch:
 
+# Add permissions needed to create a PR
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
-  update-dependencies:
+  update-dependencies-and-create-pr:
     runs-on: ubuntu-latest
-    outputs:
-      changed: ${{ steps.changes.outputs.changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-
+        with:
+          fetch-depth: 0
+      
       - name: Run dependency update
         run: |
           cd contrib/packaging/deb
@@ -28,19 +33,16 @@ jobs:
         run: |
           if git diff --quiet contrib/packaging/deb/package.sh; then
             echo "changed=false" >> $GITHUB_OUTPUT
+            echo "No changes detected in dependencies"
+            exit 0
           else
             echo "changed=true" >> $GITHUB_OUTPUT
+            echo "Changes detected in dependencies:"
+            git diff contrib/packaging/deb/package.sh
           fi
 
-  create-pr:
-    needs: [update-dependencies]
-    if: needs.update-dependencies.outputs.changed == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
       - name: Create or update PR
+        if: steps.changes.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -58,5 +60,5 @@ jobs:
             - cosign
             
             This is an automated update created by the dependency update workflow. Review the changes before approving.
-          branch: update-dependencies
+          branch: update-ubuntu-dependencies
           delete-branch: true


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
The workflow didnt have the required permissions so it was not able to create the PR.
Added the permissions and did some refactor

*Testing done:*
Tested it by running the wfl and it created the update PR.


- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
