### PR TITLE
fix(macOS): prevent self-referential ~/.aws/.aws symlink

### DIFF
--- a/pkg/config/nerdctl_config_applier.go
+++ b/pkg/config/nerdctl_config_applier.go
@@ -107,7 +107,7 @@ func updateEnvironment(fs afero.Fs, fc *Finch, finchDir, homeDir, limaVMHomeDir 
 			`echo '{"credsStore": "finchhost"}' > "$DOCKER_CONFIG/config.json"`,
 		}
 	}
-	cmdArr = append(cmdArr, `[ -L /root/.aws ] || sudo ln -fs "$AWS_DIR" /root/.aws`)
+	cmdArr = append(cmdArr, `[ -L /root/.aws ] || sudo ln -fsn "$AWS_DIR" /root/.aws`)
 
 	// Credential helper configuration in-VM only necessary on Windows.
 	// TODO: Windows requires credential helper binaries to be symlinked into the VM because

--- a/pkg/config/nerdctl_config_applier_test.go
+++ b/pkg/config/nerdctl_config_applier_test.go
@@ -69,7 +69,7 @@ AWS_DIR=/home/dir/.aws
 mkdir -p "$HOME/.finch-vm-config"
 export DOCKER_CONFIG="$HOME/.finch-vm-config"
 echo '{"credsStore": "finchhost"}' > "$DOCKER_CONFIG/config.json"
-[ -L /root/.aws ] || sudo ln -fs "$AWS_DIR" /root/.aws
+[ -L /root/.aws ] || sudo ln -fsn "$AWS_DIR" /root/.aws
 [ -L /home/mock_user.linux/.finch ] || ln -s $FINCH_DIR /home/mock_user.linux/.finch`), string(fileBytes))
 			},
 			want: nil,
@@ -96,7 +96,7 @@ echo '{"credsStore": "finchhost"}' > "$DOCKER_CONFIG/config.json"
 FINCH_DIR=/finch/dir
 AWS_DIR=/home/dir/.aws
 export DOCKER_CONFIG="$FINCH_DIR"
-[ -L /root/.aws ] || sudo ln -fs "$AWS_DIR" /root/.aws)
+[ -L /root/.aws ] || sudo ln -fsn "$AWS_DIR" /root/.aws)
 [ -L /home/mock_user.linux/.finch ] || ln -s $FINCH_DIR /home/mock_user.linux/.finch`,
 						),
 						0o644,
@@ -110,7 +110,7 @@ export DOCKER_CONFIG="$FINCH_DIR"
 FINCH_DIR=/finch/dir
 AWS_DIR=/home/dir/.aws
 export DOCKER_CONFIG="$FINCH_DIR"
-[ -L /root/.aws ] || sudo ln -fs "$AWS_DIR" /root/.aws)
+[ -L /root/.aws ] || sudo ln -fsn "$AWS_DIR" /root/.aws)
 [ -L /home/mock_user.linux/.finch ] || ln -s $FINCH_DIR /home/mock_user.linux/.finch
 mkdir -p "$HOME/.finch-vm-config"
 export DOCKER_CONFIG="$HOME/.finch-vm-config"
@@ -164,7 +164,7 @@ echo '{"credsStore": "finchhost"}' > "$DOCKER_CONFIG/config.json"`), string(file
 FINCH_DIR="$(/usr/bin/wslpath '/finch/dir')"
 AWS_DIR="$(/usr/bin/wslpath '/home/dir/.aws')"
 export DOCKER_CONFIG="$FINCH_DIR"
-[ -L /root/.aws ] || sudo ln -fs "$AWS_DIR" /root/.aws
+[ -L /root/.aws ] || sudo ln -fsn "$AWS_DIR" /root/.aws
 [ -L /home/mock_user.linux/.finch ] || ln -s $FINCH_DIR /home/mock_user.linux/.finch`), string(fileBytes))
 			},
 			want: nil,
@@ -194,7 +194,7 @@ export DOCKER_CONFIG="$FINCH_DIR"
 					"\nFINCH_DIR=\"$(/usr/bin/wslpath '/finch/dir')\"\n"+
 						"AWS_DIR=\"$(/usr/bin/wslpath '/home/dir/.aws')\"\n"+
 						"export DOCKER_CONFIG=\"$FINCH_DIR\"\n"+
-						"[ -L /root/.aws ] || sudo ln -fs \"$AWS_DIR\" /root/.aws\n"+
+						"[ -L /root/.aws ] || sudo ln -fsn \"$AWS_DIR\" /root/.aws\n"+
 						"([ -e \"$FINCH_DIR\"/cred-helpers/docker-credential-ecr-login ] || \\\n"+
 						"\t\t\t(echo \"error: docker-credential-ecr-login not found in "+
 						"$FINCH_DIR/cred-helpers directory.\")) && \\\n"+


### PR DESCRIPTION
Issue #, if available: Reported and confirmed in the runfinch community Slack #finch-interest:

*Description of changes:*

The line added to the guest's ~/.bashrc uses:

    [ -L /root/.aws ] || sudo ln -fs "$AWS_DIR" /root/.aws

Two problems compound here:

1. Without `-n`, when `/root/.aws` is already a symlink to a directory,
   `ln -s` dereferences it and nests the new link *inside* the target.
   On the host (via the writable home mount) this surfaces as:

       ~/.aws/.aws -> ~/.aws

   which breaks recursive traversal of `~/.aws` — e.g. `cp -r ~/.aws`
   aborts with "directory causes a cycle".

2. The `[ -L /root/.aws ]` guard doesn't prevent re-firing: it runs as the
   unprivileged VM user against root-owned `/root` (0700), so the stat
   fails and the test is always false — the `ln` runs on every shell.

Adding `-n` (`--no-dereference`) makes the link replacement idempotent, so
repeated runs replace the symlink in place instead of nesting.

*Testing done:*

Reproduced end-to-end, then verified in an isolated dev VM that the patched
binary writes `ln -fsn` and `~/.aws/.aws` no longer regenerates (creds
preserved). `make test-unit` + `golangci-lint` pass.

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
