### PR TITLE
feat: Add finch check-update command

### DIFF
--- a/cmd/finch/check_update.go
+++ b/cmd/finch/check_update.go
@@ -1,0 +1,74 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/runfinch/finch/pkg/flog"
+	"github.com/runfinch/finch/pkg/update"
+)
+
+var defaultFuncs = updateInfoFuncs{
+	checkForUpdate:  update.CheckForUpdate,
+	getFinchVersion: update.GetFinchVersion,
+}
+
+func newCheckUpdateCommand(logger flog.Logger) *cobra.Command {
+	updateCheckCommand := &cobra.Command{
+		Use:   "check-update",
+		Args:  cobra.NoArgs,
+		Short: "Check for Finch updates",
+		RunE:  newCheckUpdateAction(logger, defaultFuncs).runAdapter,
+	}
+
+	return updateCheckCommand
+}
+
+type checkUpdateAction struct {
+	logger flog.Logger
+	funcs  updateInfoFuncs
+}
+
+type updateInfoFuncs struct {
+	checkForUpdate  func() (bool, string, error)
+	getFinchVersion func() string
+}
+
+func newCheckUpdateAction(logger flog.Logger, funcs updateInfoFuncs) *checkUpdateAction {
+	return &checkUpdateAction{logger: logger, funcs: funcs}
+}
+
+func (uca *checkUpdateAction) runAdapter(_ *cobra.Command, _ []string) error {
+	return uca.run()
+}
+
+func (uca *checkUpdateAction) run() error {
+	releasesURL := "https://github.com/runfinch/finch/releases"
+
+	uca.logger.Info("Checking for updates...")
+
+	updateAvailable, latestVersion, err := uca.funcs.checkForUpdate()
+	if err != nil {
+		return fmt.Errorf("failed to check for updates: %w", err)
+	}
+
+	if !updateAvailable {
+		uca.logger.Info("Finch is already up to date.")
+		return nil
+	}
+
+	currentVersion := uca.funcs.getFinchVersion()
+	if currentVersion == "" || strings.HasSuffix(currentVersion, ".modified") {
+		// Warn but allow users who are on development/modified builds of Finch to update
+		uca.logger.Warnf("User is on a modified build of Finch (version: %s)", currentVersion)
+	}
+
+	uca.logger.Infof("A new version of Finch is available: %s (current version: %s)\n", latestVersion, currentVersion)
+	uca.logger.Infof("Go to %s to get the latest version of Finch\n", releasesURL)
+	return nil
+}

