### PR TITLE
feat: add journalctl logs to support-bundle

### DIFF
--- a/cmd/finch/main_native_test.go
+++ b/cmd/finch/main_native_test.go
@@ -88,7 +88,6 @@ func TestXmain(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/cmd/finch/nerdctl_native_test.go
+++ b/cmd/finch/nerdctl_native_test.go
@@ -43,7 +43,6 @@ func TestNerdctlCommand_runAdaptor(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -160,7 +159,6 @@ func TestNerdctlCommand_run(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/cmd/finch/support_bundle.go
+++ b/cmd/finch/support_bundle.go
@@ -33,15 +33,19 @@ func newSupportBundleGenerateCommand(logger flog.Logger, builder support.BundleB
 		RunE:  newGenerateSupportBundleAction(logger, builder, ncc).runAdapter,
 	}
 
-	includeUsage := "additional files to include in the support bundle, specified by absolute or relative path."
+	includeUsage := `additional files to include in the support bundle, specified by absolute or relative path.` +
+		`To include journal logs for a service, prefix the file path with "service:".`
 	if runtime.GOOS != "linux" {
-		includeUsage += `To include a file from the VM, prefix the file path with "vm:"`
+		includeUsage += ` To include a file from the VM, prefix the file path with "vm:"`
 	}
+	excludeUsage := `files to exclude from the support bundle. ` +
+		`If you specify a base name, all files matching that base name will be excluded. ` +
+		`If you specify an absolute or relative path, only exact matches will be excluded.` +
+		`To exclude journal logs for a service, prefix the file path with "service":".` +
+		`To exclude all journal logs, use "service:all"`
 
 	supportBundleGenerateCommand.Flags().StringArray("include", []string{}, includeUsage)
-	supportBundleGenerateCommand.Flags().StringArray("exclude", []string{},
-		//nolint:lll // usage string
-		"files to exclude from the support bundle. if you specify a base name, all files matching that base name will be excluded. if you specify an absolute or relative path, only exact matches will be excluded")
+	supportBundleGenerateCommand.Flags().StringArray("exclude", []string{}, excludeUsage)
 	return supportBundleGenerateCommand
 }
 

--- a/cmd/finch/version_native_test.go
+++ b/cmd/finch/version_native_test.go
@@ -115,7 +115,6 @@ func TestVersionAction_runAdaptor(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -295,7 +294,6 @@ func TestVersionAction_run(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/docs/cmd/finch_support-bundle_generate.md
+++ b/docs/cmd/finch_support-bundle_generate.md
@@ -9,7 +9,7 @@ Generates a collection of logs and configs that can be uploaded to a Github issu
 ## Options
 
 ```text
-      --exclude stringArray   files to exclude from the support bundle. if you specify a base name, all files matching that base name will be excluded. if you specify an absolute or relative path, only exact matches will be excluded
+      --exclude stringArray   files to exclude from the support bundle. If you specify a base name, all files matching that base name will be excluded. If you specify an absolute or relative path, only exact matches will be excluded. To exclude journal logs for a service, prefix the file path with "service":. To exclude all journal logs, use "service:all"
   -h, --help                  help for generate
-      --include stringArray   additional files to include in the support bundle, specified by absolute or relative path. to include a file from the VM, prefix the file path with "vm:"
+      --include stringArray   additional files to include in the support bundle, specified by absolute or relative path. To include journal logs for a service, prefix the file path with "service:". To include a file from the VM, prefix the file path with "vm:"
 ```

--- a/e2e/vm/support_bundle_remote_test.go
+++ b/e2e/vm/support_bundle_remote_test.go
@@ -6,6 +6,7 @@ package vm
 import (
 	"archive/zip"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -22,22 +23,29 @@ import (
 var testSupportBundle = func(o *option.Option) {
 	ginkgo.Describe("Support bundles", func() {
 		ginkgo.It("Should generate a support bundle", func() {
-			command.Run(o, "support-bundle", "generate")
-			entries, err := os.ReadDir(".")
-			gomega.Expect(err).Should(gomega.BeNil())
-			bundleExists := false
-			for _, dirEntry := range entries {
-				if strings.Contains(dirEntry.Name(), "finch-support") {
-					_, err := os.Stat(dirEntry.Name())
-					if err == nil {
-						bundleExists = true
-					}
+			cmd := command.Run(o, "support-bundle", "generate")
+			out := string(cmd.Wait().Err.Contents())
+			zipName := getZipName(out)
+			gomega.Expect(zipName).ShouldNot(gomega.BeEmpty())
 
-					err = os.Remove(dirEntry.Name())
-					gomega.Expect(err).Should(gomega.BeNil())
-				}
-			}
-			gomega.Expect(bundleExists).Should(gomega.BeTrue())
+			bundlePath := filepath.Join(".", zipName)
+			_, err := os.Stat(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
+
+			reader, err := zip.OpenReader(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
+
+			zipBaseName := filepath.Base(bundlePath)
+			zipPrefix := strings.TrimSuffix(zipBaseName, filepath.Ext(zipBaseName))
+			r, err := reader.Open(path.Join(zipPrefix, "logs", "journalctl", "containerd"))
+			gomega.Expect(err).Should(gomega.BeNil())
+			b, err := io.ReadAll(r) // just to make sure logs are populated
+			gomega.Expect(err).Should(gomega.BeNil())
+			gomega.Expect(b).ShouldNot(gomega.BeEmpty())
+			gomega.Expect(reader.Close()).Should(gomega.BeNil())
+
+			err = os.Remove(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
 		})
 		ginkgo.It("Should generate a support bundle with an extra file included with --include flag by relative path", func() {
 			includeFilename := fmt.Sprintf("tempTestfile%s", time.Now().Format("20060102150405"))
@@ -50,31 +58,26 @@ var testSupportBundle = func(o *option.Option) {
 				gomega.Expect(err).Should(gomega.BeNil())
 			}()
 
-			command.Run(o, "support-bundle", "generate", "--include", includeFilename)
-			entries, err := os.ReadDir(".")
+			cmd := command.Run(o, "support-bundle", "generate", "--include", includeFilename)
+			out := string(cmd.Wait().Err.Contents())
+			zipName := getZipName(out)
+			gomega.Expect(zipName).ShouldNot(gomega.BeEmpty())
+
+			bundlePath := filepath.Join(".", zipName)
+			_, err = os.Stat(bundlePath)
 			gomega.Expect(err).Should(gomega.BeNil())
-			bundleExists := false
-			for _, dirEntry := range entries {
-				if strings.Contains(dirEntry.Name(), "finch-support") {
-					_, err := os.Stat(dirEntry.Name())
-					if err == nil {
-						bundleExists = true
-					}
 
-					reader, err := zip.OpenReader(dirEntry.Name())
-					gomega.Expect(err).Should(gomega.BeNil())
+			reader, err := zip.OpenReader(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
 
-					zipBaseName := filepath.Base(dirEntry.Name())
-					zipPrefix := strings.TrimSuffix(zipBaseName, filepath.Ext(zipBaseName))
-					_, err = reader.Open(path.Join(zipPrefix, "misc", includeFilename))
-					gomega.Expect(err).Should(gomega.BeNil())
+			zipBaseName := filepath.Base(bundlePath)
+			zipPrefix := strings.TrimSuffix(zipBaseName, filepath.Ext(zipBaseName))
+			_, err = reader.Open(path.Join(zipPrefix, "misc", includeFilename))
+			gomega.Expect(err).Should(gomega.BeNil())
 
-					gomega.Expect(reader.Close()).Should(gomega.BeNil())
-					err = os.Remove(dirEntry.Name())
-					gomega.Expect(err).Should(gomega.BeNil())
-				}
-			}
-			gomega.Expect(bundleExists).Should(gomega.BeTrue())
+			gomega.Expect(reader.Close()).Should(gomega.BeNil())
+			err = os.Remove(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
 		})
 		ginkgo.It("Should generate a support bundle with an extra file included with --include flag by absolute path", func() {
 			includeFilename := fmt.Sprintf("tempTestfile%s", time.Now().Format("20060102150405"))
@@ -91,86 +94,94 @@ var testSupportBundle = func(o *option.Option) {
 			gomega.Expect(err).Should(gomega.BeNil())
 			includeAbsPath := filepath.Join(dir, includeFilename)
 
-			command.Run(o, "support-bundle", "generate", "--include", includeAbsPath)
-			entries, err := os.ReadDir(".")
+			cmd := command.Run(o, "support-bundle", "generate", "--include", includeAbsPath)
+			out := string(cmd.Wait().Err.Contents())
+			zipName := getZipName(out)
+			gomega.Expect(zipName).ShouldNot(gomega.BeEmpty())
+
+			bundlePath := filepath.Join(".", zipName)
+			_, err = os.Stat(bundlePath)
 			gomega.Expect(err).Should(gomega.BeNil())
-			bundleExists := false
-			for _, dirEntry := range entries {
-				if strings.Contains(dirEntry.Name(), "finch-support") {
-					_, err := os.Stat(dirEntry.Name())
-					if err == nil {
-						bundleExists = true
-					}
 
-					reader, err := zip.OpenReader(dirEntry.Name())
-					gomega.Expect(err).Should(gomega.BeNil())
+			reader, err := zip.OpenReader(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
 
-					zipBaseName := filepath.Base(dirEntry.Name())
-					zipPrefix := strings.TrimSuffix(zipBaseName, filepath.Ext(zipBaseName))
-					_, err = reader.Open(path.Join(zipPrefix, "misc", includeFilename))
-					gomega.Expect(err).Should(gomega.BeNil())
+			zipBaseName := filepath.Base(bundlePath)
+			zipPrefix := strings.TrimSuffix(zipBaseName, filepath.Ext(zipBaseName))
+			_, err = reader.Open(path.Join(zipPrefix, "misc", includeFilename))
+			gomega.Expect(err).Should(gomega.BeNil())
 
-					gomega.Expect(reader.Close()).Should(gomega.BeNil())
-					err = os.Remove(dirEntry.Name())
-					gomega.Expect(err).Should(gomega.BeNil())
-				}
-			}
-			gomega.Expect(bundleExists).Should(gomega.BeTrue())
+			gomega.Expect(reader.Close()).Should(gomega.BeNil())
+			err = os.Remove(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
+		})
+		ginkgo.It("Should generate a support bundle with an extra journal log included with --include", func() {
+			includeService := "dummy"
+			cmd := command.Run(o, "support-bundle", "generate", "--include", fmt.Sprintf("service:%s", includeService))
+			out := string(cmd.Wait().Err.Contents())
+			zipName := getZipName(out)
+			gomega.Expect(zipName).ShouldNot(gomega.BeEmpty())
+
+			bundlePath := filepath.Join(".", zipName)
+			_, err := os.Stat(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
+
+			reader, err := zip.OpenReader(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
+
+			zipBaseName := filepath.Base(bundlePath)
+			zipPrefix := strings.TrimSuffix(zipBaseName, filepath.Ext(zipBaseName))
+			_, err = reader.Open(path.Join(zipPrefix, "misc", includeService))
+			gomega.Expect(err).Should(gomega.BeNil())
+			gomega.Expect(reader.Close()).Should(gomega.BeNil())
+
+			err = os.Remove(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
 		})
 		ginkgo.It("Should generate a support bundle with no extra file included with --include flag but an invalid path", func() {
 			fakeFileName := "test123+fakefile"
-			command.Run(o, "support-bundle", "generate", "--include", fakeFileName)
-			entries, err := os.ReadDir(".")
+			cmd := command.Run(o, "support-bundle", "generate", "--include", fakeFileName)
+			out := string(cmd.Wait().Err.Contents())
+			zipName := getZipName(out)
+			gomega.Expect(zipName).ShouldNot(gomega.BeEmpty())
+
+			bundlePath := filepath.Join(".", zipName)
+			_, err := os.Stat(bundlePath)
 			gomega.Expect(err).Should(gomega.BeNil())
-			bundleExists := false
-			for _, dirEntry := range entries {
-				if strings.Contains(dirEntry.Name(), "finch-support") {
-					_, err := os.Stat(dirEntry.Name())
-					if err == nil {
-						bundleExists = true
-					}
 
-					reader, err := zip.OpenReader(dirEntry.Name())
-					gomega.Expect(err).Should(gomega.BeNil())
+			reader, err := zip.OpenReader(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
 
-					zipBaseName := filepath.Base(dirEntry.Name())
-					zipPrefix := strings.TrimSuffix(zipBaseName, filepath.Ext(zipBaseName))
-					_, err = reader.Open(path.Join(zipPrefix, "misc", fakeFileName))
-					gomega.Expect(err).ShouldNot(gomega.BeNil())
+			zipBaseName := filepath.Base(bundlePath)
+			zipPrefix := strings.TrimSuffix(zipBaseName, filepath.Ext(zipBaseName))
+			_, err = reader.Open(path.Join(zipPrefix, "misc", fakeFileName))
+			gomega.Expect(err).ShouldNot(gomega.BeNil())
 
-					gomega.Expect(reader.Close()).Should(gomega.BeNil())
-					err = os.Remove(dirEntry.Name())
-					gomega.Expect(err).Should(gomega.BeNil())
-				}
-			}
-			gomega.Expect(bundleExists).Should(gomega.BeTrue())
+			gomega.Expect(reader.Close()).Should(gomega.BeNil())
+			err = os.Remove(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
 		})
 		ginkgo.It("Should generate a support bundle with a default file excluded with --exclude flag by basename", func() {
-			command.Run(o, "support-bundle", "generate", "--exclude", "finch.yaml")
-			entries, err := os.ReadDir(".")
+			cmd := command.Run(o, "support-bundle", "generate", "--exclude", "finch.yaml")
+			out := string(cmd.Wait().Err.Contents())
+			zipName := getZipName(out)
+			gomega.Expect(zipName).ShouldNot(gomega.BeEmpty())
+
+			bundlePath := filepath.Join(".", zipName)
+			_, err := os.Stat(bundlePath)
 			gomega.Expect(err).Should(gomega.BeNil())
-			bundleExists := false
-			for _, dirEntry := range entries {
-				if strings.Contains(dirEntry.Name(), "finch-support") {
-					_, err := os.Stat(dirEntry.Name())
-					if err == nil {
-						bundleExists = true
-					}
 
-					reader, err := zip.OpenReader(dirEntry.Name())
-					gomega.Expect(err).Should(gomega.BeNil())
+			reader, err := zip.OpenReader(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
 
-					zipBaseName := filepath.Base(dirEntry.Name())
-					zipPrefix := strings.TrimSuffix(zipBaseName, path.Ext(zipBaseName))
-					_, err = reader.Open(path.Join(zipPrefix, "configs", "finch.yaml"))
-					gomega.Expect(err).ShouldNot(gomega.BeNil())
+			zipBaseName := filepath.Base(bundlePath)
+			zipPrefix := strings.TrimSuffix(zipBaseName, path.Ext(zipBaseName))
+			_, err = reader.Open(path.Join(zipPrefix, "configs", "finch.yaml"))
+			gomega.Expect(err).ShouldNot(gomega.BeNil())
 
-					gomega.Expect(reader.Close()).Should(gomega.BeNil())
-					err = os.Remove(dirEntry.Name())
-					gomega.Expect(err).Should(gomega.BeNil())
-				}
-			}
-			gomega.Expect(bundleExists).Should(gomega.BeTrue())
+			gomega.Expect(reader.Close()).Should(gomega.BeNil())
+			err = os.Remove(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
 		})
 		ginkgo.It("Should generate a support bundle with a default file excluded with --exclude flag by absolute path", func() {
 			includeFilename := fmt.Sprintf("tempTestfile%s", time.Now().Format("20060102150405"))
@@ -185,31 +196,26 @@ var testSupportBundle = func(o *option.Option) {
 
 			absPath, err := filepath.Abs(includeFilename)
 			gomega.Expect(err).Should(gomega.BeNil())
-			command.Run(o, "support-bundle", "generate", "--include", includeFilename, "--exclude", absPath)
-			entries, err := os.ReadDir(".")
+			cmd := command.Run(o, "support-bundle", "generate", "--include", includeFilename, "--exclude", absPath)
+			out := string(cmd.Wait().Err.Contents())
+			zipName := getZipName(out)
+			gomega.Expect(zipName).ShouldNot(gomega.BeEmpty())
+
+			bundlePath := filepath.Join(".", zipName)
+			_, err = os.Stat(bundlePath)
 			gomega.Expect(err).Should(gomega.BeNil())
-			bundleExists := false
-			for _, dirEntry := range entries {
-				if strings.Contains(dirEntry.Name(), "finch-support") {
-					_, err := os.Stat(dirEntry.Name())
-					if err == nil {
-						bundleExists = true
-					}
 
-					reader, err := zip.OpenReader(dirEntry.Name())
-					gomega.Expect(err).Should(gomega.BeNil())
+			reader, err := zip.OpenReader(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
 
-					zipBaseName := filepath.Base(dirEntry.Name())
-					zipPrefix := strings.TrimSuffix(zipBaseName, filepath.Ext(zipBaseName))
-					_, err = reader.Open(path.Join(zipPrefix, "misc", includeFilename))
-					gomega.Expect(err).ShouldNot(gomega.BeNil())
+			zipBaseName := filepath.Base(bundlePath)
+			zipPrefix := strings.TrimSuffix(zipBaseName, filepath.Ext(zipBaseName))
+			_, err = reader.Open(path.Join(zipPrefix, "misc", includeFilename))
+			gomega.Expect(err).ShouldNot(gomega.BeNil())
 
-					gomega.Expect(reader.Close()).Should(gomega.BeNil())
-					err = os.Remove(dirEntry.Name())
-					gomega.Expect(err).Should(gomega.BeNil())
-				}
-			}
-			gomega.Expect(bundleExists).Should(gomega.BeTrue())
+			gomega.Expect(reader.Close()).Should(gomega.BeNil())
+			err = os.Remove(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
 		})
 		ginkgo.It("Should generate a support bundle with a default file excluded with --exclude flag by relative path", func() {
 			includeFilename := fmt.Sprintf("tempTestfile%s", time.Now().Format("20060102150405"))
@@ -222,59 +228,94 @@ var testSupportBundle = func(o *option.Option) {
 				gomega.Expect(err).Should(gomega.BeNil())
 			}()
 
-			command.Run(o, "support-bundle", "generate", "--include", includeFilename, "--exclude", filepath.Join(".", includeFilename))
-			entries, err := os.ReadDir(".")
+			cmd := command.Run(o, "support-bundle", "generate", "--include", includeFilename, "--exclude", filepath.Join(".", includeFilename))
+			out := string(cmd.Wait().Err.Contents())
+			zipName := getZipName(out)
+			gomega.Expect(zipName).ShouldNot(gomega.BeEmpty())
+
+			bundlePath := filepath.Join(".", zipName)
+			_, err = os.Stat(bundlePath)
 			gomega.Expect(err).Should(gomega.BeNil())
-			bundleExists := false
-			for _, dirEntry := range entries {
-				if strings.Contains(dirEntry.Name(), "finch-support") {
-					_, err := os.Stat(dirEntry.Name())
-					if err == nil {
-						bundleExists = true
-					}
 
-					reader, err := zip.OpenReader(dirEntry.Name())
-					gomega.Expect(err).Should(gomega.BeNil())
+			reader, err := zip.OpenReader(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
 
-					zipBaseName := filepath.Base(dirEntry.Name())
-					zipPrefix := strings.TrimSuffix(zipBaseName, filepath.Ext(zipBaseName))
-					_, err = reader.Open(path.Join(zipPrefix, "misc", includeFilename))
-					gomega.Expect(err).ShouldNot(gomega.BeNil())
+			zipBaseName := filepath.Base(bundlePath)
+			zipPrefix := strings.TrimSuffix(zipBaseName, filepath.Ext(zipBaseName))
+			_, err = reader.Open(path.Join(zipPrefix, "misc", includeFilename))
+			gomega.Expect(err).ShouldNot(gomega.BeNil())
 
-					gomega.Expect(reader.Close()).Should(gomega.BeNil())
-					err = os.Remove(dirEntry.Name())
-					gomega.Expect(err).Should(gomega.BeNil())
-				}
-			}
-			gomega.Expect(bundleExists).Should(gomega.BeTrue())
+			gomega.Expect(reader.Close()).Should(gomega.BeNil())
+			err = os.Remove(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
 		})
 		ginkgo.It("Should generate a support bundle with no file excluded with --exclude flag with invalid path", func() {
 			fakeFileName := "test123+fakefile"
-			command.Run(o, "support-bundle", "generate", "--exclude", fakeFileName)
-			entries, err := os.ReadDir(".")
+			cmd := command.Run(o, "support-bundle", "generate", "--exclude", fakeFileName)
+			out := string(cmd.Wait().Err.Contents())
+			zipName := getZipName(out)
+			gomega.Expect(zipName).ShouldNot(gomega.BeEmpty())
+
+			bundlePath := filepath.Join(".", zipName)
+			_, err := os.Stat(bundlePath)
 			gomega.Expect(err).Should(gomega.BeNil())
-			bundleExists := false
-			for _, dirEntry := range entries {
-				if strings.Contains(dirEntry.Name(), "finch-support") {
-					_, err := os.Stat(dirEntry.Name())
-					if err == nil {
-						bundleExists = true
-					}
 
-					reader, err := zip.OpenReader(dirEntry.Name())
-					gomega.Expect(err).Should(gomega.BeNil())
+			reader, err := zip.OpenReader(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
 
-					zipBaseName := filepath.Base(dirEntry.Name())
-					zipPrefix := strings.TrimSuffix(zipBaseName, filepath.Ext(zipBaseName))
-					_, err = reader.Open(path.Join(zipPrefix, "configs", "finch.yaml"))
-					gomega.Expect(err).Should(gomega.BeNil())
+			zipBaseName := filepath.Base(bundlePath)
+			zipPrefix := strings.TrimSuffix(zipBaseName, filepath.Ext(zipBaseName))
+			_, err = reader.Open(path.Join(zipPrefix, "configs", "finch.yaml"))
+			gomega.Expect(err).Should(gomega.BeNil())
 
-					gomega.Expect(reader.Close()).Should(gomega.BeNil())
-					err = os.Remove(dirEntry.Name())
-					gomega.Expect(err).Should(gomega.BeNil())
-				}
-			}
-			gomega.Expect(bundleExists).Should(gomega.BeTrue())
+			gomega.Expect(reader.Close()).Should(gomega.BeNil())
+			err = os.Remove(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
+		})
+		ginkgo.It("Should generate a support bundle with a default journal log excluded with --exclude", func() {
+			excludeService := "containerd"
+			cmd := command.Run(o, "support-bundle", "generate", "--exclude", fmt.Sprintf("service:%s", excludeService))
+			out := string(cmd.Wait().Err.Contents())
+			zipName := getZipName(out)
+			gomega.Expect(zipName).ShouldNot(gomega.BeEmpty())
+
+			bundlePath := filepath.Join(".", zipName)
+			_, err := os.Stat(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
+
+			reader, err := zip.OpenReader(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
+
+			zipBaseName := filepath.Base(bundlePath)
+			zipPrefix := strings.TrimSuffix(zipBaseName, filepath.Ext(zipBaseName))
+			_, err = reader.Open(path.Join(zipPrefix, "logs", "journalctl", excludeService))
+			gomega.Expect(err).ShouldNot(gomega.BeNil())
+			gomega.Expect(reader.Close()).Should(gomega.BeNil())
+
+			err = os.Remove(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
+		})
+		ginkgo.It("Should generate a support bundle with no journal logs with --exclude service:all", func() {
+			cmd := command.Run(o, "support-bundle", "generate", "--exclude", "service:all")
+			out := string(cmd.Wait().Err.Contents())
+			zipName := getZipName(out)
+			gomega.Expect(zipName).ShouldNot(gomega.BeEmpty())
+
+			bundlePath := filepath.Join(".", zipName)
+			_, err := os.Stat(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
+
+			reader, err := zip.OpenReader(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
+
+			zipBaseName := filepath.Base(bundlePath)
+			zipPrefix := strings.TrimSuffix(zipBaseName, filepath.Ext(zipBaseName))
+			_, err = reader.Open(path.Join(zipPrefix, "logs", "journalctl"))
+			gomega.Expect(err).ShouldNot(gomega.BeNil())
+			gomega.Expect(reader.Close()).Should(gomega.BeNil())
+
+			err = os.Remove(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
 		})
 		ginkgo.It("Should generate a support bundle with a file excluded when specified with both --include and --exclude", func() {
 			includeFilename := fmt.Sprintf("tempTestfile%s", time.Now().Format("20060102150405"))
@@ -287,31 +328,26 @@ var testSupportBundle = func(o *option.Option) {
 				gomega.Expect(err).Should(gomega.BeNil())
 			}()
 
-			command.Run(o, "support-bundle", "generate", "--include", includeFilename, "--exclude", includeFilename)
-			entries, err := os.ReadDir(".")
+			cmd := command.Run(o, "support-bundle", "generate", "--include", includeFilename, "--exclude", includeFilename)
+			out := string(cmd.Wait().Err.Contents())
+			zipName := getZipName(out)
+			gomega.Expect(zipName).ShouldNot(gomega.BeEmpty())
+
+			bundlePath := filepath.Join(".", zipName)
+			_, err = os.Stat(bundlePath)
 			gomega.Expect(err).Should(gomega.BeNil())
-			bundleExists := false
-			for _, dirEntry := range entries {
-				if strings.Contains(dirEntry.Name(), "finch-support") {
-					_, err := os.Stat(dirEntry.Name())
-					if err == nil {
-						bundleExists = true
-					}
 
-					reader, err := zip.OpenReader(dirEntry.Name())
-					gomega.Expect(err).Should(gomega.BeNil())
+			reader, err := zip.OpenReader(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
 
-					zipBaseName := filepath.Base(dirEntry.Name())
-					zipPrefix := strings.TrimSuffix(zipBaseName, filepath.Ext(zipBaseName))
-					_, err = reader.Open(path.Join(zipPrefix, "misc", includeFilename))
-					gomega.Expect(err).ShouldNot(gomega.BeNil())
+			zipBaseName := filepath.Base(bundlePath)
+			zipPrefix := strings.TrimSuffix(zipBaseName, filepath.Ext(zipBaseName))
+			_, err = reader.Open(path.Join(zipPrefix, "misc", includeFilename))
+			gomega.Expect(err).ShouldNot(gomega.BeNil())
 
-					gomega.Expect(reader.Close()).Should(gomega.BeNil())
-					err = os.Remove(dirEntry.Name())
-					gomega.Expect(err).Should(gomega.BeNil())
-				}
-			}
-			gomega.Expect(bundleExists).Should(gomega.BeTrue())
+			gomega.Expect(reader.Close()).Should(gomega.BeNil())
+			err = os.Remove(bundlePath)
+			gomega.Expect(err).Should(gomega.BeNil())
 		})
 		ginkgo.It("Should fail to generate a support bundle when the VM is nonexistent", func() {
 			if runtime.GOOS == "linux" {
@@ -323,23 +359,26 @@ var testSupportBundle = func(o *option.Option) {
 			time.Sleep(1 * time.Second)
 			defer command.New(o, "vm", "init").WithoutCheckingExitCode().WithTimeoutInSeconds(160).Run()
 
-			command.New(o, "support-bundle", "generate").WithoutSuccessfulExit().Run()
-
-			entries, err := os.ReadDir(".")
-			gomega.Expect(err).Should(gomega.BeNil())
-			bundleExists := false
-			for _, dirEntry := range entries {
-				if strings.Contains(dirEntry.Name(), "finch-support") {
-					_, err := os.Stat(dirEntry.Name())
-					if err == nil {
-						bundleExists = true
-					}
-
-					err = os.Remove(dirEntry.Name())
-					gomega.Expect(err).Should(gomega.BeNil())
-				}
-			}
-			gomega.Expect(bundleExists).Should(gomega.BeFalse())
+			cmd := command.New(o, "support-bundle", "generate").WithoutSuccessfulExit().Run()
+			out := string(cmd.Wait().Err.Contents())
+			zipName := getZipName(out)
+			gomega.Expect(zipName).Should(gomega.BeEmpty())
 		})
 	})
+}
+
+func getZipName(cmdOutput string) string {
+	for _, line := range strings.Split(cmdOutput, "\n") {
+		if strings.Contains(line, "Bundle created: finch-support") {
+			bundleLine := strings.Split(line, "\"")
+			gomega.Expect(bundleLine).To(gomega.HaveLen(5))
+
+			zipName := strings.Split(bundleLine[3], ": ")
+			gomega.Expect(zipName).To(gomega.HaveLen(2))
+			gomega.Expect(strings.HasPrefix(zipName[1], "finch-support")).To(gomega.BeTrue())
+
+			return strings.TrimSpace(zipName[1])
+		}
+	}
+	return ""
 }

--- a/pkg/command/nerdctl_native_test.go
+++ b/pkg/command/nerdctl_native_test.go
@@ -57,7 +57,6 @@ func TestLimaCmdCreator_Create(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/config/config_native_test.go
+++ b/pkg/config/config_native_test.go
@@ -8,10 +8,11 @@ package config
 import (
 	"testing"
 
-	"github.com/runfinch/finch/pkg/mocks"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+
+	"github.com/runfinch/finch/pkg/mocks"
 )
 
 func platformLoadTests(t *testing.T) []loadTestCase {

--- a/pkg/mocks/pkg_support_config.go
+++ b/pkg/mocks/pkg_support_config.go
@@ -56,6 +56,20 @@ func (mr *BundleConfigMockRecorder) ConfigFiles() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigFiles", reflect.TypeOf((*BundleConfig)(nil).ConfigFiles))
 }
 
+// JournalServices mocks base method.
+func (m *BundleConfig) JournalServices() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "JournalServices")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// JournalServices indicates an expected call of JournalServices.
+func (mr *BundleConfigMockRecorder) JournalServices() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JournalServices", reflect.TypeOf((*BundleConfig)(nil).JournalServices))
+}
+
 // LogFiles mocks base method.
 func (m *BundleConfig) LogFiles() []string {
 	m.ctrl.T.Helper()

--- a/pkg/support/config.go
+++ b/pkg/support/config.go
@@ -3,7 +3,9 @@
 
 package support
 
-import fpath "github.com/runfinch/finch/pkg/path"
+import (
+	fpath "github.com/runfinch/finch/pkg/path"
+)
 
 type bundleConfig struct {
 	finch   fpath.Finch
@@ -16,6 +18,7 @@ type bundleConfig struct {
 type BundleConfig interface {
 	LogFiles() []string
 	ConfigFiles() []string
+	JournalServices() []string
 }
 
 // NewBundleConfig creates a new bundleConfig.

--- a/pkg/support/config_native_linux.go
+++ b/pkg/support/config_native_linux.go
@@ -16,3 +16,7 @@ func (bc *bundleConfig) ConfigFiles() []string {
 		bc.finch.ConfigFilePath(),
 	}
 }
+
+func (bc *bundleConfig) JournalServices() []string {
+	return []string{"service:containerd", "service:finch", "service:buildkit", "service:soci"}
+}

--- a/pkg/support/config_remote.go
+++ b/pkg/support/config_remote.go
@@ -29,3 +29,7 @@ func (bc *bundleConfig) ConfigFiles() []string {
 		bc.finch.ConfigFilePath(bc.rootDir),
 	}
 }
+
+func (bc *bundleConfig) JournalServices() []string {
+	return []string{"service:containerd", "service:finch", "service:buildkit", "service:soci"}
+}

--- a/pkg/support/support_test.go
+++ b/pkg/support/support_test.go
@@ -5,6 +5,7 @@ package support
 
 import (
 	"archive/zip"
+	"fmt"
 	"io"
 	"os/user"
 	"runtime"
@@ -66,7 +67,7 @@ func TestSupportBundleBuilder_GenerateSupportBundle(t *testing.T) {
 				logger *mocks.Logger,
 				config *mocks.BundleConfig,
 				ecc *mocks.CommandCreator,
-				_ *mocks.NerdctlCmdCreator,
+				ncc *mocks.NerdctlCmdCreator,
 				cmd *mocks.Command,
 				lima *mocks.MockLimaWrapper,
 				systemDeps *mocks.SupportSystemDeps,
@@ -105,6 +106,8 @@ func TestSupportBundleBuilder_GenerateSupportBundle(t *testing.T) {
 				logger.EXPECT().Debugln("Copying in log files...")
 				logger.EXPECT().Debugf("Copying %s...", "log1")
 				logger.EXPECT().Debugf("Copying %s...", "log2")
+				checkJournalCmdOutputs(logger, config, ecc, ncc, cmd, lima, mockUser)
+
 				logger.EXPECT().Debugln("Copying in config files...")
 				logger.EXPECT().Debugf("Copying %s...", "config1")
 				logger.EXPECT().Debugf("Copying %s...", "config2")
@@ -121,7 +124,7 @@ func TestSupportBundleBuilder_GenerateSupportBundle(t *testing.T) {
 				logger *mocks.Logger,
 				config *mocks.BundleConfig,
 				ecc *mocks.CommandCreator,
-				_ *mocks.NerdctlCmdCreator,
+				ncc *mocks.NerdctlCmdCreator,
 				cmd *mocks.Command,
 				lima *mocks.MockLimaWrapper,
 				systemDeps *mocks.SupportSystemDeps,
@@ -157,6 +160,8 @@ func TestSupportBundleBuilder_GenerateSupportBundle(t *testing.T) {
 
 				logger.EXPECT().Debugln("Copying in log files...")
 				logger.EXPECT().Debugf("Copying %s...", "log1")
+				checkJournalCmdOutputs(logger, config, ecc, ncc, cmd, lima, mockUser)
+
 				logger.EXPECT().Debugln("Copying in config files...")
 				logger.EXPECT().Debugf("Copying %s...", "config1")
 				logger.EXPECT().Debugln("Copying in additional files...")
@@ -173,7 +178,7 @@ func TestSupportBundleBuilder_GenerateSupportBundle(t *testing.T) {
 				logger *mocks.Logger,
 				config *mocks.BundleConfig,
 				ecc *mocks.CommandCreator,
-				_ *mocks.NerdctlCmdCreator,
+				ncc *mocks.NerdctlCmdCreator,
 				cmd *mocks.Command,
 				lima *mocks.MockLimaWrapper,
 				systemDeps *mocks.SupportSystemDeps,
@@ -209,6 +214,8 @@ func TestSupportBundleBuilder_GenerateSupportBundle(t *testing.T) {
 
 				logger.EXPECT().Debugln("Copying in log files...")
 				logger.EXPECT().Infof("Excluding %s...", "log1")
+				checkJournalCmdOutputs(logger, config, ecc, ncc, cmd, lima, mockUser)
+
 				logger.EXPECT().Debugln("Copying in config files...")
 				logger.EXPECT().Debugf("Copying %s...", "config1")
 				logger.EXPECT().Debugln("Copying in additional files...")
@@ -224,7 +231,7 @@ func TestSupportBundleBuilder_GenerateSupportBundle(t *testing.T) {
 				logger *mocks.Logger,
 				config *mocks.BundleConfig,
 				ecc *mocks.CommandCreator,
-				_ *mocks.NerdctlCmdCreator,
+				ncc *mocks.NerdctlCmdCreator,
 				cmd *mocks.Command,
 				lima *mocks.MockLimaWrapper,
 				systemDeps *mocks.SupportSystemDeps,
@@ -260,6 +267,8 @@ func TestSupportBundleBuilder_GenerateSupportBundle(t *testing.T) {
 
 				logger.EXPECT().Debugln("Copying in log files...")
 				logger.EXPECT().Debugf("Copying %s...", "log1")
+				checkJournalCmdOutputs(logger, config, ecc, ncc, cmd, lima, mockUser)
+
 				logger.EXPECT().Debugln("Copying in config files...")
 				logger.EXPECT().Infof("Excluding %s...", "config1")
 				logger.EXPECT().Debugln("Copying in additional files...")
@@ -275,7 +284,7 @@ func TestSupportBundleBuilder_GenerateSupportBundle(t *testing.T) {
 				logger *mocks.Logger,
 				config *mocks.BundleConfig,
 				ecc *mocks.CommandCreator,
-				_ *mocks.NerdctlCmdCreator,
+				ncc *mocks.NerdctlCmdCreator,
 				cmd *mocks.Command,
 				lima *mocks.MockLimaWrapper,
 				systemDeps *mocks.SupportSystemDeps,
@@ -311,6 +320,8 @@ func TestSupportBundleBuilder_GenerateSupportBundle(t *testing.T) {
 
 				logger.EXPECT().Debugln("Copying in log files...")
 				logger.EXPECT().Debugf("Copying %s...", "log1")
+				checkJournalCmdOutputs(logger, config, ecc, ncc, cmd, lima, mockUser)
+
 				logger.EXPECT().Debugln("Copying in config files...")
 				logger.EXPECT().Debugf("Copying %s...", "config1")
 				logger.EXPECT().Debugln("Copying in additional files...")
@@ -366,6 +377,8 @@ func TestSupportBundleBuilder_GenerateSupportBundle(t *testing.T) {
 
 				logger.EXPECT().Debugln("Copying in log files...")
 				logger.EXPECT().Debugf("Copying %s...", "log1")
+				checkJournalCmdOutputs(logger, config, ecc, ncc, cmd, lima, mockUser)
+
 				logger.EXPECT().Debugln("Copying in config files...")
 				logger.EXPECT().Debugf("Copying %s...", "config1")
 				logger.EXPECT().Debugln("Copying in additional files...")
@@ -404,7 +417,7 @@ func TestSupportBundleBuilder_GenerateSupportBundle(t *testing.T) {
 				logger *mocks.Logger,
 				config *mocks.BundleConfig,
 				ecc *mocks.CommandCreator,
-				_ *mocks.NerdctlCmdCreator,
+				ncc *mocks.NerdctlCmdCreator,
 				cmd *mocks.Command,
 				lima *mocks.MockLimaWrapper,
 				systemDeps *mocks.SupportSystemDeps,
@@ -440,6 +453,8 @@ func TestSupportBundleBuilder_GenerateSupportBundle(t *testing.T) {
 
 				logger.EXPECT().Debugln("Copying in log files...")
 				logger.EXPECT().Debugf("Copying %s...", "log1")
+				checkJournalCmdOutputs(logger, config, ecc, ncc, cmd, lima, mockUser)
+
 				logger.EXPECT().Debugln("Copying in config files...")
 				logger.EXPECT().Debugf("Copying %s...", "config1")
 				logger.EXPECT().Debugln("Copying in additional files...")
@@ -723,5 +738,41 @@ func TestSupport_writeVersionOutput(t *testing.T) {
 			}
 			assert.True(t, found, "Expected file not found in zip archive")
 		})
+	}
+}
+
+func checkJournalCmdOutputs(
+	logger *mocks.Logger,
+	config *mocks.BundleConfig,
+	ecc *mocks.CommandCreator,
+	ncc *mocks.NerdctlCmdCreator,
+	cmd *mocks.Command,
+	lima *mocks.MockLimaWrapper,
+	mockUser *user.User,
+) {
+	config.EXPECT().JournalServices().Return([]string{
+		"service:containerd",
+		"service:finch",
+		"service:buildkit",
+		"service:soci-snapshotter",
+	})
+
+	services := []string{"containerd", "finch", "buildkit", "soci-snapshotter"}
+	logger.EXPECT().Debugln("Copying in journal logs...")
+
+	for _, service := range services {
+		switch runtime.GOOS {
+		case "linux":
+			ecc.EXPECT().Create("journalctl", "--no-pager", "-xu", service).Return(cmd)
+			logger.EXPECT().Debugf("Copying %s...", fmt.Sprintf("service:%s", service))
+		case "windows", "darwin":
+			logger.EXPECT().Debugf("Copying %s...", fmt.Sprintf("service:%s", service))
+			ncc.EXPECT().CreateWithoutStdio("shell", "finch", "sudo", "journalctl", "--no-pager", "-xu", service).Return(cmd)
+			cmd.EXPECT().SetStdout(gomock.Any())
+			cmd.EXPECT().SetStderr(gomock.Any())
+			cmd.EXPECT().Start()
+			cmd.EXPECT().Wait()
+			lima.EXPECT().LimaUser(false).Return(mockUser).AnyTimes()
+		}
 	}
 }


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Added support for journalctl logs to be added to the support bundle. Default logs include containerd and finch-daemon logs.

*Testing done:*
I wasn't sure of the best way to test this so the best I could do was add something to e2e tests to ensure that the logs folder exists. Ideally I wanted to check if the files were populated with the right info.


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
