### PR TITLE
ci: upload signed artifacts tarball to S3 alongside .pkg

### DIFF
--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -164,6 +164,18 @@ jobs:
                       "name": "Finch-${{ needs.get-latest-tag.outputs.tag }}-x86_64.pkg",
                       "os": "mac",
                       "architecture": "x86_64"
+                  },
+                  {
+                      "name": "finch-${{ needs.get-latest-tag.outputs.tag }}-aarch64.tar.gz",
+                      "os": "mac",
+                      "architecture": "aarch64",
+                      "type": "tarball"
+                  },
+                  {
+                      "name": "finch-${{ needs.get-latest-tag.outputs.tag }}-x86_64.tar.gz",
+                      "os": "mac",
+                      "architecture": "x86_64",
+                      "type": "tarball"
                   }
               ]
           }

--- a/installer-builder/tools/release-installer.sh
+++ b/installer-builder/tools/release-installer.sh
@@ -35,6 +35,12 @@ releaseInstaller() {
     echo "[6/12] Merge Back Signed Executables to Finch Build"
     bash ./installer-builder/tools/merge-back-signed-executables.sh "$ARCH"
 
+    echo "[6.5/12] Upload signed artifacts tarball to S3"
+    tar -czf "./installer-builder/output/finch-${FINCH_VERSION}-${ARCH}.tar.gz" \
+        -C "./installer-builder/output/origin" _output
+    aws s3 cp "./installer-builder/output/finch-${FINCH_VERSION}-${ARCH}.tar.gz" \
+        "s3://${INSTALLER_PRIVATE_BUCKET_NAME}/finch-${FINCH_VERSION}-${ARCH}.tar.gz" --no-progress
+
     echo "[7/12] Build .pkg"
     bash ./installer-builder/tools/build-macos-pkg.sh "$ARCH" "$FINCH_VERSION"
 


### PR DESCRIPTION
**Description of changes:**

After step [6/12] (merge-back-signed-executables), this commit:

1. **Tars the signed `_output/` directory** and uploads it to the same S3 bucket as the `.pkg` installer. This makes pre-extracted artifacts available for toolbox bundling without needing to extract from `.pkg` on the ToD worker.

2. **Adds tarball entries to the release definition JSON** that gets uploaded to the trigger bucket. This ensures the tarballs flow through the `ReleaseTriggerLambda` into `FinchReleaseAutomationConfig/latest.json`, making them visible to bundle-tool.

The `.pkg` build and upload (steps 7-12) is unchanged. Both artifacts coexist in S3.

**Naming:** `finch-${VERSION}-${ARCH}.tar.gz` (e.g., `finch-v1.17.1-aarch64.tar.gz`)

**Testing done:**

* Ran the exact `tar` and `aws s3 cp` commands locally against `finch-installer-private`
* Downloaded the uploaded tarball, extracted, ran `finch vm init` + `finch run` from the extracted artifacts
* Confirmed tarball size is ~490MB (consistent with .pkg)
* Uploaded a test release definition with tarball entries to the trigger bucket; Lambda parsed it successfully (no-op'd due to existing version)
* shellcheck passes

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