--- a/cmd/finch/check_update_test.go
+++ b/cmd/finch/check_update_test.go
@@ -1,0 +1,211 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/runfinch/finch/pkg/mocks"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestNewCheckUpdateCommand(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	logger := mocks.NewLogger(ctrl)
+	cmd := newCheckUpdateCommand(logger)
+
+	assert.Equal(t, "check-update", cmd.Name())
+	assert.Equal(t, "Check for Finch updates", cmd.Short)
+	assert.NotNil(t, cmd.RunE)
+}
+
+func TestCheckUpdateAction(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	logger := mocks.NewLogger(ctrl)
+
+	action := newCheckUpdateAction(logger, defaultFuncs)
+	assert.NotNil(t, action)
+	assert.Equal(t, logger, action.logger)
+}
+
+func TestCheckUpdateAction_runAdapter(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		wantErr error
+		cmd     func(t *testing.T) *cobra.Command
+		args    []string
+		mockSvc func(*mocks.Logger, *gomock.Controller)
+		funcs   updateInfoFuncs
+	}{
+		{
+			name:    "update available",
+			wantErr: nil,
+			cmd: func(_ *testing.T) *cobra.Command {
+				c := &cobra.Command{
+					Use: "check-update",
+				}
+				return c
+			},
+			args: []string{},
+			mockSvc: func(logger *mocks.Logger, _ *gomock.Controller) {
+				logger.EXPECT().Info("Checking for updates...").Times(1)
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any()).Times(1)
+			},
+			funcs: updateInfoFuncs{
+				checkForUpdate: func() (bool, string, error) {
+					return true, "1.1.0", nil
+				},
+				getFinchVersion: func() string {
+					return "1.0.0"
+				},
+			},
+		},
+		{
+			name:    "update not available",
+			wantErr: nil,
+			cmd: func(_ *testing.T) *cobra.Command {
+				c := &cobra.Command{
+					Use: "check-update",
+				}
+				return c
+			},
+			args: []string{},
+			mockSvc: func(logger *mocks.Logger, _ *gomock.Controller) {
+				logger.EXPECT().Info("Checking for updates...").Times(1)
+				logger.EXPECT().Info("Finch is already up to date.").Times(1)
+			},
+			funcs: updateInfoFuncs{
+				checkForUpdate: func() (bool, string, error) {
+					return false, "1.0.0", nil
+				},
+				getFinchVersion: func() string {
+					return "1.0.0"
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			logger := mocks.NewLogger(ctrl)
+			tc.mockSvc(logger, ctrl)
+
+			err := newCheckUpdateAction(logger, tc.funcs).runAdapter(tc.cmd(t), tc.args)
+			if tc.wantErr != nil {
+				assert.Equal(t, tc.wantErr.Error(), err.Error())
+			} else {
+				assert.Equal(t, tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestCheckUpdateAction_run(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		wantErr   error
+		checkOnly bool
+		mockSvc   func(*mocks.Logger, *gomock.Controller)
+		funcs     updateInfoFuncs
+	}{
+		{
+			name:      "no update available",
+			wantErr:   nil,
+			checkOnly: true,
+			mockSvc: func(logger *mocks.Logger, _ *gomock.Controller) {
+				logger.EXPECT().Info("Checking for updates...").Times(1)
+				logger.EXPECT().Info("Finch is already up to date.").Times(1)
+			},
+			funcs: updateInfoFuncs{
+				checkForUpdate: func() (bool, string, error) {
+					return false, "1.0.0", nil
+				},
+				getFinchVersion: func() string {
+					return "1.0.0"
+				},
+			},
+		},
+		{
+			name:      "update available",
+			wantErr:   nil,
+			checkOnly: true,
+			mockSvc: func(logger *mocks.Logger, _ *gomock.Controller) {
+				logger.EXPECT().Info("Checking for updates...").Times(1)
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any()).Times(1)
+			},
+			funcs: updateInfoFuncs{
+				checkForUpdate: func() (bool, string, error) {
+					return true, "1.1.0", nil
+				},
+				getFinchVersion: func() string {
+					return "1.0.0"
+				},
+			},
+		},
+		{
+			name:      "error checking for update",
+			wantErr:   errors.New("failed to check for updates: network error"),
+			checkOnly: true,
+			mockSvc: func(logger *mocks.Logger, _ *gomock.Controller) {
+				logger.EXPECT().Info("Checking for updates...").Times(1)
+			},
+			funcs: updateInfoFuncs{
+				checkForUpdate: func() (bool, string, error) {
+					return false, "", errors.New("network error")
+				},
+			},
+		},
+		{
+			name:      "update available with modified build",
+			wantErr:   nil,
+			checkOnly: true,
+			mockSvc: func(logger *mocks.Logger, _ *gomock.Controller) {
+				logger.EXPECT().Info("Checking for updates...").Times(1)
+				logger.EXPECT().Warnf("User is on a modified build of Finch (version: %s)", "1.0.0.modified").Times(1)
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any()).Times(1)
+			},
+			funcs: updateInfoFuncs{
+				checkForUpdate: func() (bool, string, error) {
+					return true, "1.1.0", nil
+				},
+				getFinchVersion: func() string {
+					return "1.0.0.modified"
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			logger := mocks.NewLogger(ctrl)
+			tc.mockSvc(logger, ctrl)
+
+			err := newCheckUpdateAction(logger, tc.funcs).run()
+			if tc.wantErr != nil {
+				assert.Equal(t, tc.wantErr.Error(), err.Error())
+			} else {
+				assert.Equal(t, tc.wantErr, err)
+			}
+		})
+	}
+}

--- a/cmd/finch/main_native.go
+++ b/cmd/finch/main_native.go
@@ -112,6 +112,7 @@ var newApp = func(
 	// append finch specific commands
 	allCommands = append(allCommands,
 		newVersionCommand(ncc, logger, stdOut),
+		newCheckUpdateCommand(logger),
 		newSupportBundleCommand(logger, supportBundleBuilder, ncc),
 		newGenDocsCommand(rootCmd, logger, fs, system.NewStdLib()),
 	)

--- a/cmd/finch/main_native_test.go
+++ b/cmd/finch/main_native_test.go
@@ -47,7 +47,7 @@ func TestNewApp(t *testing.T) {
 	assert.Equal(t, cmd.SilenceErrors, true)
 	// confirm the number of command, comprised of nerdctl commands + finch commands
 	// one less than "remote", because there are no VM commands on native
-	assert.Equal(t, len(cmd.Commands()), len(nerdctlCmds)+3)
+	assert.Equal(t, len(cmd.Commands()), len(nerdctlCmds)+4)
 
 	// PersistentPreRunE should set logger level to debug if the debug flag exists.
 	mockCmd := &cobra.Command{}
@@ -88,7 +88,6 @@ func TestXmain(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/cmd/finch/main_remote.go
+++ b/cmd/finch/main_remote.go
@@ -122,6 +122,7 @@ var newApp = func(
 	// append finch specific commands
 	allCommands = append(allCommands,
 		newVersionCommand(ncc, logger, stdOut),
+		newCheckUpdateCommand(logger),
 		virtualMachineCommands(logger, fp, ncc, ecc, fs, fc, home, finchRootPath),
 		newSupportBundleCommand(logger, supportBundleBuilder, ncc),
 		newGenDocsCommand(rootCmd, logger, fs, system.NewStdLib()),

--- a/cmd/finch/main_remote_test.go
+++ b/cmd/finch/main_remote_test.go
@@ -195,7 +195,7 @@ func TestNewApp(t *testing.T) {
 	assert.Equal(t, cmd.SilenceUsage, true)
 	assert.Equal(t, cmd.SilenceErrors, true)
 	// confirm the number of command, comprised of nerdctl commands + finch commands
-	assert.Equal(t, len(cmd.Commands()), len(nerdctlCmds)+4)
+	assert.Equal(t, len(cmd.Commands()), len(nerdctlCmds)+5)
 
 	// PersistentPreRunE should set logger level to debug if the debug flag exists.
 	mockCmd := &cobra.Command{}

--- a/cmd/finch/nerdctl_native_test.go
+++ b/cmd/finch/nerdctl_native_test.go
@@ -43,7 +43,6 @@ func TestNerdctlCommand_runAdaptor(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -160,7 +159,6 @@ func TestNerdctlCommand_run(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/cmd/finch/version_native_test.go
+++ b/cmd/finch/version_native_test.go
@@ -115,7 +115,6 @@ func TestVersionAction_runAdaptor(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -295,7 +294,6 @@ func TestVersionAction_run(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/command/nerdctl_native_test.go
+++ b/pkg/command/nerdctl_native_test.go
@@ -57,7 +57,6 @@ func TestLimaCmdCreator_Create(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/config/config_native_test.go
+++ b/pkg/config/config_native_test.go
@@ -8,10 +8,11 @@ package config
 import (
 	"testing"
 
-	"github.com/runfinch/finch/pkg/mocks"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+
+	"github.com/runfinch/finch/pkg/mocks"
 )
 
 func platformLoadTests(t *testing.T) []loadTestCase {

--- a/pkg/update/finch.go
+++ b/pkg/update/finch.go
@@ -1,0 +1,75 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package update manages the download and installation process for users to update
+// Finch to the newest release and for VM OS image updates
+package update
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/runfinch/finch/pkg/version"
+)
+
+// GetFinchVersion returns the Finch client version.
+func GetFinchVersion() (clientVersion string) {
+	return version.Version
+}
+
+// CheckForUpdate checks if an update is available for Finch.
+func CheckForUpdate() (bool, string, error) {
+	currentVersion := GetFinchVersion()
+	currentVersion = strings.Split(currentVersion, "+")[0]
+
+	if currentVersion == "" || strings.HasSuffix(currentVersion, ".modified") {
+		// Warn but allow users who are on development/modified builds of Finch to update
+		currentVersion = ""
+	}
+
+	latestVersion, err := version.GetLatestVersion()
+	if err != nil {
+		return false, "", err
+	}
+
+	latestVersion = strings.TrimPrefix(latestVersion, "v")
+
+	updateAvailable, err := compareVersions(currentVersion, latestVersion)
+	if err != nil {
+		return false, "", err
+	}
+
+	return updateAvailable, latestVersion, nil
+}
+
+// compareVersions compares two version numbers assumed to be in the form '#.#.#'.
+func compareVersions(a, b string) (bool, error) {
+	// Handle empty current version (development builds)
+	if a == "" {
+		return true, nil
+	}
+
+	aParts := strings.Split(a, ".")
+	bParts := strings.Split(b, ".")
+
+	if len(aParts) != len(bParts) {
+		return false, fmt.Errorf("version format mismatch: current version '%s' has %d parts, latest version '%s' has %d parts",
+			a, len(aParts), b, len(bParts))
+	}
+
+	for i := 0; i < len(aParts); i++ {
+		aNum := 0
+		bNum := 0
+		_, _ = fmt.Sscanf(aParts[i], "%d", &aNum)
+		_, _ = fmt.Sscanf(bParts[i], "%d", &bNum)
+
+		if aNum < bNum {
+			return true, nil
+		} else if aNum > bNum {
+			return false, nil
+		}
+	}
+
+	// Versions are equal
+	return false, nil
+}

--- a/pkg/update/finch_test.go
+++ b/pkg/update/finch_test.go
@@ -1,0 +1,145 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package update
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFinchVersions(t *testing.T) {
+	t.Parallel()
+
+	client := GetFinchVersion()
+	assert.IsType(t, "", client)
+}
+
+func TestCompareVersions(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		a           string
+		b           string
+		expected    bool
+		expectError bool
+	}{
+		{
+			name:        "equal versions",
+			a:           "1.0.0",
+			b:           "1.0.0",
+			expected:    false,
+			expectError: false,
+		},
+		{
+			name:        "older major version",
+			a:           "0.9.0",
+			b:           "1.0.0",
+			expected:    true,
+			expectError: false,
+		},
+		{
+			name:        "newer major version",
+			a:           "2.0.0",
+			b:           "1.0.0",
+			expected:    false,
+			expectError: false,
+		},
+		{
+			name:        "older minor version",
+			a:           "1.0.0",
+			b:           "1.1.0",
+			expected:    true,
+			expectError: false,
+		},
+		{
+			name:        "newer minor version",
+			a:           "1.2.0",
+			b:           "1.1.0",
+			expected:    false,
+			expectError: false,
+		},
+		{
+			name:        "older patch version",
+			a:           "1.0.0",
+			b:           "1.0.1",
+			expected:    true,
+			expectError: false,
+		},
+		{
+			name:        "newer patch version",
+			a:           "1.0.2",
+			b:           "1.0.1",
+			expected:    false,
+			expectError: false,
+		},
+		{
+			name:        "empty current version",
+			a:           "",
+			b:           "1.0.0",
+			expected:    true,
+			expectError: false,
+		},
+		{
+			name:        "version format mismatch - shorter vs longer",
+			a:           "1.0",
+			b:           "1.0.1",
+			expected:    false,
+			expectError: true,
+		},
+		{
+			name:        "version format mismatch - longer vs shorter",
+			a:           "1.0.1",
+			b:           "1.0",
+			expected:    false,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := compareVersions(tc.a, tc.b)
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "version format mismatch")
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestGetLatestVersion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("type check only", func(t *testing.T) {
+		t.Parallel()
+		version, err := func() (string, error) {
+			return "1.0.0", nil
+		}()
+		assert.IsType(t, "", version)
+		assert.IsType(t, (*error)(nil), &err)
+	})
+}
+
+func TestCheckForUpdate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("function structure", func(t *testing.T) {
+		t.Parallel()
+
+		updateAvailable, latestVersion, err := CheckForUpdate()
+
+		// Verify return types regardless of success/failure
+		assert.IsType(t, false, updateAvailable)
+		assert.IsType(t, "", latestVersion)
+		// Function should return an error due to network issues in test environment
+		if err != nil {
+			assert.IsType(t, (*error)(nil), &err)
+		}
+	})
+}

--- a/pkg/version/version_latest.go
+++ b/pkg/version/version_latest.go
@@ -1,0 +1,64 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	// LatestVersionURL is the CloudFront URL to check for the latest version.
+	LatestVersionURL = "https://artifact.runfinch.com/manifest/latest-version.json"
+)
+
+// Info represents the structure of the latest-version.json file.
+type Info struct {
+	Latest string `json:"latest_version"`
+}
+
+// GetLatestVersion fetches the latest version from the CloudFront URL.
+func GetLatestVersion() (_ string, err error) {
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	req, err := http.NewRequest(http.MethodGet, LatestVersionURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Add User-Agent header to avoid potential 403 errors
+	req.Header.Set("User-Agent", "Finch-User")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch latest version: %w", err)
+	}
+
+	defer func() {
+		if rErr := resp.Body.Close(); err != nil {
+			err = fmt.Errorf("%w: %w", err, rErr)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to fetch latest version, status code: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var versionInfo Info
+	if err := json.Unmarshal(body, &versionInfo); err != nil {
+		return "", fmt.Errorf("failed to parse version info: %w", err)
+	}
+
+	return versionInfo.Latest, nil
+}


### PR DESCRIPTION
Issue #, if available:
Partial implementation of #1451 

*Description of changes:*
In internal discussion we decided that the most sensible thing to do when shipping the update feature would be to split it into two sections — one section to check for updates, and another section to do the updating. This is the first of said parts.

Thanks @cartrius for spearheading the approach here!

*Testing done:*
`make test-unit`


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
