### PR TITLE
docs: document credential plaintext w/ finch login

### DIFF
--- a/docs/registry-authentication.md
+++ b/docs/registry-authentication.md
@@ -82,3 +82,5 @@ If the login has been successful, you should see:
 ```bash
 Login Succeeded
 ```
+
+**Note:** We do not recommend this approach in production environments as passwords are stored in plaintext on the system. More security-conscious users should opt to use a credential helper instead.


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Call out `finch login` storing credentials in plaintext on the system

*Testing done:*



- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
