### PR TITLE
docs: add link to setup self hosted runners

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,6 +235,10 @@ The VM instance is not expected to exist before running e2e tests, please make s
 ./_output/bin/finch vm remove
 ```
 
+### Setting Up Testing Infrastructure
+
+If you want to set up your own testing infrastructure in your fork (including self-hosted runners and S3 buckets), please refer to the [runfinch/infrastructure repository](https://github.com/runfinch/infrastructure) for detailed setup instructions.
+
 ## Commits
 
 ### Conventional Commit Messages


### PR DESCRIPTION
Issue #, if available:

This PR adds documentation linking the finch readme to the infrastructure project, this will enable external contributors to setup our CI and release infra in their fork.

*Description of changes:*

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
