### PR TITLE
ci: add test coverage to e2e

### DIFF
--- a/.github/workflows/e2e-linux.yaml
+++ b/.github/workflows/e2e-linux.yaml
@@ -120,6 +120,8 @@ jobs:
           sudo -E env "PATH=$PATH" INSTALLED=true REGISTRY=${{ steps.vars.outputs.has_creds == true && env.REGISTRY || '' }} make test-e2e-container
           sudo -E env "PATH=$PATH" INSTALLED=true REGISTRY=${{ steps.vars.outputs.has_creds == true && env.REGISTRY || '' }} make test-e2e-vm
           sudo -E env "PATH=/usr/libexec/finch:/usr/libexec/finch/cni/bin/:/usr/local/bin:$PATH" NERDCTL_TOML=/etc/finch/nerdctl/nerdctl.toml BUILDKIT_HOST=unix:///var/lib/finch/buildkit/buildkitd.sock  make test-e2e-daemon-linux
+      - name: Show test coverage
+        run: make test-e2e-cov
       - name: Change ownership of reports
         if: always()
         run: |

--- a/.github/workflows/e2e-macos.yaml
+++ b/.github/workflows/e2e-macos.yaml
@@ -93,6 +93,8 @@ jobs:
           git clean -f -d
           REGISTRY=${{ steps.vars.outputs.has_creds == true && env.REGISTRY || '' }} make ${{ inputs.test-command }}
         shell: zsh {0}
+      - name: Show test coverage
+        run: make test-e2e-cov
       - name: Set artifacts name outputs
         if: always()
         id: set-multiple-vars

--- a/.github/workflows/e2e-ubuntu-finch.yaml
+++ b/.github/workflows/e2e-ubuntu-finch.yaml
@@ -175,6 +175,8 @@ jobs:
           eval $(ssh-agent)
           sudo -E env "PATH=$PATH" INSTALLED=true make test-e2e-container
           sudo -E env "PATH=$PATH" INSTALLED=true make test-e2e-vm
+      - name: Show test coverage
+        run: make test-e2e-cov
       - name: Change ownership of reports
         if: always()
         run: |

--- a/.github/workflows/e2e-windows.yaml
+++ b/.github/workflows/e2e-windows.yaml
@@ -98,6 +98,8 @@ jobs:
           git clean -f -d
 
           make ${{ inputs.test-command }}
+      - name: Show test coverage
+        run: make test-e2e-cov
       - name: Set artifacts name outputs
         if: always()
         id: set-multiple-vars

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ _vde_output/
 **/*.tar.gz
 **/*.lz4
 **/*.img
+cov/
 tmp/
 .vscode/
 tools_bin/


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Add rudimentary e2e testing to our e2e CI.

This is by no means comprehensive, and this is also using the older coverage formats for purposes of combining testing outputs. There's maybe some other ways we can get e2e coverage (in particular I'm interested in combining this with unit test coverage), but this might be a decent first step

*Testing done:*
Tested on a Mac instance and ensured it generated coverage reports.


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
