### PR TITLE
ci: revert alert comment in benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -69,9 +69,5 @@ jobs:
           tool: 'go'
           benchmark-data-dir-path: "dev/bench/macOS/${{ env.OS_VERSION }}/${{ env.ARCH }}"
           output-file-path: benchmark.txt
-          alert-threshold: "200%"
-          fail-on-alert: true
-          comment-on-alert: true
-          alert-comment-cc-users: '@runfinch/maintainers'
       - name: Push benchmark result
         run: git push 'https://github.com/runfinch/finch.git' gh-pages:gh-pages


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
The benchmark workflow seems to hang in the upload results stage even when github-token is present. Removing it for now to make sure benchmarks run every day.


*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
