### PR TITLE
chore: upgrade macos runners

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -115,7 +115,7 @@ jobs:
   macos-e2e-tests:
     strategy:
       matrix:
-        version: ['13', '14']
+        version: ['14', '15']
         test-command: ['test-e2e-vm-serial', 'test-e2e-container']
         arch: ['X64', 'arm64']
         runner-type: ['test']

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -186,7 +186,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['13', '14']
+        version: ['14', '15']
         test-command: ['test-e2e-vm-serial', 'test-e2e-container', 'test-e2e-daemon']
         arch: ['X64', 'arm64']
         runner-type: ['test']


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Macos 13 runners have been deprecated, upgrading the CI runners to 14 and 15.

*Testing done:*



- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
