### PR TITLE
chore(ci): disable deb canary temporarily

### DIFF
--- a/.github/workflows/canary-deb.yaml
+++ b/.github/workflows/canary-deb.yaml
@@ -14,8 +14,9 @@ on:
         type: string
 
   # This workflow will run every 5 min
-  schedule:
-    - cron: '*/10 * * * *'
+  # TODO: revert once Finch v1.18.0 is properly released.
+  # schedule:
+    # - cron: '*/10 * * * *'
   
   # This workflow will run when the workflow file is updated
   pull_request:


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Temporarily disabling deb canary until Finch v1.18.0 is properly released.

*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
