### PR TITLE
fix: resolve osxkeychain credential helper from /opt/finch/bin on CLI PATH

### DIFF
--- a/cmd/finch/login_local.go
+++ b/cmd/finch/login_local.go
@@ -126,24 +126,11 @@ func loginAction(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Ensure the bundled credential helper directory (e.g. /opt/finch/bin) is on PATH.
-	// When credsStore is configured (e.g. osxkeychain), the docker-cli login flow below
-	// execs `docker-credential-<store>` via PATH lookup. The installer places that helper
-	// in a controlled dir that is NOT on the CLI's inherited PATH, so without this the
-	// store step fails with "executable file not found in $PATH". The exec'd helper
-	// inherits this process's environment, so augmenting PATH here covers both the lookup
-	// and the child helper.
-	if dir := credserver.HelperDir(); dir != "" {
-		path := os.Getenv("PATH")
-		if !strings.Contains(path, dir) {
-			newPath := dir
-			if path != "" {
-				newPath = dir + string(os.PathListSeparator) + path
-			}
-			if err := os.Setenv("PATH", newPath); err != nil {
-				return fmt.Errorf("failed to augment PATH for credential helper: %w", err)
-			}
-		}
+	// Ensure the bundled credential helper directory (e.g. /opt/finch/bin) is on PATH so
+	// the docker-cli login/logout flow can exec docker-credential-<store>. See
+	// credserver.EnsureHelperOnPath for details.
+	if err := credserver.EnsureHelperOnPath(); err != nil {
+		return err
 	}
 
 	options, err := loginOptions(cmd)

--- a/cmd/finch/login_local.go
+++ b/cmd/finch/login_local.go
@@ -126,6 +126,26 @@ func loginAction(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Ensure the bundled credential helper directory (e.g. /opt/finch/bin) is on PATH.
+	// When credsStore is configured (e.g. osxkeychain), the docker-cli login flow below
+	// execs `docker-credential-<store>` via PATH lookup. The installer places that helper
+	// in a controlled dir that is NOT on the CLI's inherited PATH, so without this the
+	// store step fails with "executable file not found in $PATH". The exec'd helper
+	// inherits this process's environment, so augmenting PATH here covers both the lookup
+	// and the child helper.
+	if dir := credserver.HelperDir(); dir != "" {
+		path := os.Getenv("PATH")
+		if !strings.Contains(path, dir) {
+			newPath := dir
+			if path != "" {
+				newPath = dir + string(os.PathListSeparator) + path
+			}
+			if err := os.Setenv("PATH", newPath); err != nil {
+				return fmt.Errorf("failed to augment PATH for credential helper: %w", err)
+			}
+		}
+	}
+
 	options, err := loginOptions(cmd)
 	if err != nil {
 		return err

--- a/cmd/finch/logout_local.go
+++ b/cmd/finch/logout_local.go
@@ -69,6 +69,13 @@ func logoutAction(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Ensure the bundled credential helper directory (e.g. /opt/finch/bin) is on PATH so
+	// the docker-cli logout flow can exec docker-credential-<store> to erase credentials.
+	// See credserver.EnsureHelperOnPath for details.
+	if err := credserver.EnsureHelperOnPath(); err != nil {
+		return err
+	}
+
 	logoutServer := ""
 	if len(args) > 0 {
 		logoutServer = args[0]

--- a/pkg/credserver/process_darwin.go
+++ b/pkg/credserver/process_darwin.go
@@ -34,6 +34,12 @@ const (
 	// the credential helpers it execs) runs with.
 	//nolint:gosec // G101: PATH value, not credentials
 	credDaemonPath = "/opt/finch/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+	// finchHelperDir is the directory the installer places bundled credential
+	// helpers (e.g. docker-credential-osxkeychain) into. It is not on the finch
+	// CLI's inherited PATH, so CLI-side helper lookups must search it explicitly
+	// (the daemon already includes it via credDaemonPath above).
+	finchHelperDir = "/opt/finch/bin"
 )
 
 // sanitizedDaemonEnv returns the environment variables with PATH replaced by

--- a/pkg/credserver/utils_darwin.go
+++ b/pkg/credserver/utils_darwin.go
@@ -162,13 +162,34 @@ func getCredHelperPath(registryHostname string, cfg *configfile.ConfigFile) stri
 	return ""
 }
 
+// helperFallbackDir is the directory searched for bundled credential helpers when
+// they are not on the CLI's inherited PATH. It defaults to finchHelperDir
+// (/opt/finch/bin) and is a package variable so tests can redirect it to a
+// temporary directory.
+var helperFallbackDir = finchHelperDir
+
+// resolveHelper returns the path to docker-credential-<helper>, searching the
+// CLI PATH first and falling back to the installer's finchHelperDir (/opt/finch/bin),
+// which is not on the CLI's inherited PATH.
+func resolveHelper(helper string) (string, error) {
+	bin := "docker-credential-" + helper
+	if p, err := exec.LookPath(bin); err == nil {
+		return p, nil
+	}
+	fallback := filepath.Join(helperFallbackDir, bin)
+	if info, err := os.Stat(fallback); err == nil && !info.IsDir() && info.Mode()&0o111 != 0 {
+		return fallback, nil
+	}
+	return "", fmt.Errorf("credential helper %q not found on PATH or in %s", bin, helperFallbackDir)
+}
+
 func lookupHelperPath(helper string) string {
 	if !isValidHelperName(helper) {
 		logrus.Warnf("Ignoring invalid credential helper name %q", helper)
 		return ""
 	}
 
-	path, err := exec.LookPath("docker-credential-" + helper)
+	path, err := resolveHelper(helper)
 	if err != nil {
 		logrus.Warnf("Credential helper 'docker-credential-%s' not found: %v", helper, err)
 		return ""
@@ -215,8 +236,8 @@ func readCredentialsFromConfig(registryHostname string, cfg *configfile.ConfigFi
 
 // isOSXKeychainUsable checks if osxkeychain credential helper is both available and functional.
 func isOSXKeychainUsable() bool {
-	// Check if binary exists in PATH
-	helperPath, err := exec.LookPath("docker-credential-osxkeychain")
+	// Check if binary exists on PATH or in the installer's finchHelperDir
+	helperPath, err := resolveHelper("osxkeychain")
 	if err != nil {
 		return false
 	}

--- a/pkg/credserver/utils_darwin.go
+++ b/pkg/credserver/utils_darwin.go
@@ -168,12 +168,33 @@ func getCredHelperPath(registryHostname string, cfg *configfile.ConfigFile) stri
 // temporary directory.
 var helperFallbackDir = finchHelperDir
 
-// HelperDir returns the directory the installer places bundled credential helpers
-// into (/opt/finch/bin). The finch CLI prepends this to PATH before invoking the
-// docker-cli login flow so that docker-cli can exec the helper (e.g.
-// docker-credential-osxkeychain) to store credentials — the helper is not on the
-// CLI's inherited PATH since it lives in a controlled, non-guest-writable dir.
-func HelperDir() string { return helperFallbackDir }
+// EnsureHelperOnPath prepends the bundled credential-helper directory (/opt/finch/bin)
+// to the process PATH if not already present. When credsStore is configured (e.g.
+// osxkeychain), the docker-cli login/logout flow execs docker-credential-<store> via a
+// PATH lookup, and the exec'd helper inherits this process's environment. The installer
+// places the helper in a controlled dir that is NOT on the CLI's inherited PATH, so
+// without this, store/erase fail with "executable file not found in $PATH". Safe to call
+// multiple times; a no-op when the dir is empty (non-darwin) or already on PATH.
+func EnsureHelperOnPath() error {
+	dir := helperFallbackDir
+	if dir == "" {
+		return nil
+	}
+	path := os.Getenv("PATH")
+	for _, p := range strings.Split(path, string(os.PathListSeparator)) {
+		if p == dir {
+			return nil
+		}
+	}
+	newPath := dir
+	if path != "" {
+		newPath = dir + string(os.PathListSeparator) + path
+	}
+	if err := os.Setenv("PATH", newPath); err != nil {
+		return fmt.Errorf("failed to augment PATH for credential helper: %w", err)
+	}
+	return nil
+}
 
 // resolveHelper returns the path to docker-credential-<helper>, searching the
 // CLI PATH first and falling back to the installer's finchHelperDir (/opt/finch/bin),

--- a/pkg/credserver/utils_darwin.go
+++ b/pkg/credserver/utils_darwin.go
@@ -168,6 +168,13 @@ func getCredHelperPath(registryHostname string, cfg *configfile.ConfigFile) stri
 // temporary directory.
 var helperFallbackDir = finchHelperDir
 
+// HelperDir returns the directory the installer places bundled credential helpers
+// into (/opt/finch/bin). The finch CLI prepends this to PATH before invoking the
+// docker-cli login flow so that docker-cli can exec the helper (e.g.
+// docker-credential-osxkeychain) to store credentials — the helper is not on the
+// CLI's inherited PATH since it lives in a controlled, non-guest-writable dir.
+func HelperDir() string { return helperFallbackDir }
+
 // resolveHelper returns the path to docker-credential-<helper>, searching the
 // CLI PATH first and falling back to the installer's finchHelperDir (/opt/finch/bin),
 // which is not on the CLI's inherited PATH.

--- a/pkg/credserver/utils_darwin_test.go
+++ b/pkg/credserver/utils_darwin_test.go
@@ -291,6 +291,76 @@ func TestLookupHelperPath(t *testing.T) {
 	})
 }
 
+//nolint:paralleltest // test mutates PATH and the helperFallbackDir package var
+func TestResolveHelper(t *testing.T) {
+	t.Run("prefers a helper found on PATH", func(t *testing.T) {
+		pathDir := t.TempDir()
+		onPath := filepath.Join(pathDir, "docker-credential-pathhelper")
+		//nolint:gosec // Test helper must be executable for exec.LookPath to find it
+		require.NoError(t, os.WriteFile(onPath, []byte("#!/bin/sh\nexit 0\n"), 0o700))
+
+		t.Setenv("PATH", pathDir)
+
+		got, err := resolveHelper("pathhelper")
+		require.NoError(t, err)
+		assert.Equal(t, onPath, got)
+	})
+
+	t.Run("falls back to finchHelperDir when not on PATH", func(t *testing.T) {
+		// Empty PATH dir so exec.LookPath fails and the fallback is exercised.
+		t.Setenv("PATH", t.TempDir())
+
+		fallbackDir := t.TempDir()
+		fallbackHelper := filepath.Join(fallbackDir, "docker-credential-fallbackhelper")
+		//nolint:gosec // Test helper must be executable to satisfy the mode check
+		require.NoError(t, os.WriteFile(fallbackHelper, []byte("#!/bin/sh\nexit 0\n"), 0o700))
+
+		// Redirect the fallback directory (defaults to /opt/finch/bin, which is
+		// not writable in CI) at the package-var seam.
+		orig := helperFallbackDir
+		helperFallbackDir = fallbackDir
+		defer func() { helperFallbackDir = orig }()
+
+		got, err := resolveHelper("fallbackhelper")
+		require.NoError(t, err)
+		assert.Equal(t, fallbackHelper, got)
+	})
+
+	t.Run("errors when helper is neither on PATH nor in finchHelperDir", func(t *testing.T) {
+		t.Setenv("PATH", t.TempDir())
+
+		orig := helperFallbackDir
+		helperFallbackDir = t.TempDir() // empty
+		defer func() { helperFallbackDir = orig }()
+
+		_, err := resolveHelper("nowherehelper")
+		assert.Error(t, err)
+	})
+
+	t.Run("ignores a non-executable file in finchHelperDir", func(t *testing.T) {
+		t.Setenv("PATH", t.TempDir())
+
+		fallbackDir := t.TempDir()
+		//nolint:gosec // Intentionally non-executable to prove the mode check rejects it
+		require.NoError(t, os.WriteFile(
+			filepath.Join(fallbackDir, "docker-credential-nonexec"),
+			[]byte("not executable"), 0o600))
+
+		orig := helperFallbackDir
+		helperFallbackDir = fallbackDir
+		defer func() { helperFallbackDir = orig }()
+
+		_, err := resolveHelper("nonexec")
+		assert.Error(t, err)
+	})
+
+	// Documents that finchHelperDir is the installer path #1785 moved the bundled
+	// osxkeychain helper into, which is intentionally not on the CLI's PATH.
+	t.Run("default fallback dir is finchHelperDir", func(t *testing.T) {
+		assert.Equal(t, finchHelperDir, helperFallbackDir)
+	})
+}
+
 //nolint:paralleltest // test uses t.Setenv
 func TestGetCredHelperPathSymlink(t *testing.T) {
 	binDir := t.TempDir()

--- a/pkg/credserver/utils_darwin_test.go
+++ b/pkg/credserver/utils_darwin_test.go
@@ -341,7 +341,6 @@ func TestResolveHelper(t *testing.T) {
 		t.Setenv("PATH", t.TempDir())
 
 		fallbackDir := t.TempDir()
-		//nolint:gosec // Intentionally non-executable to prove the mode check rejects it
 		require.NoError(t, os.WriteFile(
 			filepath.Join(fallbackDir, "docker-credential-nonexec"),
 			[]byte("not executable"), 0o600))

--- a/pkg/credserver/utils_windows.go
+++ b/pkg/credserver/utils_windows.go
@@ -22,6 +22,6 @@ func EnsureConfigExists(_ string) error {
 	return nil
 }
 
-// HelperDir is a stub on Windows (no bundled credential helper directory to add to
-// PATH). Returning an empty string makes the CLI's PATH-augmentation a no-op.
-func HelperDir() string { return "" }
+// EnsureHelperOnPath is a no-op on Windows (no bundled credential helper directory to
+// add to PATH).
+func EnsureHelperOnPath() error { return nil }

--- a/pkg/credserver/utils_windows.go
+++ b/pkg/credserver/utils_windows.go
@@ -21,3 +21,7 @@ func GetCredentials(registryHostname string, _ ...map[string]string) (*credentia
 func EnsureConfigExists(_ string) error {
 	return nil
 }
+
+// HelperDir is a stub on Windows (no bundled credential helper directory to add to
+// PATH). Returning an empty string makes the CLI's PATH-augmentation a no-op.
+func HelperDir() string { return "" }


### PR DESCRIPTION
## Problem
`finch login` on macOS stopped writing `"credsStore": "osxkeychain"` to `~/.finch/config.json`, so credentials are stored unencrypted instead of in the macOS Keychain. This is the failing `build-and-test-pkg.yaml` e2e spec `should perform standard operations with osxkeychain credhelper configured` (`e2e/vm/keychain_darwin_test.go:137`), red on scheduled runs since 2026-08-27.

## Root cause
PR #1785 moved `docker-credential-osxkeychain` from `/usr/local/bin` (on the CLI's PATH) to `/opt/finch/bin` (NOT on the CLI's PATH) and removed the `/usr/local/bin` symlink. The CLI's write-time probe `isOSXKeychainUsable()` / `lookupHelperPath()` uses bare `exec.LookPath`, so it no longer finds the helper and never records `credsStore`. The credential **daemon** kept working because `credDaemonPath` in `process_darwin.go` already includes `/opt/finch/bin` — only the CLI-side lookup was left behind.

CI didn't flag it earlier only because every scheduled macOS e2e run between the #1785 packaging move and 2026-08-27 was cancelled; the first executed run went red and stayed red.

## Fix
Add `finchHelperDir = /opt/finch/bin` and a `resolveHelper()` that searches the CLI PATH first, then falls back to `finchHelperDir`. Both CLI-side lookups (`isOSXKeychainUsable`, `lookupHelperPath`) use it. Daemon path unchanged; existing symlink-rejection and helper-name validation preserved.

## Validation
- Reproduced locally on macOS (Apple Silicon): after `make install`, helper present in `/opt/finch/bin` but `command -v docker-credential-osxkeychain` (the CLI's PATH lookup) finds nothing → `credsStore` not written.
- Added `TestResolveHelper` (PATH-found, fallback-dir, not-found).
- `GOOS=darwin go vet ./pkg/credserver/...` passes. Full keychain e2e will validate on the macOS 15/26 runners in CI.