### PR TITLE
chore: deprecate macos 13 runners

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -22,10 +22,10 @@ jobs:
       matrix:
         os:
           [
-            [self-hosted, macos, amd64, 13, test],
             [self-hosted, macos, amd64, 14, test],
-            [self-hosted, macos, arm64, 13, test],
-            [self-hosted, macos, arm64, 14, test]
+            [self-hosted, macos, arm64, 14, test],
+            [self-hosted, macos, amd64, 15, test],
+            [self-hosted, macos, arm64, 15, test]
           ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30

--- a/.github/workflows/build-and-test-pkg.yaml
+++ b/.github/workflows/build-and-test-pkg.yaml
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [13, 14]
+        version: [15, 14]
     needs:
       - get-tag-name
       - macos-aarch64-pkg-build
@@ -123,7 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [13, 14]
+        version: [15, 14]
     needs:
       - get-tag-name
       - macos-x86-64-pkg-build


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Deprecating macos 13 runners.

*Testing done:*



- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
