### PR TITLE
ci: group dependabot alerts

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -17,6 +17,11 @@ updates:
       patterns:
         - "github.com/docker/docker"
         - "github.com/docker/cli"
+    project-dependency:
+      exclude-patterns:
+        - "github.com/containerd/nerdctl/v2"
+        - "github.com/docker/docker"
+        - "github.com/docker/cli"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
Issue #, if available:
This PR groups dependency updates into 3 groups based on its ability to cause issues to finch
- Docker group: groups docker cli and moby updates together 
- Nerdctl : any nerdctl update can potentially break finch test suite
- project-dependency group: All other dependency updates


*Description of changes:*

*Testing done:*



- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
