### PR TITLE
fix: fix yaml char in windows

### DIFF
--- a/msi-builder/postinstall.bat
+++ b/msi-builder/postinstall.bat
@@ -3,7 +3,7 @@ SET InstallDir=%~1
 SET FilePath=%InstallDir%\os\finch.yaml
 
 if exist "%FilePath%" (
-    powershell -Command "$installPath = '%InstallDir%'.Replace('\', '/'); (Get-Content '%FilePath%') -replace '__INSTALLFOLDER__', $installPath | Set-Content -Encoding UTF8 '%FilePath%'"
+    powershell -Command "$installPath = '%InstallDir%'.Replace('\', '/'); $content = Get-Content '%FilePath%' -Raw; $content = $content -replace '__INSTALLFOLDER__', $installPath; $content = $content.Replace(\"`r`n\", \"`n\"); $utf8NoBom = New-Object System.Text.UTF8Encoding $false; [System.IO.File]::WriteAllText('%FilePath%', $content, $utf8NoBom)"
 )
 
 icacls "%InstallDir%\lima\data" /grant Users:(OI)(CI)M


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
1. Added System.Text.UTF8Encoding which will remove the BOM (byte order of marking) ufeff before starting of each section.
2. Replaced CRLF with LF. Linux system dont understand CRLF and when we edit the file and do a SetContent line endings were added as CRLF in the post install script. 
3. Our test probably wont be doing an installation rather will be testing on build artifact as this didn't run during the PR and got merged.

*Testing done:*
Ran the failing workflow: https://github.com/runfinch/finch/actions/runs/19070037215


- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
