### PR TITLE
chore: pass github secrets from top level workflow

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -28,4 +28,5 @@ jobs:
     permissions:
       contents: write    # Required for uploading release assets
       id-token: write    # Required for AWS OIDC authentication
+    secrets: inherit     # Pass all secrets to child workflows
     uses: ./.github/workflows/release-automation.yaml


### PR DESCRIPTION
Issue #, if available:
We noticed workflow failures when the release automation workflow was triggerred by the release-please workflow
The child workflow was not able to retrieve values from the github secrets
We believe this was due to the fact that release-please automation did not pass `secrets: inherit` to its child workflow, resulting in the `Error: Input required and not supplied: aws-region` errors

This pr adds `secrets: inherit` to the workflow

*Description of changes:*

*Testing done:*



- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
