### PR TITLE
chore: group dependabot prs into one single pr

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -29,3 +29,7 @@ updates:
   commit-message:
     prefix: "ci"
     include: "scope"
+  groups:
+    github-actions:
+      patterns:
+        - "*"


### PR DESCRIPTION
Issue #, if available:

Group the github actions dependabot PRs into a single PR so that we can spend less time fixing multiple dependabot update PRs

*Description of changes:*

*Testing done:*



- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
