### PR TITLE
ci(fix): race condition when building and testing installers

### DIFF
--- a/.github/workflows/build-and-test-deb.yaml
+++ b/.github/workflows/build-and-test-deb.yaml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       ref_name:
+        description: "name of git ref for which to build installer"
         required: true
         type: string
   workflow_call:
@@ -31,6 +32,7 @@ jobs:
     outputs:
       tag: ${{ steps.check-tag.outputs.tag }}
       version: ${{ steps.check-tag.outputs.version }}
+      commit: ${{ steps.export-commit.outputs.commit }}
     steps:
       - name: Check tag from workflow input and github ref
         id: check-tag
@@ -50,6 +52,17 @@ jobs:
             version="0.0.1+${{ github.sha }}"
           fi
           echo "version=$version" >> ${GITHUB_OUTPUT}
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ steps.check-tag.outputs.tag }}
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: true
+      - name: Export commit hash
+        id: export-commit
+        run: |
+          commit=$(git rev-parse HEAD)
+          echo "commit=$commit" >> ${GITHUB_OUTPUT}
 
   ubuntu-deb-build-and-test:
     needs: get-tag-and-version
@@ -76,7 +89,7 @@ jobs:
             rm -rf ${{ github.workspace }}/*
         - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
           with:
-            ref: ${{ inputs.tag }}
+            ref: ${{ needs.get-tag-and-version.outputs.commit }}
             fetch-depth: 0
             persist-credentials: false
             submodules: true

--- a/.github/workflows/build-and-test-msi.yaml
+++ b/.github/workflows/build-and-test-msi.yaml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       ref_name:
+        description: "name of git ref for which to build installer"
         required: true
         type: string
   workflow_call:
@@ -32,6 +33,7 @@ jobs:
     outputs:
       tag: ${{ steps.check-tag.outputs.tag }}
       version: ${{ steps.check-tag.outputs.version }}
+      commit: ${{ steps.export-commit.outputs.commit }}
     steps:
       - name: Check tag from workflow input and github ref
         id: check-tag
@@ -51,7 +53,18 @@ jobs:
             version="0.0.1"
           fi
           echo "version=$version" >> ${GITHUB_OUTPUT}
-  
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ steps.check-tag.outputs.tag }}
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: true
+      - name: Export commit hash
+        id: export-commit
+        run: |
+          commit=$(git rev-parse HEAD)
+          echo "commit=$commit" >> ${GITHUB_OUTPUT}
+
   windows-msi-build:
     needs: get-tag-name
     runs-on: [self-hosted, windows, amd64, release]
@@ -78,7 +91,7 @@ jobs:
           cache: false
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          ref: ${{ needs.get-tag-name.outputs.tag }}
+          ref: ${{ needs.get-tag-name.outputs.commit }}
           fetch-depth: 0
           persist-credentials: false
           submodules: recursive
@@ -162,8 +175,6 @@ jobs:
     needs:
       - get-tag-name
       - windows-msi-build
-    strategy:
-      fail-fast: false
     runs-on: [self-hosted, windows, amd64, release]
     timeout-minutes: 180
     steps:
@@ -188,7 +199,7 @@ jobs:
           cache: false
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          ref: ${{ needs.get-tag-name.outputs.tag }}
+          ref: ${{ needs.get-tag-name.outputs.commit }}
           fetch-depth: 0
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/build-and-test-pkg.yaml
+++ b/.github/workflows/build-and-test-pkg.yaml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       ref_name:
+        description: "name of git ref for which to build installer"
         required: true
         type: string
   workflow_call:
@@ -24,6 +25,7 @@ jobs:
     timeout-minutes: 2
     outputs:
       tag: ${{ steps.check-tag.outputs.tag }}
+      commit: ${{ steps.export-commit.outputs.commit }}
     steps:
       - name: Check tag from workflow input and github ref
         id: check-tag
@@ -33,7 +35,20 @@ jobs:
           else
             tag=${{ github.ref_name }}
           fi
+          echo "using tag=${tag}"
           echo "tag=$tag" >> ${GITHUB_OUTPUT}
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ steps.check-tag.outputs.tag }}
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: true
+      - name: Export commit hash
+        id: export-commit
+        run: |
+          commit=$(git rev-parse HEAD)
+          echo "using commit=${commit}"
+          echo "commit=$commit" >> ${GITHUB_OUTPUT}
 
   macos-aarch64-pkg-build:
     needs: get-tag-name
@@ -45,6 +60,7 @@ jobs:
       output_arch: aarch64
       version: 14
       tag: ${{ needs.get-tag-name.outputs.tag }}
+      commit: ${{ needs.get-tag-name.outputs.commit }}
 
   macos-x86-64-pkg-build:
     needs: get-tag-name
@@ -56,6 +72,7 @@ jobs:
       output_arch: x86_64
       version: 14
       tag: ${{ needs.get-tag-name.outputs.tag }}
+      commit: ${{ needs.get-tag-name.outputs.commit }}
 
   macos-aarch64-pkg-test:
     strategy:
@@ -73,6 +90,7 @@ jobs:
       output_arch: aarch64
       version: ${{ matrix.version }}
       tag: ${{ needs.get-tag-name.outputs.tag }}
+      commit: ${{ needs.get-tag-name.outputs.commit }}
 
   macos-x86-64-pkg-test:
     strategy:
@@ -90,3 +108,4 @@ jobs:
       output_arch: x86_64
       version: ${{ matrix.version }}
       tag: ${{ needs.get-tag-name.outputs.tag }}
+      commit: ${{ needs.get-tag-name.outputs.commit }}

--- a/.github/workflows/build-pkg.yaml
+++ b/.github/workflows/build-pkg.yaml
@@ -17,6 +17,9 @@ on:
       tag:
         type: string
         required: true
+      commit:
+        type: string
+        required: true
 
 permissions:
   # This is required for configure-aws-credentials to request an OIDC JWT ID token to access AWS resources later on.
@@ -46,7 +49,7 @@ jobs:
         shell: zsh {0}
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          ref: ${{ inputs.tag }}
+          ref: ${{ inputs.commit }}
           fetch-depth: 0
           persist-credentials: false
           submodules: true

--- a/.github/workflows/test-pkg.yaml
+++ b/.github/workflows/test-pkg.yaml
@@ -17,6 +17,9 @@ on:
       tag:
         type: string
         required: true
+      commit:
+        type: string
+        required: true
 
 permissions:
   # This is required for configure-aws-credentials to request an OIDC JWT ID token to access AWS resources later on.
@@ -45,7 +48,7 @@ jobs:
       - name: Checkout the tag
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          ref: ${{ inputs.tag }}
+          ref: ${{ inputs.commit }}
           fetch-depth: 0
           persist-credentials: false
           submodules: true


### PR DESCRIPTION
Issue #, if available:

## Description of changes
When building and testing the installers, it's possible for the ref which we are building the installer for (e.g. `main`), to change during the build process. This is less likely when building off of a tag, but recently when testing various fixes to the release workflow, I had this happen several times when building installers off of `main`.

The workflow will now checkout the ref once at the start, and propagate the exact commit to checkout to the rest of the steps which re-checkout.

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
