### PR TITLE
ci: remove default version from finch rpm spec

### DIFF
--- a/contrib/packaging/rpm/finch.spec
+++ b/contrib/packaging/rpm/finch.spec
@@ -4,40 +4,7 @@
 %global debug_package %{nil}
 %global pkg_config ../config
 
-# default versions and commit ids
-# actual values are passed as build options to rpmbuild in contrib/packaging/rpm/build.sh
-%global _finch_release 1.2.3
-%global _finch_commit b84b424926d5f4e2d2abf0c51507856a73221e9d
-%global _buildkit_release 0.15.1
-%global _buildkit_commit 979542e90f2cb38077c808e0867d8d2c16ed10b8
-%global _soci_release 0.7.0
-%global _soci_commit 7c6fae2c3848fe8ad161ce35d3423898cea5fde8
-%global _finch_daemon_release 0.19.1
-%global _finch_daemon_commit 7ee991cb3be01fdb0013649b9e8fc6b5e3c5a35d
-%global _cosign_release 2.4.0
-%global _cosign_commit b5e7dc123a272080f4af4554054797296271e902
-%global _min_containerd_version >=1.7.24
-%global _min_nerdctl_version >=2.1.5
-%global _min_cni_plugins_version >=1.7.0
-
-# build_latest takes precendence because build_local is for debugging
-%if %{undefined build_latest} && %{undefined build_local}
-# if neither is defined, fall back to default values
-%global finch_release %{_finch_release}
-%global finch_commit %{_finch_commit}
-%global buildkit_release %{_buildkit_release}
-%global buildkit_commit %{_buildkit_commit}
-%global soci_release %{_soci_release}
-%global soci_commit %{_soci_commit}
-%global finch_daemon_release %{_finch_daemon_release}
-%global finch_daemon_commit %{_finch_daemon_commit}
-%global cosign_release %{_cosign_release}
-%global cosign_commit %{_cosign_commit}
-%global min_containerd_version %{_min_containerd_version}
-%global min_nerdctl_version %{_min_nerdctl_version}
-%global min_cni_plugins_version %{_min_cni_plugins_version}
-%endif
-
+# finch
 %global finch_package github.com/runfinch/finch
 %global finch_src finch-%{finch_commit}
 %global finch_rpm_version %(r=%finch_release; echo ${r%%%%-*})


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Removes the default version of packages listed in the `finch.spec` file since the `build.sh` script will always pass the versions to it.

*Testing done:*

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
