### PR TITLE
fix: finch run panic without arguments

### DIFF
--- a/cmd/finch/nerdctl_remote_test.go
+++ b/cmd/finch/nerdctl_remote_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
-	"github.com/runfinch/finch/pkg/command"
 	"github.com/runfinch/finch/pkg/config"
 	"github.com/runfinch/finch/pkg/mocks"
 )
@@ -130,99 +129,6 @@ func TestNerdctlCommand_withVMErrors(t *testing.T) {
 			fs := afero.NewMemMapFs()
 			tc.mockSvc(t, ncc, ecc, ncsd, logger, ctrl, fs)
 			assert.Equal(t, tc.wantErr, newNerdctlCommand(ncc, ecc, ncsd, logger, fs, tc.fc).run(tc.cmdName, tc.args))
-		})
-	}
-}
-
-func TestNerdctlCommand_withEmptyArgs(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		name    string
-		cmdName string
-		args    []string
-	}{
-		{
-			name:    "finch run with no arguments",
-			cmdName: "container run",
-			args:    []string{},
-		},
-		{
-			name:    "finch compose with no arguments",
-			cmdName: "compose",
-			args:    []string{},
-		},
-		{
-			name:    "finch exec with no arguments",
-			cmdName: "exec",
-			args:    []string{},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			ctrl := gomock.NewController(t)
-			ecc := mocks.NewCommandCreator(ctrl)
-			ncc := mocks.NewNerdctlCmdCreator(ctrl)
-			ncsd := mocks.NewNerdctlCommandSystemDeps(ctrl)
-			logger := mocks.NewLogger(ctrl)
-			fs := afero.NewMemMapFs()
-			fc := &config.Finch{}
-
-			// Mock VM status check to return running
-			getVMStatusC := mocks.NewCommand(ctrl)
-			ncc.EXPECT().CreateWithoutStdio("ls", "-f", "{{.Status}}", limaInstanceName).Return(getVMStatusC)
-			getVMStatusC.EXPECT().Output().Return([]byte("Running"), nil)
-			logger.EXPECT().Debugf("Status of virtual machine: %s", "Running")
-
-			// Mock environment variable lookups (these happen in the run method)
-			envVars := []string{
-				"COSIGN_PASSWORD", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
-				"AWS_SESSION_TOKEN", "COMPOSE_FILE", "SOURCE_DATE_EPOCH",
-				"AWS_ECR_DISABLE_CACHE", "AWS_ECR_CACHE_DIR", "AWS_ECR_IGNORE_CREDS_STORAGE",
-			}
-			for _, envVar := range envVars {
-				ncsd.EXPECT().LookupEnv(envVar).Return("", false).AnyTimes()
-			}
-
-			// Mock Windows-specific system calls (GetCmdArgs method calls these)
-			ncsd.EXPECT().GetWd().Return("C:\\test", nil).AnyTimes()
-			ncsd.EXPECT().FilePathAbs(gomock.Any()).DoAndReturn(func(path string) (string, error) {
-				return path, nil
-			}).AnyTimes()
-			ncsd.EXPECT().FilePathToSlash(gomock.Any()).DoAndReturn(func(path string) string {
-				return path
-			}).AnyTimes()
-			ncsd.EXPECT().FilePathJoin(gomock.Any()).DoAndReturn(func(_ ...string) string {
-				return "/mnt/c/test"
-			}).AnyTimes()
-
-			// Mock the RunWithReplacingStdout method (used when --help is present)
-			ncc.EXPECT().RunWithReplacingStdout(gomock.Any(), gomock.Any()).DoAndReturn(
-				func(replacements []command.Replacement, args ...string) error {
-					// Verify that --help was added to the arguments
-					found := false
-					for _, arg := range args {
-						if arg == "--help" {
-							found = true
-							break
-						}
-					}
-					assert.True(t, found, "Expected --help to be added to arguments")
-
-					// Verify the replacement is correct (nerdctl -> finch)
-					assert.Len(t, replacements, 1, "Expected one replacement")
-					assert.Equal(t, "nerdctl", replacements[0].Source, "Expected source to be 'nerdctl'")
-					assert.Equal(t, "finch", replacements[0].Target, "Expected target to be 'finch'")
-
-					return nil
-				})
-
-			// This should not panic and should complete successfully
-			err := newNerdctlCommand(ncc, ecc, ncsd, logger, fs, fc).run(tc.cmdName, tc.args)
-			assert.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
Issue #, if available:
fixes #1633 

*Description of changes:*
Added a length check to prevent panic when run without arguments

*Testing done:*
Before 
```
~ finch run    
panic: runtime error: index out of range [0] with length 0
..
~ finch compose
panic: runtime error: index out of range [0] with length 0
..
~ finch exec
panic: runtime error: index out of range [0] with length 0
..
```
After 
```
~ finch run 
Run a command in a new container. Optionally specify "ipfs://" or "ipns://" scheme to pull image from IPFS.

Usage: finch container run [flags] IMAGE [COMMAND] [ARG...]

Flags:
      --add-host strings                               Add a custom host-to-IP mapping (host:ip)
      --annotation stringArray                         Add an annotation to the container (passed through to the OCI runtime)
  -a, --attach strings                                 Attach STDIN, STDOUT, or STDERR
      --blkio-weight uint16                            Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
      --blkio-weight-device stringArray                Block IO weight (relative device weight) (default [])
      --cap-add strings                                Add Linux capabilities
      --cap-drop strings                               Drop Linux capabilities
      --cgroup-conf strings                            Configure cgroup v2 (key=value)
      --cgroup-parent string                           Optional parent cgroup for the container
      --cgroupns string                                Cgroup namespace to use, the default depends on the cgroup version ("host"|"private") (default "private")
      --cidfile string                                 Write the container ID to the file
     .....
~ finch exec
Run a command in a running container

Usage: finch exec [flags] CONTAINER COMMAND [ARG...]

Flags:
  -d, --detach             Detached mode: run command in the background
  -e, --env stringArray    Set environment variables
      --env-file strings   Set environment variables from file
  -h, --help               help for exec
  -i, --interactive        Keep STDIN open even if not attached
      --privileged         Give extended privileges to the command
  -t, --tty                Allocate a pseudo-TTY
  -u, --user string        Username or UID (format: <name|uid>[:<group|gid>])
  -w, --workdir string     Working directory inside the container

See also 'finch --help' for the global flags such as '--namespace', '--snapshotter', and '--cgroup-manager'. 

~ finch compose 
Compose

Usage: finch compose [flags] COMMAND

Commands:
  build    Build or rebuild services
  config   Validate and view the Compose file
  cp       Copy files/folders between a service container and the local filesystem
  create   Creates containers for one or more services
  down     Remove containers and associated resources
  exec     Execute a command in a running container of the service
  images   List images used by created containers in services
  kill     Force stop service containers
  logs     Show logs of running containers
  pause    Pause all processes within containers of service(s). They can be unpaused with finch compose unpause
  port     Print the public port for a port binding
  ps       List containers of services
  pull     Pull service images
  push     Push service images
  restart  Restart containers of given (or all) services
  rm       Remove stopped service containers
  run      Run a one-off command on a service
  start    Start existing containers for service(s)
  stop     Stop running containers without removing them.
  top      Display the running processes of service containers
  unpause  Unpause all processes within containers of service(s).
  up       Create and start containers
  version  Show the Compose version information
....
```

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
