### PR TITLE
ci: increase timeout to 60 minutes for running e2e test in build-and-test-deb

### DIFF
--- a/.github/workflows/build-and-test-deb.yaml
+++ b/.github/workflows/build-and-test-deb.yaml
@@ -76,7 +76,7 @@ jobs:
           - arch: 'arm64'
             output-arch: 'arm64'
     runs-on: codebuild-finch-${{ matrix.arch }}-2-instance-${{ github.run_id }}-${{ github.run_attempt }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
         - name: Configure AWS credentials
           uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0


### PR DESCRIPTION
Workflows are timing out while running e2e test in build-and-test-deb workflow. Doubling the current timeout. 

Issue #, if available:

*Description of changes:*

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
