### PR TITLE
feat: warn that Finch VM is not a security boundary on vm init

### DIFF
--- a/cmd/finch/virtual_machine_init.go
+++ b/cmd/finch/virtual_machine_init.go
@@ -134,6 +134,10 @@ func (iva *initVMAction) run() error {
 			"https://runfinch.com/docs/managing-finch/windows/wsl-configuration/")
 	}
 
+	iva.logger.Warnln("Please note that Finch is a developer tool and is not meant for use in production environments, " +
+		"especially one running multi-tenant workloads. The virtual machine that Finch manages on macOS and Windows " +
+		"does not create a security boundary and exists for the sole purpose of running Linux containers on macOS and Windows.")
+
 	iva.logger.Info("Finch virtual machine started successfully")
 	return nil
 }

--- a/cmd/finch/virtual_machine_init_test.go
+++ b/cmd/finch/virtual_machine_init_test.go
@@ -89,6 +89,9 @@ func TestInitVMAction_runAdapter(t *testing.T) {
 						"To run finch with more restricted access, follow " +
 						"https://runfinch.com/docs/managing-finch/windows/wsl-configuration/")
 				}
+				logger.EXPECT().Warnln("Please note that Finch is a developer tool and is not meant for use in production environments, " +
+					"especially one running multi-tenant workloads. The virtual machine that Finch manages on macOS and Windows " +
+					"does not create a security boundary and exists for the sole purpose of running Linux containers on macOS and Windows.")
 				logger.EXPECT().Info("Finch virtual machine started successfully")
 			},
 		},
@@ -161,6 +164,9 @@ func TestInitVMAction_run(t *testing.T) {
 						"To run finch with more restricted access, follow " +
 						"https://runfinch.com/docs/managing-finch/windows/wsl-configuration/")
 				}
+				logger.EXPECT().Warnln("Please note that Finch is a developer tool and is not meant for use in production environments, " +
+					"especially one running multi-tenant workloads. The virtual machine that Finch manages on macOS and Windows " +
+					"does not create a security boundary and exists for the sole purpose of running Linux containers on macOS and Windows.")
 				logger.EXPECT().Info("Finch virtual machine started successfully")
 			},
 		},
@@ -291,6 +297,9 @@ func TestInitVMAction_run(t *testing.T) {
 						"To run finch with more restricted access, follow " +
 						"https://runfinch.com/docs/managing-finch/windows/wsl-configuration/")
 				}
+				logger.EXPECT().Warnln("Please note that Finch is a developer tool and is not meant for use in production environments, " +
+					"especially one running multi-tenant workloads. The virtual machine that Finch manages on macOS and Windows " +
+					"does not create a security boundary and exists for the sole purpose of running Linux containers on macOS and Windows.")
 				logger.EXPECT().Info("Finch virtual machine started successfully")
 			},
 		},


### PR DESCRIPTION
*Description of changes:*

Emit a warning during `finch vm init` clarifying that Finch is a developer tool not meant for production/multi-tenant use, and that the VM it manages on macOS and Windows does not create a security boundary. This mirrors the README callout added in #1798, surfacing the same guidance in the CLI at the point users create the VM.

The warning is logged just before the "Finch virtual machine started successfully" message, so success confirmation remains the final line. It lives in the shared `run()` path, so it applies to both macOS and Windows.

Exact wording matches the README callout from #1798.

*Testing done:*

- `GOOS=darwin go build ./cmd/finch/` and `GOOS=windows`/`darwin go test -c ./cmd/finch/` compile cleanly.
- Updated the 3 success-path unit tests in `virtual_machine_init_test.go` to expect the new warning.
- Unit tests are build-gated to darwin/windows and will run in CI on those runners.

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.