### PR TITLE
feat: use vzNAT for vz networking, gate socket_vmnet behind config for qemu

### DIFF
--- a/cmd/finch/main_darwin.go
+++ b/cmd/finch/main_darwin.go
@@ -27,7 +27,7 @@ func dependencies(
 	logger flog.Logger,
 	finchRootPath string,
 ) []*dependency.Group {
-	return []*dependency.Group{
+	groups := []*dependency.Group{
 		credhelper.NewDependencyGroup(
 			ecc,
 			fs,
@@ -37,6 +37,13 @@ func dependencies(
 			finchRootPath,
 			system.NewStdLib().Arch(),
 		),
-		vmnet.NewDependencyGroup(ecc, ncc, fs, fp, logger),
 	}
+
+	if fc.VMNet != nil && *fc.VMNet {
+		if fc.VMType != nil && *fc.VMType == "qemu" {
+			groups = append(groups, vmnet.NewDependencyGroup(ecc, ncc, fs, fp, logger))
+		}
+	}
+
+	return groups
 }

--- a/cmd/finch/main_darwin_test.go
+++ b/cmd/finch/main_darwin_test.go
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build darwin
+
+package main
+
+import (
+	"testing"
+
+	"github.com/lima-vm/lima/pkg/limayaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/xorcare/pointer"
+
+	"github.com/runfinch/finch/pkg/config"
+)
+
+func TestDependencies_Default(t *testing.T) {
+	t.Parallel()
+
+	fc := &config.Finch{}
+	groups := dependencies(nil, fc, "", nil, nil, nil, "")
+	// Only credhelper group, no vmnet
+	assert.Equal(t, 1, len(groups))
+}
+
+func TestDependencies_VMNetEnabledQemu(t *testing.T) {
+	t.Parallel()
+
+	fc := &config.Finch{}
+	fc.VMNet = pointer.Bool(true)
+	vmType := limayaml.VMType("qemu")
+	fc.VMType = &vmType
+	groups := dependencies(nil, fc, "", nil, nil, nil, "")
+	// credhelper + vmnet (socket_vmnet needed for qemu)
+	assert.Equal(t, 2, len(groups))
+}
+
+func TestDependencies_VMNetEnabledVz(t *testing.T) {
+	t.Parallel()
+
+	fc := &config.Finch{}
+	fc.VMNet = pointer.Bool(true)
+	vmType := limayaml.VMType("vz")
+	fc.VMType = &vmType
+	groups := dependencies(nil, fc, "", nil, nil, nil, "")
+	// Only credhelper, no socket_vmnet (vz uses vzNAT instead)
+	assert.Equal(t, 1, len(groups))
+}
+
+func TestDependencies_VMNetDisabledQemu(t *testing.T) {
+	t.Parallel()
+
+	fc := &config.Finch{}
+	fc.VMNet = pointer.Bool(false)
+	vmType := limayaml.VMType("qemu")
+	fc.VMType = &vmType
+	groups := dependencies(nil, fc, "", nil, nil, nil, "")
+	// Only credhelper, vmnet explicitly disabled
+	assert.Equal(t, 1, len(groups))
+}

--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -27,6 +27,7 @@ type SystemSettings struct {
 	Rosetta               *bool                 `yaml:"rosetta,omitempty"`
 	BootDisk              *string               `yaml:"bootdisk,omitempty"`
 	DataDisk              *string               `yaml:"datadisk,omitempty"`
+	VMNet                 *bool                 `yaml:"vmnet,omitempty"`
 	SharedSystemSettings  `yaml:",inline"`
 }
 

--- a/pkg/config/lima_config_applier_darwin.go
+++ b/pkg/config/lima_config_applier_darwin.go
@@ -80,6 +80,15 @@ func (lca *limaConfigApplier) configureVirtualizationFramework(limaCfg *limatype
 		userModeEmulationInstallationScript(limaCfg)
 	}
 
+	// Configure vzNAT networking for vz when vmnet is enabled (no sudo required)
+	if lca.cfg.VMNet != nil && *lca.cfg.VMNet {
+		if lca.cfg.VMType != nil && *lca.cfg.VMType == "vz" {
+			limaCfg.Networks = append(limaCfg.Networks, limatype.Network{
+				VZNAT: pointer.Bool(true),
+			})
+		}
+	}
+
 	return limaCfg, nil
 }
 

--- a/pkg/dependency/vmnet/binaries_unix.go
+++ b/pkg/dependency/vmnet/binaries_unix.go
@@ -99,6 +99,10 @@ func (bin *binaries) Installed() bool {
 // Install creates the privileged location (`bin.installationPath()`), copies socket_vmnet files from the build output
 // directory to said location, and sets the correct permissions.
 func (bin *binaries) Install() error {
+	if bin.l != nil {
+		bin.l.Infof("socket_vmnet setup requires sudo. If this hangs, run 'finch vm init' interactively.")
+	}
+
 	mkdirCmd := bin.cmdCreator.Create("sudo", "mkdir", "-p", bin.installationPath())
 	_, err := mkdirCmd.Output()
 	if err != nil {


### PR DESCRIPTION
****Issue #, if available:** Closes #1173

**Description of changes:** Eliminates the requirement for root privilege during `finch vm init` for the default (vz) VM type by gating shared networking behind an opt-in `vmnet` config option.

Previously, `finch vm init` unconditionally installed socket_vmnet to `/opt/finch/` (requiring sudo) regardless of VM type. This caused silent hangs in non-interactive environments (AI terminals, CI, clamshell mode) where the sudo prompt cannot be fulfilled.

Changes:
* Added `vmnet` config option (default: `false`). When disabled, no shared networking is configured. When enabled:
  * **vz**: Configures `vzNAT: true` in the Lima config, providing host-to-VM IP access via Apple's Virtualization framework without privilege escalation.
  * **qemu**: Installs socket_vmnet (requires one-time sudo), providing a routable IP on a shared virtual network (`192.168.105.0/24`).
* Added a warning message before sudo operations during socket_vmnet installation, so users in non-interactive contexts get a clear message instead of a silent hang.

**Testing done:**
* `finch vm init` with vz (default): no sudo prompt, no `lima0`, port forwarding works
* `finch vm init` with vz + `vmnet: true`: no sudo prompt, vzNAT configured, `lima0` created, VM reachable from host via IPv6 ping
* `finch vm init` with qemu (default): no sudo prompt, no socket_vmnet, port forwarding works
* `finch vm init` with qemu + `vmnet: true`: warning shown, sudo prompt appears, socket_vmnet installs, `lima0` created, VM reachable from host
* `finch vm stop && finch vm start` with socket_vmnet: no re-prompt (NOPASSWD sudoers rule persists)
* Unit tests added for dependency gating logic (4 test cases, all pass)
* Existing vmnet and config unit tests pass
* Builds clean on darwin, windows, and linux

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
