### PR TITLE
feat: dynamic path resolution for lima config during vm init

### DIFF
--- a/cmd/finch/resolve_paths.go
+++ b/cmd/finch/resolve_paths.go
@@ -1,0 +1,69 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build darwin || windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// resolveBaseYamlPaths reads the base YAML template, detects the baked-in
+// install root, replaces it with the current install root, and writes the
+// resolved copy to outputPath. The original template is never modified.
+func resolveBaseYamlPaths(templatePath, outputPath string) error {
+	absTemplatePath, err := filepath.Abs(templatePath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve base YAML path: %w", err)
+	}
+
+	currentRoot := filepath.Dir(filepath.Dir(absTemplatePath))
+
+	content, err := os.ReadFile(absTemplatePath) //nolint:gosec // known internal path
+	if err != nil {
+		return fmt.Errorf("failed to read base YAML template: %w", err)
+	}
+
+	oldRoot := detectRoot(string(content))
+
+	var resolved []byte
+	if oldRoot == "" || oldRoot == currentRoot {
+		resolved = content
+	} else {
+		resolved = []byte(strings.ReplaceAll(string(content), oldRoot, currentRoot))
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o750); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	//nolint:gosec // outputPath is the internal lima config directory
+	if err := os.WriteFile(outputPath, resolved, 0o644); err != nil {
+		return fmt.Errorf("failed to write resolved base YAML: %w", err)
+	}
+
+	return nil
+}
+
+// detectRoot finds the baked-in install root by locating the first "/os/"
+// path in the content. The image location is always present and uses this
+// pattern: "<root>/os/<image>.qcow2".
+func detectRoot(content string) string {
+	idx := strings.Index(content, "/os/")
+	if idx < 0 {
+		return ""
+	}
+	start := strings.LastIndexAny(content[:idx], "\"' \n")
+	if start < 0 {
+		return ""
+	}
+	root := content[start+1 : idx]
+	if len(root) == 0 || root[0] != '/' {
+		return ""
+	}
+	return root
+}

