### PR TITLE
ci(canary): move to script, use own downloader

### DIFF
--- a/.github/workflows/canary-deb.yaml
+++ b/.github/workflows/canary-deb.yaml
@@ -21,55 +21,18 @@ on:
   pull_request:
     paths:
       - '.github/workflows/canary-deb.yaml'
+      - 'scripts/canary-deb.sh'
   
 jobs:
   canary-deb:
     name: Test Finch APT repo health
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 2
     steps:
-      - name: Setup environment variables
-        run: |
-          ARCH=$(dpkg --print-architecture)
-          echo "ARCH=${ARCH}" >> $GITHUB_ENV
-      - name: Download latest Finch release from GitHub
-        id: release-download
-        uses: "robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05" # v1.12.0
+      - name: Checkout canary script
+        uses: actions/checkout@v5
         with:
-          latest: true
-          fileName: '*${{ env.ARCH }}.deb'
-          out-file-path: github-release
-      - name: Add Finch APT Repository
-        run: |
-          echo "Detected architecture: ${{ env.ARCH }}"
-          
-          curl -fsSL https://artifact.runfinch.com/deb/GPG_KEY.pub | gpg --dearmor -o /usr/share/keyrings/runfinch-finch-archive-keyring.gpg
-          echo "deb [signed-by=/usr/share/keyrings/runfinch-finch-archive-keyring.gpg arch=${{ env.ARCH }}] https://artifact.runfinch.com/deb noble main" | sudo tee /etc/apt/sources.list.d/runfinch-finch.list
-
-          # This should only update the runfinch repo.
-          # If this breaks, changing it to `sudo apt-get update` should be acceptable, it just takes longer to run.
-          sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/runfinch-finch.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
-      - name: Download .deb from APT repo
-        run: apt-get download runfinch-finch
-        
-      - name: Verify shasum matches GitHub release shasum
-        run: |
-          # Strip v from tag
-          tag=${{ steps.release-download.outputs.tag_name }}
-          version=${tag/v/}
-          filename=runfinch-finch_${version}_${ARCH}.deb
-
-          apt_file=${GITHUB_WORKSPACE}/${filename}
-          apt_file_shasum=$(sha256sum ${apt_file} | awk '{print $1}')
-
-          github_file=${GITHUB_WORKSPACE}/github-release/${filename}
-          github_file_shasum=$(sha256sum ${github_file} | awk '{print $1}')
-          
-          if [[ $(diff <(echo ${apt_file_shasum}) <(echo ${github_file_shasum})) ]]; then
-            echo "❌ sha256sum mismatch!"
-            echo "apt repo shasum: ${apt_file_shasum}"
-            echo "GitHub release shasum: ${github_file_shasum}"
-            exit 1
-          else
-            echo "✅ shasum ${apt_file_shasum} identical"
-          fi
+          sparse-checkout: |
+            scripts/canary-deb.sh
+      - name: Run canary script
+        run: ./scripts/canary-deb.sh

--- a/scripts/canary-deb.sh
+++ b/scripts/canary-deb.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -o pipefail
+
+ARCH=$(dpkg --print-architecture)
+echo "Detected architecture: ${ARCH}"
+
+if [[ -z "${GITHUB_WORKSPACE}" ]]; then
+    GITHUB_WORKSPACE=${PWD}
+fi
+
+#
+# GitHub artifact downloading
+#
+
+github_artifact_dir=${GITHUB_WORKSPACE}/github-release
+
+req=$(curl https://api.github.com/repos/runfinch/finch/releases/latest)
+deb_asset=$(echo ${req} | jq --arg suffix "${ARCH}.deb" '.assets[] | select(.name|endswith($suffix))')
+
+deb_url=$(echo ${deb_asset} | jq -r '.url')
+filename=$(echo ${deb_asset} | jq -r '.name')
+
+sha_unparsed=$(echo ${deb_asset} | jq -r '.digest')
+while IFS=':' read -ra sha_arr; do
+    expected_shasum=${sha_arr[1]}
+done <<< "${sha_unparsed}"
+
+mkdir ${github_artifact_dir}
+curl -L -H "Accept: application/octet-stream" -o ${github_artifact_dir}/${filename} ${deb_url}
+
+github_file_shasum=$(sha256sum ${github_artifact_dir}/${filename} | awk '{print $1}')
+
+if [[ $(diff <(echo ${expected_shasum}) <(echo ${github_file_shasum})) ]]; then
+    printf "shasum mismatch from GitHub\nexpected:%1\ngot:%s\n" expected_shasum github_file_shasum
+    exit 1
+fi
+
+#
+# APT repo downloading
+#
+
+curl -fsSL https://artifact.runfinch.com/deb/GPG_KEY.pub | gpg --dearmor -o /usr/share/keyrings/runfinch-finch-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/runfinch-finch-archive-keyring.gpg arch=${ARCH}] https://artifact.runfinch.com/deb noble main" | sudo tee /etc/apt/sources.list.d/runfinch-finch.list
+
+# This should only update the runfinch repo.
+# If this breaks, changing it to `sudo apt-get update` should be acceptable, it just takes longer to run.
+sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/runfinch-finch.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
+
+apt-get download runfinch-finch
+apt_file=${GITHUB_WORKSPACE}/${filename}
+apt_file_shasum=$(sha256sum ${apt_file} | awk '{print $1}')
+
+#
+# Compare shasums
+#
+
+if [[ $(diff <(echo ${apt_file_shasum}) <(echo ${expected_shasum})) ]]; then
+    echo "❌ sha256sum mismatch!"
+    echo "apt repo shasum: ${apt_file_shasum}"
+    echo "GitHub release shasum: ${github_file_shasum}"
+    exit 1
+else
+    echo "✅ shasum ${apt_file_shasum} identical"
+fi


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
I found that getting the release tag takes quite a while since we clone the whole repo. The release downloader action has a way to get the tag output so I'd like to reuse that so our canaries run even faster.

Additionally, added an optimization so that we only update the runfinch sources repo. This would also take some time in some runs of this.

These optimizations combined should bring our canary runs pretty consistently under 15 seconds.

*Testing done:*



- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
