### PR TITLE
fix: ci permissions block for release-please

### DIFF
--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -62,7 +62,7 @@ jobs:
       # This is required for configure-aws-credentials to request an OIDC JWT ID token to access AWS resources later on.
       # More info: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
       id-token: write
-      contents: read # this is required for actions/checkout
+      contents: write # this is required for actions/checkout
     secrets: inherit
     with:
       ref_name: ${{ needs.get-latest-tag.outputs.tag }}

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -6,14 +6,14 @@ on:
 name: release-please
 
 permissions:
-  contents: read
+  contents: write # Required for trigger-release-automation job
   pull-requests: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     timeout-minutes: 2
     outputs:
@@ -25,4 +25,7 @@ jobs:
     name: Trigger release-automation.yaml if PR is merged
     needs: [release-please]
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    permissions:
+      contents: write    # Required for uploading release assets
+      id-token: write    # Required for AWS OIDC authentication
     uses: ./.github/workflows/release-automation.yaml


### PR DESCRIPTION
Issue #, if available:

It seems like the permissions block added in [this commit](https://github.com/runfinch/finch/pull/1539) has been failing the release-please pr due to it not having enough permissions to call other workflows. 


*Description of changes:*

*Testing done:*



- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