--- a/cmd/finch/resolve_paths_test.go
+++ b/cmd/finch/resolve_paths_test.go
@@ -1,0 +1,119 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build darwin || windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectRoot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{
+			name:     "detects root from image location",
+			content:  `  - location: "/Applications/Finch/os/image.qcow2"`,
+			expected: "/Applications/Finch",
+		},
+		{
+			name:     "detects root from toolbox path",
+			content:  `  - location: "/home/user/.toolbox/tools/finch/1.17.0/os/image.qcow2"`,
+			expected: "/home/user/.toolbox/tools/finch/1.17.0",
+		},
+		{
+			name:     "returns empty when no /os/ marker",
+			content:  `  mountType: virtiofs`,
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := detectRoot(tc.content)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestResolveBaseYamlPaths(t *testing.T) {
+	t.Parallel()
+
+	tmpRoot := t.TempDir()
+	osDir := filepath.Join(tmpRoot, "os")
+	require.NoError(t, os.MkdirAll(osDir, 0o750))
+
+	yamlContent := `images:
+  - location: "/Applications/Finch/os/finch-al2023-os-image-arm64.qcow2"
+    arch: "aarch64"
+provision:
+  - mode: user
+    script: |
+      sudo cp /Applications/Finch/finch-daemon/finch-daemon /usr/local/bin/finch-daemon
+      sudo cp /Applications/Finch/finch-cred/docker-credential-finchhost /usr/bin/docker-credential-finchhost
+mounts:
+  - location: "/Applications/Finch/finch-daemon"
+    writable: true
+  - location: "/Applications/Finch/finch-cred"
+    writable: true
+`
+	templatePath := filepath.Join(osDir, "finch.yaml")
+	require.NoError(t, os.WriteFile(templatePath, []byte(yamlContent), 0o644))
+
+	outputPath := filepath.Join(tmpRoot, "lima", "data", "_config", "base.yaml")
+
+	err := resolveBaseYamlPaths(templatePath, outputPath)
+	require.NoError(t, err)
+
+	// Template is unchanged
+	original, err := os.ReadFile(templatePath) //nolint:gosec // test
+	require.NoError(t, err)
+	assert.Equal(t, yamlContent, string(original))
+
+	// Resolved output has correct paths
+	resolved, err := os.ReadFile(outputPath) //nolint:gosec // test
+	require.NoError(t, err)
+	resolvedStr := string(resolved)
+	assert.Contains(t, resolvedStr, tmpRoot+"/os/finch-al2023-os-image-arm64.qcow2")
+	assert.Contains(t, resolvedStr, tmpRoot+"/finch-daemon/finch-daemon")
+	assert.Contains(t, resolvedStr, tmpRoot+"/finch-cred/docker-credential-finchhost")
+	assert.Contains(t, resolvedStr, tmpRoot+"/finch-daemon\"")
+	assert.Contains(t, resolvedStr, tmpRoot+"/finch-cred\"")
+	assert.NotContains(t, resolvedStr, "/Applications/Finch")
+}
+
+func TestResolveBaseYamlPaths_NoRewriteWhenPathsMatch(t *testing.T) {
+	t.Parallel()
+
+	tmpRoot := t.TempDir()
+	osDir := filepath.Join(tmpRoot, "os")
+	require.NoError(t, os.MkdirAll(osDir, 0o750))
+
+	yamlContent := `images:
+  - location: "` + tmpRoot + `/os/image.qcow2"
+    arch: "aarch64"
+`
+	templatePath := filepath.Join(osDir, "finch.yaml")
+	require.NoError(t, os.WriteFile(templatePath, []byte(yamlContent), 0o644))
+
+	outputPath := filepath.Join(tmpRoot, "lima", "data", "_config", "base.yaml")
+
+	err := resolveBaseYamlPaths(templatePath, outputPath)
+	require.NoError(t, err)
+
+	resolved, err := os.ReadFile(outputPath) //nolint:gosec // test
+	require.NoError(t, err)
+	assert.Equal(t, yamlContent, string(resolved))
+}

--- a/cmd/finch/virtual_machine_init.go
+++ b/cmd/finch/virtual_machine_init.go
@@ -97,10 +97,10 @@ func (iva *initVMAction) run() error {
 	// Resolve paths in the base YAML to match the current finch install location.
 	// Writes the resolved copy to the lima config directory, leaving the original
 	// template unchanged. The resolved file is passed to limactl start.
-	resolvedYamlPath := filepath.Join(filepath.Dir(filepath.Dir(iva.baseYamlFilePath)), "lima", "data", "_config", "base.yaml")
-	err = resolveBaseYamlPaths(iva.baseYamlFilePath, resolvedYamlPath)
-	if err != nil {
-		return fmt.Errorf("failed to resolve base YAML paths: %w", err)
+	limaYamlPath := iva.baseYamlFilePath
+	resolvedYamlPath := filepath.Join(filepath.Dir(iva.baseYamlFilePath), "base.yaml")
+	if err = resolveBaseYamlPaths(iva.baseYamlFilePath, resolvedYamlPath); err == nil {
+		limaYamlPath = resolvedYamlPath
 	}
 
 	err = dependency.InstallOptionalDeps(iva.optionalDepGroups, iva.logger)
@@ -117,7 +117,7 @@ func (iva *initVMAction) run() error {
 	}
 
 	instanceName := fmt.Sprintf("--name=%v", limaInstanceName)
-	startOpts := []string{"start", instanceName, resolvedYamlPath, "--tty=false"}
+	startOpts := []string{"start", instanceName, limaYamlPath, "--tty=false"}
 	if iva.finchConfig == nil || *iva.finchConfig.VMType == "vz" {
 		// Starting with 2.0, Lima uses ssh over vsock by default on systemd >= 256 (https://github.com/lima-vm/lima/pull/3979)
 		// which is causing a ssh "permission denied" issue with VZ driver.

--- a/cmd/finch/virtual_machine_init.go
+++ b/cmd/finch/virtual_machine_init.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
 	"runtime"
 
 	"github.com/runfinch/finch/pkg/disk"
@@ -93,6 +94,15 @@ func (iva *initVMAction) run() error {
 		return err
 	}
 
+	// Resolve paths in the base YAML to match the current finch install location.
+	// Writes the resolved copy to the lima config directory, leaving the original
+	// template unchanged. The resolved file is passed to limactl start.
+	resolvedYamlPath := filepath.Join(filepath.Dir(filepath.Dir(iva.baseYamlFilePath)), "lima", "data", "_config", "base.yaml")
+	err = resolveBaseYamlPaths(iva.baseYamlFilePath, resolvedYamlPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve base YAML paths: %w", err)
+	}
+
 	err = dependency.InstallOptionalDeps(iva.optionalDepGroups, iva.logger)
 	if err != nil {
 		iva.logger.Errorf("Dependency error: %v", err)
@@ -107,7 +117,7 @@ func (iva *initVMAction) run() error {
 	}
 
 	instanceName := fmt.Sprintf("--name=%v", limaInstanceName)
-	startOpts := []string{"start", instanceName, iva.baseYamlFilePath, "--tty=false"}
+	startOpts := []string{"start", instanceName, resolvedYamlPath, "--tty=false"}
 	if iva.finchConfig == nil || *iva.finchConfig.VMType == "vz" {
 		// Starting with 2.0, Lima uses ssh over vsock by default on systemd >= 256 (https://github.com/lima-vm/lima/pull/3979)
 		// which is causing a ssh "permission denied" issue with VZ driver.


### PR DESCRIPTION
**Description of changes:** At build time, absolute paths (e.g., `/Applications/Finch/os/...`) are baked into the Lima base YAML template. This means the binary only works when installed at that exact path.

This PR resolves paths at runtime during `finch vm init`. It reads the shipped template, detects the baked-in root, replaces it with the actual install location, and writes a resolved copy to `lima/data/_config/base.yaml`. Lima reads that instead of the original template. The shipped artifact is never modified.

This enables finch to run from any install location without a separate build.

**Testing done:** Added unit tests and verified rewrite behavior. Here is an example moving to userspace:
```
ayushkp@842f5776e312 finch % cp -R _output /tmp/finch-userspace
ayushkp@842f5776e312 finch % cd /tmp/finch-userspace
ayushkp@842f5776e312 finch-userspace % ls
bin		cred-helpers	finch-cred	lima		os
config.yaml	dependencies	finch-daemon	lima-template
ayushkp@842f5776e312 finch-userspace %    /tmp/finch-userspace/bin/finch vm remove -f 2>/dev/null
ayushkp@842f5776e312 finch-userspace %    /tmp/finch-userspace/bin/finch vm init
INFO[0000] binaries directory doesn't exist
INFO[0000] Requesting root access to finish network dependency configuration
INFO[0002] sudoers file not found: open /etc/sudoers.d/finch-lima: no such file or directory
INFO[0005] Initializing and starting Finch virtual machine...
INFO[0035] Finch virtual machine started successfully
INFO[0035] Credential daemon started                     pid=9853
ayushkp@842f5776e312 finch-userspace %    grep "finch-userspace" /tmp/finch-userspace/os/base.yaml | head -3
  - location: "/private/tmp/finch-userspace/os/finch-al2023-os-image-arm64-26589989136.qcow2"
      sudo cp /private/tmp/finch-userspace/finch-daemon/finch-daemon /usr/local/bin/finch-daemon
      sudo cp /private/tmp/finch-userspace/finch-daemon/docker-credential-finch /usr/bin/docker-credential-finch
ayushkp@842f5776e312 finch-userspace %    /tmp/finch-userspace/bin/finch run --rm alpine echo "hello from moved location"
bash: line 1: cd: /tmp/finch-userspace: No such file or directory
docker.io/library/alpine:latest:                                                  resolved       |++++++++++++++++++++++++++++++++++++++|
index-sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b:    done           |++++++++++++++++++++++++++++++++++++++|
manifest-sha256:e7a1a92a5bfeee40966aea60f0796b0e7917cc35591542701834f03a68fa3d18: done           |++++++++++++++++++++++++++++++++++++++|
config-sha256:1991bd789d7184290c3cce84fd6af068b8b745e9bddf178661ce7f5ecf68135c:   done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:5de55e5ef9c033997441461efe7ba23a986db059c0bb78b38f84ee0d72b99167:    done           |++++++++++++++++++++++++++++++++++++++|
elapsed: 2.4 s                                                                    total:  4.0 Mi (1.7 MiB/s)
hello from moved location
```

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
