### PR TITLE
fix: update benchmark supported versions

### DIFF
--- a/dev/bench/index.html
+++ b/dev/bench/index.html
@@ -37,9 +37,15 @@
 </head>
 <body>
 <h1>Finch Benchmark</h1>
-<a href="./macOS/12/arm64/index.html">macOS 12 arm64</a>
-<a href="./macOS/12/x86_64/index.html">macOS 12 x86_64</a>
 <a href="./macOS/13/arm64/index.html">macOS 13 arm64</a>
 <a href="./macOS/13/x86_64/index.html">macOS 13 x86_64</a>
+<a href="./macOS/14/arm64/index.html">macOS 14 arm64</a>
+<a href="./macOS/14/x86_64/index.html">macOS 14 x86_64</a>
+<br>
+<details>
+    <summary>Older Benchmarking Data</summary>
+    <a href="./macOS/12/arm64/index.html">macOS 12 arm64</a>
+    <a href="./macOS/12/x86_64/index.html">macOS 12 x86_64</a>
+</details>
 </body>
 </html>


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
We haven't supported MacOS for a few months now. Changed our benchmarking page to show MacOS 13 + 14 instead of 12 + 13, and moved MacOS 12 benchmarks behind a drop-down menu.

*Testing done:*

Checks if the local HTML looks good, it's a bit annoying that opening also moves around all the other elements but this seems well out of my scope to fix this.

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
